### PR TITLE
Implement dynamic top/bottom aliases

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -112,6 +112,10 @@ export class NormalComponent<
     this.initPorts()
   }
 
+  _getSchRotationBeforeLayout(): number | string {
+    return this._parsedProps.schRotation ?? 0
+  }
+
   /**
    * Override this method for better control over the auto-discovery of ports.
    *
@@ -502,7 +506,7 @@ export class NormalComponent<
     const schPortArrangement = this._getSchematicPortArrangement()
     const schematic_component = db.schematic_component.insert({
       center,
-      rotation: props.schRotation ?? 0,
+      rotation: this._getSchRotationBeforeLayout(),
       size: dimensions.getSize(),
       // We should be using the full size, but circuit-to-svg incorrectly
       // uses the schematic_component size to draw boxes instead of the

--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -316,24 +316,34 @@ export abstract class PrimitiveComponent<
     )
   }
 
+  _getSchRotationBeforeLayout(): number | string {
+    return this._parsedProps.schRotation ?? 0
+  }
+
   _getSchematicSymbolName(): keyof typeof symbols | undefined {
     const { _parsedProps: props } = this
     const base_symbol_name = this.config
       .schematicSymbolName as keyof typeof symbols
 
     // normalize the rotation
-    let normalizedRotation = props.schRotation
+    let normalizedRotation = this._getSchRotationBeforeLayout()
     if (normalizedRotation === undefined) {
       normalizedRotation = 0
     }
-    // Normalize rotation to be between 0 and 360
-    normalizedRotation = normalizedRotation % 360
+    normalizedRotation =
+      (typeof normalizedRotation === "string"
+        ? parseFloat(normalizedRotation)
+        : normalizedRotation) % 360
     if (normalizedRotation < 0) {
       normalizedRotation += 360
     }
 
     // Validate that rotation is a multiple of 90 degrees
-    if (props.schRotation !== undefined && normalizedRotation % 90 !== 0) {
+    const userRotation =
+      typeof props.schRotation === "string"
+        ? parseFloat(props.schRotation)
+        : props.schRotation
+    if (userRotation !== undefined && userRotation % 90 !== 0) {
       throw new Error(
         `Schematic rotation ${props.schRotation} is not supported for ${this.componentName}`,
       )

--- a/lib/components/normal-components/Capacitor.ts
+++ b/lib/components/normal-components/Capacitor.ts
@@ -14,6 +14,35 @@ export class Capacitor extends NormalComponent<
   typeof capacitorProps,
   PassivePorts
 > {
+  private _hasTopBottom: boolean = false
+  constructor(props: any) {
+    let hasTopBottom = false
+    if (props && props.connections) {
+      hasTopBottom = "top" in props.connections || "bottom" in props.connections
+      const newConns: Record<string, any> = { ...props.connections }
+      if ("top" in newConns) {
+        newConns.pin2 = newConns.top
+        delete newConns.top
+      }
+      if ("bottom" in newConns) {
+        newConns.pin1 = newConns.bottom
+        delete newConns.bottom
+      }
+      props = { ...props, connections: newConns }
+    }
+    super(props)
+    this._hasTopBottom = hasTopBottom
+  }
+
+  _getSchRotationBeforeLayout(): number | string {
+    const { _parsedProps: props } = this
+    const hasPullup = props.pullupFor || props.pullupTo
+    const hasTopBottom = this._hasTopBottom
+
+    if (props.schRotation !== undefined) return props.schRotation
+    if (hasPullup || hasTopBottom) return 90
+    return 0
+  }
   // @ts-ignore (cause the symbolName is string and not fixed)
   get config() {
     return {

--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -232,9 +232,13 @@ export class Port extends PrimitiveComponent<typeof portProps> {
       (this.parent as any)?._parsedProps?.schRotation ??
       0
 
-    const rot = ((typeof parentRotation === "string"
-      ? parseFloat(parentRotation)
-      : parentRotation) % 360 + 360) % 360
+    const rot =
+      (((typeof parentRotation === "string"
+        ? parseFloat(parentRotation)
+        : parentRotation) %
+        360) +
+        360) %
+      360
 
     const rotateSide = (side: string): string => {
       const map: Record<string, Record<number, string>> = {

--- a/tests/components/normal-components/capacitor-top-bottom-alias.test.tsx
+++ b/tests/components/normal-components/capacitor-top-bottom-alias.test.tsx
@@ -1,0 +1,29 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("capacitor top/bottom connections auto rotate", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <capacitor
+        name="C1"
+        capacitance="0.1uF"
+        footprint="0402"
+        connections={{ top: "net.VCC", bottom: "net.GND" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const schematicComponent = circuit.db.schematic_component.list()[0]
+  expect(schematicComponent.symbol_name).toBe("capacitor_up")
+
+  expect(circuit.db.source_trace.list().map((t) => t.display_name).sort()).toMatchInlineSnapshot(`
+    [
+      "capacitor.C1 > port.pin1 to net.GND",
+      "capacitor.C1 > port.pin2 to net.VCC",
+    ]
+  `)
+})

--- a/tests/components/normal-components/capacitor-top-bottom-alias.test.tsx
+++ b/tests/components/normal-components/capacitor-top-bottom-alias.test.tsx
@@ -20,7 +20,12 @@ test("capacitor top/bottom connections auto rotate", async () => {
   const schematicComponent = circuit.db.schematic_component.list()[0]
   expect(schematicComponent.symbol_name).toBe("capacitor_up")
 
-  expect(circuit.db.source_trace.list().map((t) => t.display_name).sort()).toMatchInlineSnapshot(`
+  expect(
+    circuit.db.source_trace
+      .list()
+      .map((t) => t.display_name)
+      .sort(),
+  ).toMatchInlineSnapshot(`
     [
       "capacitor.C1 > port.pin1 to net.GND",
       "capacitor.C1 > port.pin2 to net.VCC",


### PR DESCRIPTION
## Summary
- rotate capacitors automatically if pullup connections or top/bottom aliases are provided
- allow ports to match top/bottom based on schematic rotation
- refactor rotation lookups with `_getSchRotationBeforeLayout`
- test capacitor connections using top and bottom pins

## Testing
- `bun test tests/components/normal-components/capacitor-top-bottom-alias.test.tsx`
- `bun test`
