### PR TITLE
Add footprint URL support

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -661,8 +661,11 @@ export class NormalComponent<
       this._queueAsyncEffect("load-footprint-url", async () => {
         const res = await fetch(url)
         const soup = await res.json()
-        const { name: componentName, pcbRotation: componentRotation, pinLabels } =
-          this.props
+        const {
+          name: componentName,
+          pcbRotation: componentRotation,
+          pinLabels,
+        } = this.props
         const fpComponents = createComponentsFromCircuitJson(
           { componentName, componentRotation, footprint: url, pinLabels },
           soup as any,

--- a/tests/components/normal-components/footprint-url.test.tsx
+++ b/tests/components/normal-components/footprint-url.test.tsx
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test"
+import { fp } from "@tscircuit/footprinter"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getTestFootprintServer } from "tests/fixtures/get-test-footprint-server"
+
+test("footprint url is loaded", async () => {
+  const footprintJson = fp.string("0402").soup()
+  const { url } = getTestFootprintServer(footprintJson)
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip name="U1" footprint={url} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const pads = circuit.db.pcb_smtpad.list()
+  expect(pads.length).toBeGreaterThan(0)
+})

--- a/tests/fixtures/get-test-footprint-server.tsx
+++ b/tests/fixtures/get-test-footprint-server.tsx
@@ -1,0 +1,21 @@
+import { serve } from "bun"
+import { afterEach } from "bun:test"
+
+export const getTestFootprintServer = (json: any) => {
+  const server = serve({
+    port: 0,
+    fetch: () =>
+      new Response(JSON.stringify(json), {
+        headers: { "Content-Type": "application/json" },
+      }),
+  })
+
+  afterEach(() => {
+    server.stop()
+  })
+
+  return {
+    url: `http://localhost:${server.port}/footprint.json`,
+    close: () => server.stop(),
+  }
+}


### PR DESCRIPTION
## Summary
- support loading footprints from URLs
- return no ports when footprint is a URL
- test footprint URL loading
- test fixture for test server to serve footprint JSON

## Testing
- `bun test tests/components/normal-components/footprint-url.test.tsx`
- `bun test`