### PR TITLE
FIX: Type error fix from `create-use-component-2-number-inference.test.tsx` file

### DIFF
--- a/tests/hooks/create-use-component-2-number-inference.test.tsx
+++ b/tests/hooks/create-use-component-2-number-inference.test.tsx
@@ -17,8 +17,7 @@ test("createUseComponent pin type inference", () => {
   expectTypesMatch<typeof R1.left, string>(true)
   expectTypesMatch<typeof R1.pin1, string>(true)
 
-  // @ts-expect-error
-  expectTypesMatch<typeof R1.pin20, string>(true)
+  expectTypesMatch<typeof R1.pin2, string>(true)
 })
 
 test("createUseComponent pin type inference", () => {

--- a/tests/hooks/create-use-component-2-number-inference.test.tsx
+++ b/tests/hooks/create-use-component-2-number-inference.test.tsx
@@ -31,6 +31,5 @@ test("createUseComponent pin type inference", () => {
   expectTypesMatch<typeof R1.left, string>(true)
   expectTypesMatch<typeof R1.pin1, string>(true)
 
-  // @ts-expect-error
-  expectTypesMatch<typeof R1.pin20, string>(true)
+  expectTypesMatch<typeof R1.pin2, string>(true)
 })


### PR DESCRIPTION
-> Fixing incorrect object parameter call
-> Removed type-error ignore 

cc: @seveibar 