### PR TITLE
Respect platform disable flags

### DIFF
--- a/lib/RootCircuit.ts
+++ b/lib/RootCircuit.ts
@@ -18,6 +18,7 @@ export class RootCircuit {
   isRoot = true
   schematicDisabled = false
   pcbDisabled = false
+  partsEngineDisabled = false
   pcbRoutingDisabled = false
 
   /**
@@ -37,6 +38,17 @@ export class RootCircuit {
     // TODO rename to rootCircuit
     this.root = this
     this.platform = platform
+    if (platform) {
+      if (platform.pcbDisabled !== undefined) {
+        this.pcbDisabled = platform.pcbDisabled
+      }
+      if (platform.schematicDisabled !== undefined) {
+        this.schematicDisabled = platform.schematicDisabled
+      }
+      if (platform.partsEngineDisabled !== undefined) {
+        this.partsEngineDisabled = platform.partsEngineDisabled
+      }
+    }
   }
 
   add(componentOrElm: PrimitiveComponent | ReactElement) {

--- a/lib/augment-platform-config.d.ts
+++ b/lib/augment-platform-config.d.ts
@@ -3,5 +3,8 @@ import type { LocalCacheEngine } from "./local-cache-engine"
 declare module "@tscircuit/props" {
   interface PlatformConfig {
     localCacheEngine?: LocalCacheEngine
+    pcbDisabled?: boolean
+    schematicDisabled?: boolean
+    partsEngineDisabled?: boolean
   }
 }

--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -133,7 +133,7 @@ export class NormalComponent<
       pinCount?: number
     } = {},
   ) {
-    if (this.root?.schematicDisabled) return
+    if (this.getInheritedProperty("schematicDisabled")) return
     const { config } = this
     const portsToCreate: Port[] = []
 
@@ -403,7 +403,7 @@ export class NormalComponent<
    * You can override this method to do more complicated things.
    */
   doInitialSchematicComponentRender() {
-    if (this.root?.schematicDisabled) return
+    if (this.getInheritedProperty("schematicDisabled")) return
     const { db } = this.root!
 
     const { schematicSymbolName } = this.config
@@ -464,7 +464,7 @@ export class NormalComponent<
   }
 
   _doInitialSchematicComponentRenderWithSymbol() {
-    if (this.root?.schematicDisabled) return
+    if (this.getInheritedProperty("schematicDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
 
@@ -489,7 +489,7 @@ export class NormalComponent<
   }
 
   _doInitialSchematicComponentRenderWithSchematicBoxDimensions() {
-    if (this.root?.schematicDisabled) return
+    if (this.getInheritedProperty("schematicDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const dimensions = this._getSchematicBoxDimensions()!
@@ -567,7 +567,7 @@ export class NormalComponent<
   }
 
   doInitialPcbComponentRender() {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const subcircuit = this.getSubcircuit()
@@ -618,7 +618,7 @@ export class NormalComponent<
    * the width/height of the component
    */
   doInitialPcbComponentSizeCalculation(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     if (!this.pcb_component_id) return
     const { db } = this.root!
     const { _parsedProps: props } = this
@@ -811,7 +811,7 @@ export class NormalComponent<
   }
 
   getPortsFromSchematicSymbol(): Port[] {
-    if (this.root?.schematicDisabled) return []
+    if (this.getInheritedProperty("schematicDisabled")) return []
     const { config } = this
     if (!config.schematicSymbolName) return []
     const symbol: SchSymbol = (symbols as any)[config.schematicSymbolName]
@@ -1093,6 +1093,7 @@ export class NormalComponent<
   }
 
   doInitialPartsEngineRender(): void {
+    if (this.getInheritedProperty("partsEngineDisabled")) return
     const partsEngine = this.getInheritedProperty("partsEngine")
     if (!partsEngine) return
     const { db } = this.root!
@@ -1126,6 +1127,7 @@ export class NormalComponent<
   }
 
   updatePartsEngineRender(): void {
+    if (this.getInheritedProperty("partsEngineDisabled")) return
     const { db } = this.root!
 
     const source_component = db.source_component.get(this.source_component_id!)

--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -79,6 +79,9 @@ export abstract class PrimitiveComponent<
       }
       current = current.parent as PrimitiveComponent<ZodProps> | null // Move up to the parent
     }
+    if (this.root && propertyName in this.root) {
+      return (this.root as any)[propertyName]
+    }
     if (this.root?.platform && propertyName in this.root.platform) {
       return this.root.platform[propertyName as keyof typeof this.root.platform]
     }

--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -34,7 +34,7 @@ export class Board extends Group<typeof boardProps> {
   }
 
   doInitialPcbBoardAutoSize(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     if (!this.pcb_board_id) return
     const { db } = this.root!
     const { _parsedProps: props } = this
@@ -94,7 +94,7 @@ export class Board extends Group<typeof boardProps> {
   }
 
   doInitialPcbComponentRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
 
@@ -150,14 +150,14 @@ export class Board extends Group<typeof boardProps> {
   }
 
   doInitialPcbDesignRuleChecks() {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     if (this.getInheritedProperty("routingDisabled")) return
 
     super.doInitialPcbDesignRuleChecks()
   }
 
   updatePcbDesignRuleChecks() {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     if (this.getInheritedProperty("routingDisabled")) return
     const { db } = this.root!
 

--- a/lib/components/normal-components/Chip.ts
+++ b/lib/components/normal-components/Chip.ts
@@ -47,7 +47,7 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
   }
 
   doInitialPcbComponentRender() {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
 

--- a/lib/components/normal-components/Jumper.ts
+++ b/lib/components/normal-components/Jumper.ts
@@ -73,7 +73,7 @@ export class Jumper<PinLabels extends string = never> extends NormalComponent<
   }
 
   doInitialPcbComponentRender() {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
 

--- a/lib/components/primitive-components/Cutout.ts
+++ b/lib/components/primitive-components/Cutout.ts
@@ -19,7 +19,7 @@ export class Cutout extends PrimitiveComponent<typeof cutoutProps> {
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const subcircuit = this.getSubcircuit()

--- a/lib/components/primitive-components/FabricationNotePath.ts
+++ b/lib/components/primitive-components/FabricationNotePath.ts
@@ -15,7 +15,7 @@ export class FabricationNotePath extends PrimitiveComponent<
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const subcircuit = this.getSubcircuit()
     const { _parsedProps: props } = this

--- a/lib/components/primitive-components/FabricationNoteText.ts
+++ b/lib/components/primitive-components/FabricationNoteText.ts
@@ -12,7 +12,7 @@ export class FabricationNoteText extends PrimitiveComponent<
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const container = this.getPrimitiveContainer()!

--- a/lib/components/primitive-components/Footprint.ts
+++ b/lib/components/primitive-components/Footprint.ts
@@ -19,7 +19,7 @@ export class Footprint extends PrimitiveComponent<typeof footprintProps> {
    * to any constraints that are defined.
    */
   doInitialPcbFootprintLayout() {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const constraints = this.children.filter(
       (child) => child.componentName === "Constraint",
     ) as Constraint[]

--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -81,7 +81,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
   }
 
   doInitialPcbComponentRender() {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const pcb_group = db.pcb_group.insert({
@@ -104,7 +104,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
 
     const bounds = getBoundsOfPcbComponents(this.children)
@@ -489,7 +489,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
   doInitialPcbTraceRender() {
     const debug = Debug("tscircuit:core:doInitialPcbTraceRender")
     if (!this.isSubcircuit) return
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     if (this.getInheritedProperty("routingDisabled")) return
     if (this._shouldUseTraceByTraceRouting()) return
 
@@ -646,7 +646,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
   }
 
   doInitialSchematicComponentRender() {
-    if (this.root?.schematicDisabled) return
+    if (this.getInheritedProperty("schematicDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const schematic_group = db.schematic_group.insert({
@@ -773,7 +773,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
   }
 
   doInitialPcbDesignRuleChecks() {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     if (this.getInheritedProperty("routingDisabled")) return
     const { db } = this.root!
 

--- a/lib/components/primitive-components/Hole.ts
+++ b/lib/components/primitive-components/Hole.ts
@@ -19,7 +19,7 @@ export class Hole extends PrimitiveComponent<typeof holeProps> {
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const subcircuit = this.getSubcircuit()

--- a/lib/components/primitive-components/Keepout.ts
+++ b/lib/components/primitive-components/Keepout.ts
@@ -17,7 +17,7 @@ export class Keepout extends PrimitiveComponent<typeof pcbKeepoutProps> {
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const subcircuit = this.getSubcircuit()
     const { db } = this.root!
     const { _parsedProps: props } = this

--- a/lib/components/primitive-components/Net.ts
+++ b/lib/components/primitive-components/Net.ts
@@ -99,7 +99,7 @@ export class Net extends PrimitiveComponent<typeof netProps> {
    * This should only run if the autorouter is sequential-trace
    */
   doInitialPcbRouteNetIslands(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     if (this.getSubcircuit()._parsedProps.routingDisabled) return
     if (
       this.getSubcircuit()._getAutorouterConfig().groupMode !==

--- a/lib/components/primitive-components/NetAlias.ts
+++ b/lib/components/primitive-components/NetAlias.ts
@@ -13,7 +13,7 @@ export class NetAlias extends PrimitiveComponent<typeof netAliasProps> {
   }
 
   doInitialSchematicComponentRender(): void {
-    if (this.root?.schematicDisabled) return
+    if (this.getInheritedProperty("schematicDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
 

--- a/lib/components/primitive-components/PcbTrace.ts
+++ b/lib/components/primitive-components/PcbTrace.ts
@@ -24,7 +24,7 @@ export class PcbTrace extends PrimitiveComponent<typeof pcbTraceProps> {
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const container = this.getPrimitiveContainer()!

--- a/lib/components/primitive-components/PlatedHole.ts
+++ b/lib/components/primitive-components/PlatedHole.ts
@@ -91,7 +91,7 @@ export class PlatedHole extends PrimitiveComponent<typeof platedHoleProps> {
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const position = this._getGlobalPcbPositionBeforeLayout()
@@ -198,7 +198,7 @@ export class PlatedHole extends PrimitiveComponent<typeof platedHoleProps> {
   }
 
   doInitialPcbPortAttachment(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     db.pcb_plated_hole.update(this.pcb_plated_hole_id!, {
       pcb_port_id: this.matchedPort?.pcb_port_id!,

--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -289,7 +289,7 @@ export class Port extends PrimitiveComponent<typeof portProps> {
   }
 
   doInitialPcbPortRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { matchedComponents } = this
 

--- a/lib/components/primitive-components/SchematicText.ts
+++ b/lib/components/primitive-components/SchematicText.ts
@@ -14,7 +14,7 @@ export class SchematicText extends PrimitiveComponent<
   }
 
   doInitialSchematicPrimitiveRender(): void {
-    if (this.root?.schematicDisabled) return
+    if (this.getInheritedProperty("schematicDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
 

--- a/lib/components/primitive-components/SilkscreenCircle.ts
+++ b/lib/components/primitive-components/SilkscreenCircle.ts
@@ -15,7 +15,7 @@ export class SilkscreenCircle extends PrimitiveComponent<
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const { maybeFlipLayer } = this._getPcbPrimitiveFlippedHelpers()

--- a/lib/components/primitive-components/SilkscreenLine.ts
+++ b/lib/components/primitive-components/SilkscreenLine.ts
@@ -15,7 +15,7 @@ export class SilkscreenLine extends PrimitiveComponent<
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const { maybeFlipLayer } = this._getPcbPrimitiveFlippedHelpers()

--- a/lib/components/primitive-components/SilkscreenPath.ts
+++ b/lib/components/primitive-components/SilkscreenPath.ts
@@ -16,7 +16,7 @@ export class SilkscreenPath extends PrimitiveComponent<
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const { maybeFlipLayer } = this._getPcbPrimitiveFlippedHelpers()

--- a/lib/components/primitive-components/SilkscreenRect.ts
+++ b/lib/components/primitive-components/SilkscreenRect.ts
@@ -15,7 +15,7 @@ export class SilkscreenRect extends PrimitiveComponent<
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const { maybeFlipLayer } = this._getPcbPrimitiveFlippedHelpers()

--- a/lib/components/primitive-components/SilkscreenText.ts
+++ b/lib/components/primitive-components/SilkscreenText.ts
@@ -14,7 +14,7 @@ export class SilkscreenText extends PrimitiveComponent<
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const container = this.getPrimitiveContainer()!

--- a/lib/components/primitive-components/SmtPad.ts
+++ b/lib/components/primitive-components/SmtPad.ts
@@ -50,7 +50,7 @@ export class SmtPad extends PrimitiveComponent<typeof smtPadProps> {
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     if (!props.portHints) return
@@ -171,7 +171,7 @@ export class SmtPad extends PrimitiveComponent<typeof smtPadProps> {
   }
 
   doInitialPcbPortAttachment(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     db.pcb_smtpad.update(this.pcb_smtpad_id!, {
       pcb_port_id: this.matchedPort?.pcb_port_id!,

--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -316,7 +316,7 @@ export class Trace
     }
   }
   doInitialPcbTraceRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props, parent } = this
     const subcircuit = this.getSubcircuit()
@@ -664,7 +664,7 @@ export class Trace
   }
 
   _doInitialSchematicTraceRenderWithDisplayLabel(): void {
-    if (this.root?.schematicDisabled) return
+    if (this.getInheritedProperty("schematicDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props, parent } = this
 
@@ -847,7 +847,7 @@ export class Trace
   }
 
   doInitialSchematicTraceRender(): void {
-    if (this.root?.schematicDisabled) return
+    if (this.getInheritedProperty("schematicDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props, parent } = this
 

--- a/lib/components/primitive-components/TraceHint.ts
+++ b/lib/components/primitive-components/TraceHint.ts
@@ -66,7 +66,7 @@ export class TraceHint extends PrimitiveComponent<typeof traceHintProps> {
   }
 
   doInitialPcbTraceHintRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
 

--- a/lib/components/primitive-components/Via.ts
+++ b/lib/components/primitive-components/Via.ts
@@ -56,7 +56,7 @@ export class Via extends PrimitiveComponent<typeof viaProps> {
   }
 
   doInitialPcbPrimitiveRender(): void {
-    if (this.root?.pcbDisabled) return
+    if (this.getInheritedProperty("pcbDisabled")) return
     const { db } = this.root!
     const { _parsedProps: props } = this
     const position = this._getGlobalPcbPositionBeforeLayout()


### PR DESCRIPTION
## Summary
- map new `PlatformConfig` booleans to `RootCircuit`
- expose root config via `getInheritedProperty`
- honor `partsEngineDisabled` in rendering
- use inherited flags for PCB/Schematic rendering

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_683b39289ea8832ea2b578462c263e5b