### PR TITLE
WIP: add the pcb_via from the output_pcb_traces from server

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -7,7 +7,6 @@ import * as SAL from "@tscircuit/schematic-autolayout"
 import { CapacityMeshAutorouter } from "lib/utils/autorouting/CapacityMeshAutorouter"
 import type { SimplifiedPcbTrace } from "lib/utils/autorouting/SimpleRouteJson"
 import {
-  type AnyCircuitElement,
   type LayerRef,
   type PcbTrace,
   type PcbVia,
@@ -26,12 +25,10 @@ import { TraceHint } from "../TraceHint"
 import type { ISubcircuit } from "./ISubcircuit"
 import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/public-exports"
 import type { GenericLocalAutorouter } from "lib/utils/autorouting/GenericLocalAutorouter"
-import outputTraces from "../../../../output_pcb_circuit.json"
 
 export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
   extends NormalComponent<Props>
-  implements ISubcircuit
-{
+  implements ISubcircuit {
   pcb_group_id: string | null = null
   subcircuit_id: string | null = null
 

--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -28,7 +28,8 @@ import type { GenericLocalAutorouter } from "lib/utils/autorouting/GenericLocalA
 
 export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
   extends NormalComponent<Props>
-  implements ISubcircuit {
+  implements ISubcircuit
+{
   pcb_group_id: string | null = null
   subcircuit_id: string | null = null
 


### PR DESCRIPTION
The ses file on merge creates all the via's as `pcb_via` and returns in output_pcb_traces. Inserting all the `pcb_via` elements directly and not by the route of `pcb_trace` in core. 