### PR TITLE
Add VIN and EN nets to selectors

### DIFF
--- a/lib/sel/sel.ts
+++ b/lib/sel/sel.ts
@@ -54,7 +54,15 @@ type PolarizedSel = Record<
   }
 >
 
-type CommonNetNames = "VCC" | "GND" | "VDD" | "PWR" | "V5" | "V3_3"
+type CommonNetNames =
+  | "VCC"
+  | "GND"
+  | "VDD"
+  | "PWR"
+  | "V5"
+  | "V3_3"
+  | "VIN"
+  | "EN"
 
 type TransistorSel = Record<`Q${Nums40}`, Record<TransistorPinNames, string>>
 

--- a/tests/sel/sel1.test.ts
+++ b/tests/sel/sel1.test.ts
@@ -28,6 +28,14 @@ test("sel1 - sel.net.VCC = net.VCC", () => {
   expect(sel.net.VCC).toBe("net.VCC")
 })
 
+test("sel1 - sel.net.VIN = net.VIN", () => {
+  expect(sel.net.VIN).toBe("net.VIN")
+})
+
+test("sel1 - sel.net.EN = net.EN", () => {
+  expect(sel.net.EN).toBe("net.EN")
+})
+
 test("sel1 - sel.CN1.pin1 = .CN1 > .pin1", () => {
   expect(sel.CN1.pin1).toBe(".CN1 > .pin1")
 })


### PR DESCRIPTION
## Summary
- expand list of common nets with `VIN` and `EN`
- test the new nets in the selector utility

## Testing
- `bun test --timeout 10000`