### PR TITLE
fix bounds calculation not updating center of pcb component

### DIFF
--- a/lib/components/base-components/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent.ts
@@ -316,7 +316,15 @@ export class NormalComponent<
 
     const bounds = getBoundsOfPcbComponents(this.children)
 
+    if (bounds.width === 0 || bounds.height === 0) return
+
+    const center = {
+      x: (bounds.minX + bounds.maxX) / 2,
+      y: (bounds.minY + bounds.maxY) / 2,
+    }
+
     db.pcb_component.update(this.pcb_component_id!, {
+      center,
       width: bounds.width,
       height: bounds.height,
     })

--- a/tests/components/normal-components/chip-cad-position-in-group.test.tsx
+++ b/tests/components/normal-components/chip-cad-position-in-group.test.tsx
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("chip CAD component position inside offset group", () => {
+  const { project } = getTestFixture()
+
+  project.add(
+    <board width="10mm" height="10mm">
+      <group pcbX={5} pcbY={3}>
+        <chip
+          name="U1"
+          footprint="soic8"
+          cadModel={{
+            stlUrl: "https://example.com/chip.stl",
+          }}
+        />
+      </group>
+    </board>,
+  )
+
+  project.render()
+
+  const cadComponent = project.db.cad_component.list()[0]
+  const pcbComponent = project.db.pcb_component.list()[0]
+
+  expect(cadComponent).toBeDefined()
+  expect(pcbComponent).toBeDefined()
+
+  expect(pcbComponent.center.x).toBeCloseTo(5, 1)
+  // The CAD component position should include the group's offset
+  expect(cadComponent.position.x).toBeCloseTo(5, 1)
+  expect(cadComponent.position.y).toBeCloseTo(3, 1)
+  expect(cadComponent.position.z).toBeCloseTo(0.7, 1) // Default board thickness/2
+})


### PR DESCRIPTION
CC @imrishabh18 this will fix the issue where components have weird drag and drop issues where you can't click them in the center.