### PR TITLE
fix: bundle-size.yml file doesn't run on pr from forks

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,7 +1,7 @@
 name: Size
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
 

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,9 +1,8 @@
 name: Size
 
 on:
-  pull_request_target:
-    branches:
-      - main
+  pull_request:
+    branches: [main]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -87,11 +87,10 @@ jobs:
 
       - name: Update comment
         uses: marocchino/sticky-pull-request-comment@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
         with:
           header: Size Report
-          proxy-url: https://add-pr-comment-proxy-tscircuit.vercel.app/api 
-          repo-token: ${{ secrets.GITHUB_TOKEN }}                                                                         
-          allow-repeats: false
           message: |
             ## Size Report
             ### Bundle Size
@@ -108,5 +107,5 @@ jobs:
             ```
             ${{ steps.pr-install-size.outputs.full_output }}
             ```
-
-            
+          proxy-url: https://add-pr-comment-proxy-tscircuit.vercel.app/api
+          allow-repeats: false

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -87,10 +87,11 @@ jobs:
 
       - name: Update comment
         uses: marocchino/sticky-pull-request-comment@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
         with:
           header: Size Report
+          proxy-url: https://add-pr-comment-proxy-tscircuit.vercel.app/api 
+          repo-token: ${{ secrets.GITHUB_TOKEN }}                                                                         
+          allow-repeats: false
           message: |
             ## Size Report
             ### Bundle Size
@@ -107,3 +108,5 @@ jobs:
             ```
             ${{ steps.pr-install-size.outputs.full_output }}
             ```
+
+            

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -86,7 +86,7 @@ jobs:
           fi
 
       - name: Update comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: mshick/add-pr-comment@v2
         env:
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Fixes #360 
/claim #360

I changed the workflow to use `pull_request_target` instead of `pull_request`
