### PR TITLE
test: verify footprinter soic4 using autocloud

### DIFF
--- a/tests/components/normal-components/__snapshots__/footprinter-soic4-pcb.snap.svg
+++ b/tests/components/normal-components/__snapshots__/footprinter-soic4-pcb.snap.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600"><style>
+              .boundary { fill: #000; }
+              .pcb-board { fill: none; }
+              .pcb-trace { fill: none; }
+              .pcb-hole-outer { fill: rgb(200, 52, 52); }
+              .pcb-hole-inner { fill: rgb(255, 38, 226); }
+              .pcb-pad { }
+              .pcb-boundary { fill: none; stroke: #fff; stroke-width: 0.3; }
+              .pcb-silkscreen { fill: none; }
+              .pcb-silkscreen-top { stroke: #f2eda1; }
+              .pcb-silkscreen-bottom { stroke: #f2eda1; }
+              .pcb-silkscreen-text { fill: #f2eda1; }
+            </style><rect class="boundary" x="0" y="0" width="800" height="600"/><rect class="pcb-boundary" x="25" y="175" width="750" height="250"/><path class="pcb-board" d="M 25 425 L 775 425 L 775 175 L 25 175 Z" stroke="rgba(255, 255, 255, 0.5)" stroke-width="2.5"/><g transform="translate(525, 300) rotate(0) scale(1, -1)"><rect class="pcb-component" x="-66.25000000000001" y="-23.375" width="132.50000000000003" height="46.75"/><rect class="pcb-component-outline" x="-66.25000000000001" y="-23.375" width="132.50000000000003" height="46.75"/></g><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="458.75" y="276.625" width="25" height="15"/><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="458.75" y="308.375" width="25" height="15"/><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="566.25" y="308.375" width="25" height="15"/><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="566.25" y="276.625" width="25" height="15"/><path class="pcb-silkscreen pcb-silkscreen-top" d="M 486.25 331.3125 L 486.25 268.6875 L 512.0833333333334 268.6875 L 513.0665560383959 273.63049433471576 L 515.8665374096738 277.82096259032625 L 520.0570056652842 280.6209439616041 L 525 281.6041666666667 L 529.9429943347158 280.6209439616041 L 534.1334625903262 277.82096259032625 L 536.9334439616041 273.63049433471576 L 537.9166666666666 268.6875 L 563.75 268.6875 L 563.75 331.3125 L 486.25 331.3125 Z" stroke-width="2.5" data-pcb-component-id="pcb_component_0" data-pcb-silkscreen-path-id="pcb_silkscreen_path_0"/></svg>

--- a/tests/components/normal-components/footprinter-soic4.test.tsx
+++ b/tests/components/normal-components/footprinter-soic4.test.tsx
@@ -7,18 +7,17 @@ test("footprinter-soic4 with autorouter", () => {
   const { circuit } = getTestFixture()
 
   circuit.add(
-    <board width="30mm" height="10mm" autorouter={{
-      serverUrl: autoroutingServerUrl,
-      serverMode: "solve-endpoint",
-      inputFormat: "simplified",
-    }}>
-      <pushbutton
-        footprint="soic4"
-          name="U1"
-          schX={3}
-          pcbX={5}
-        />
-    </board>
+    <board
+      width="30mm"
+      height="10mm"
+      autorouter={{
+        serverUrl: autoroutingServerUrl,
+        serverMode: "solve-endpoint",
+        inputFormat: "simplified",
+      }}
+    >
+      <pushbutton footprint="soic4" name="U1" schX={3} pcbX={5} />
+    </board>,
   )
 
   circuit.render()

--- a/tests/components/normal-components/footprinter-soic4.test.tsx
+++ b/tests/components/normal-components/footprinter-soic4.test.tsx
@@ -1,0 +1,36 @@
+import { test, expect } from "bun:test"
+import { getTestAutoroutingServer } from "tests/fixtures/get-test-autorouting-server"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("footprinter-soic4 with autorouter", () => {
+  const { autoroutingServerUrl } = getTestAutoroutingServer()
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="10mm" autorouter={{
+      serverUrl: autoroutingServerUrl,
+      serverMode: "solve-endpoint",
+      inputFormat: "simplified",
+    }}>
+      <pushbutton
+        footprint="soic4"
+          name="U1"
+          schX={3}
+          pcbX={5}
+        />
+    </board>
+  )
+
+  circuit.render()
+
+  const pcb_traces = circuit.db.pcb_trace.list()
+  expect(pcb_traces.length).toBe(0)
+
+  const source_ports = circuit.db.source_port.list()
+  expect(source_ports.length).toBe(4)
+
+  const pcb_ports = circuit.db.pcb_port.list()
+  expect(pcb_ports.length).toBe(4)
+
+  expect(circuit).toMatchPcbSnapshot(import.meta.path)
+})


### PR DESCRIPTION
New core outputs the correct circuit json for soic4 footprint, but the current snippets webworker or some other service using old version of core most probably

https://registry-api.tscircuit.com/admin/autorouting_jobs/get?autorouting_job_id=6948acc4-db57-4064-8415-9b793a24f10b (circuit json output which is given by snippets)

cc: @seveibar 