### PR TITLE
Fix pulldown traces

### DIFF
--- a/lib/components/normal-components/Resistor.ts
+++ b/lib/components/normal-components/Resistor.ts
@@ -36,6 +36,8 @@ export class Resistor extends NormalComponent<
     this._createNetsFromProps([
       this.props.pullupFor,
       this.props.pullupTo,
+      this.props.pulldownFor,
+      this.props.pulldownTo,
       ...this._getNetsFromConnectionsProp(),
     ])
   }
@@ -52,6 +54,20 @@ export class Resistor extends NormalComponent<
         new Trace({
           from: `${this.getSubcircuitSelector()} > port.2`,
           to: this.props.pullupTo,
+        }),
+      )
+    }
+    if (this.props.pulldownFor && this.props.pulldownTo) {
+      this.add(
+        new Trace({
+          from: `${this.getSubcircuitSelector()} > port.1`,
+          to: this.props.pulldownFor,
+        }),
+      )
+      this.add(
+        new Trace({
+          from: `${this.getSubcircuitSelector()} > port.2`,
+          to: this.props.pulldownTo,
         }),
       )
     }

--- a/tests/components/normal-components/resistor-pulldown.test.tsx
+++ b/tests/components/normal-components/resistor-pulldown.test.tsx
@@ -1,0 +1,32 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { sel } from "lib/sel"
+
+// Test that pulldown properties create nets and schematic labels
+
+test("resistor pulldown nets have labels", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor
+        name="R1"
+        resistance="10k"
+        pulldownFor={sel.net.V3_3}
+        pulldownTo={sel.net.GND}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const traces = circuit.db.source_trace.list().map((t) => t.display_name)
+  expect(traces).toMatchInlineSnapshot(`
+    [
+      "resistor.R1 > port.1 to net.V3_3",
+      "resistor.R1 > port.2 to net.GND",
+    ]
+  `)
+
+  expect(circuit.db.schematic_net_label.list()).toHaveLength(2)
+})


### PR DESCRIPTION
## Summary
- support pulldown nets in Resistor component
- test that pulldown nets create traces and labels

## Testing
- `bun test tests/components/normal-components/resistor-pulldown.test.tsx`

------
https://chatgpt.com/codex/tasks/task_b_683e1d5197c4832eb0bdfccb67cd715f