### PR TITLE
Don't do PcbRouteNetIslands when routingDisabled, export types from Renderable

### DIFF
--- a/lib/components/primitive-components/Net.ts
+++ b/lib/components/primitive-components/Net.ts
@@ -89,6 +89,8 @@ export class Net extends PrimitiveComponent<typeof netProps> {
    */
   doInitialPcbRouteNetIslands(): void {
     if (this.root?.pcbDisabled) return
+    if (this.getSubcircuit()._parsedProps.routingDisabled) return
+
     const { db } = this.root!
     const { _parsedProps: props } = this
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,5 +9,8 @@ export * from "./hooks/use-led"
 export * from "./hooks/use-resistor"
 export * from "./utils/public-exports"
 
+// Allows easier introspection of render process
+export * from "./components/base-components/Renderable"
+
 import "./register-catalogue"
 import "./fiber/intrinsic-jsx"


### PR DESCRIPTION
Based on these benchmarking results:

![image](https://github.com/user-attachments/assets/c6f4e3a6-8d9d-4e59-bc4f-cf9e9d393f35)
