### PR TITLE
Implement schematic flex layout

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -31,6 +31,7 @@ import { getBoundsOfPcbComponents } from "lib/utils/get-bounds-of-pcb-components
 import { Group_doInitialSchematicLayoutMatchAdapt } from "./Group_doInitialSchematicLayoutMatchAdapt"
 import { Group_doInitialSourceAddConnectivityMapKey } from "./Group_doInitialSourceAddConnectivityMapKey"
 import { Group_doInitialSchematicLayoutGrid } from "./Group_doInitialSchematicLayoutGrid"
+import { Group_doInitialSchematicLayoutFlex } from "./Group_doInitialSchematicLayoutFlex"
 import { Group_doInitialPcbLayoutGrid } from "./Group_doInitialPcbLayoutGrid"
 
 export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
@@ -662,6 +663,9 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     if (schematicLayoutMode === "match-adapt") {
       this._doInitialSchematicLayoutMatchAdapt()
     }
+    if (schematicLayoutMode === "flex") {
+      this._doInitialSchematicLayoutFlex()
+    }
     if (schematicLayoutMode === "grid") {
       this._doInitialSchematicLayoutGrid()
     }
@@ -673,6 +677,10 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
 
   _doInitialSchematicLayoutGrid(): void {
     Group_doInitialSchematicLayoutGrid(this)
+  }
+
+  _doInitialSchematicLayoutFlex(): void {
+    Group_doInitialSchematicLayoutFlex(this)
   }
 
   _getPcbLayoutMode(): "grid" | "flex" | "match-adapt" | "none" {

--- a/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutFlex.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutFlex.ts
@@ -1,0 +1,133 @@
+import type { Group } from "./Group"
+import type { PrimitiveComponent } from "lib/components/base-components/PrimitiveComponent"
+
+export function Group_doInitialSchematicLayoutFlex(group: Group<any>) {
+  const { db } = group.root!
+  const props = group._parsedProps as any
+
+  const schematicChildren = group.children.filter(
+    (c) => c.schematic_component_id,
+  ) as PrimitiveComponent[]
+
+  if (schematicChildren.length === 0) return
+
+  const flexDirection =
+    props.schLayout?.flexDirection ??
+    props.flexDirection ??
+    (props.flexRow ? "row" : props.flexColumn ? "column" : "row")
+
+  const gapOption = props.schLayout?.gap ?? props.gap
+  let gap = 1
+  if (typeof gapOption === "number") gap = gapOption
+  else if (typeof gapOption === "object" && gapOption !== null) {
+    gap = flexDirection === "row" ? gapOption.x : gapOption.y
+  }
+
+  const childSizes = schematicChildren.map((child) => {
+    const comp = db.schematic_component.get(child.schematic_component_id!)
+    return {
+      width: comp?.size?.width ?? 1,
+      height: comp?.size?.height ?? 1,
+    }
+  })
+
+  const groupCenter = group._getGlobalSchematicPositionBeforeLayout()
+
+  if (flexDirection === "row") {
+    const totalWidth =
+      childSizes.reduce((s, c) => s + c.width, 0) + gap * (childSizes.length - 1)
+    let currentX = groupCenter.x - totalWidth / 2
+    const maxHeight = Math.max(...childSizes.map((s) => s.height))
+
+    schematicChildren.forEach((child, i) => {
+      const size = childSizes[i]
+      currentX += size.width / 2
+      const newCenter = { x: currentX, y: groupCenter.y }
+
+      const schComp = db.schematic_component.get(child.schematic_component_id!)
+      if (schComp) {
+        const deltaX = newCenter.x - schComp.center.x
+        const deltaY = newCenter.y - schComp.center.y
+        db.schematic_component.update(child.schematic_component_id!, {
+          center: newCenter,
+        })
+        const ports = db.schematic_port.list({
+          schematic_component_id: child.schematic_component_id!,
+        })
+        for (const port of ports) {
+          db.schematic_port.update(port.schematic_port_id, {
+            center: { x: port.center.x + deltaX, y: port.center.y + deltaY },
+          })
+        }
+        const texts = db.schematic_text.list({
+          schematic_component_id: child.schematic_component_id!,
+        })
+        for (const text of texts) {
+          db.schematic_text.update(text.schematic_text_id, {
+            position: {
+              x: text.position.x + deltaX,
+              y: text.position.y + deltaY,
+            },
+          })
+        }
+      }
+      currentX += size.width / 2 + gap
+    })
+
+    if (group.schematic_group_id) {
+      db.schematic_group.update(group.schematic_group_id, {
+        width: totalWidth,
+        height: maxHeight,
+        center: groupCenter,
+      })
+    }
+  } else {
+    const totalHeight =
+      childSizes.reduce((s, c) => s + c.height, 0) + gap * (childSizes.length - 1)
+    let currentY = groupCenter.y + totalHeight / 2
+    const maxWidth = Math.max(...childSizes.map((s) => s.width))
+
+    schematicChildren.forEach((child, i) => {
+      const size = childSizes[i]
+      currentY -= size.height / 2
+      const newCenter = { x: groupCenter.x, y: currentY }
+
+      const schComp = db.schematic_component.get(child.schematic_component_id!)
+      if (schComp) {
+        const deltaX = newCenter.x - schComp.center.x
+        const deltaY = newCenter.y - schComp.center.y
+        db.schematic_component.update(child.schematic_component_id!, {
+          center: newCenter,
+        })
+        const ports = db.schematic_port.list({
+          schematic_component_id: child.schematic_component_id!,
+        })
+        for (const port of ports) {
+          db.schematic_port.update(port.schematic_port_id, {
+            center: { x: port.center.x + deltaX, y: port.center.y + deltaY },
+          })
+        }
+        const texts = db.schematic_text.list({
+          schematic_component_id: child.schematic_component_id!,
+        })
+        for (const text of texts) {
+          db.schematic_text.update(text.schematic_text_id, {
+            position: {
+              x: text.position.x + deltaX,
+              y: text.position.y + deltaY,
+            },
+          })
+        }
+      }
+      currentY -= size.height / 2 + gap
+    })
+
+    if (group.schematic_group_id) {
+      db.schematic_group.update(group.schematic_group_id, {
+        width: maxWidth,
+        height: totalHeight,
+        center: groupCenter,
+      })
+    }
+  }
+}

--- a/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutFlex.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutFlex.ts
@@ -35,7 +35,8 @@ export function Group_doInitialSchematicLayoutFlex(group: Group<any>) {
 
   if (flexDirection === "row") {
     const totalWidth =
-      childSizes.reduce((s, c) => s + c.width, 0) + gap * (childSizes.length - 1)
+      childSizes.reduce((s, c) => s + c.width, 0) +
+      gap * (childSizes.length - 1)
     let currentX = groupCenter.x - totalWidth / 2
     const maxHeight = Math.max(...childSizes.map((s) => s.height))
 
@@ -83,7 +84,8 @@ export function Group_doInitialSchematicLayoutFlex(group: Group<any>) {
     }
   } else {
     const totalHeight =
-      childSizes.reduce((s, c) => s + c.height, 0) + gap * (childSizes.length - 1)
+      childSizes.reduce((s, c) => s + c.height, 0) +
+      gap * (childSizes.length - 1)
     let currentY = groupCenter.y + totalHeight / 2
     const maxWidth = Math.max(...childSizes.map((s) => s.width))
 

--- a/tests/components/normal-components/board-flex-layout.test.tsx
+++ b/tests/components/normal-components/board-flex-layout.test.tsx
@@ -5,7 +5,11 @@ test("board flex layout positions schematic components in a row", () => {
   const { circuit } = getTestFixture()
 
   circuit.add(
-    <board schLayout={{ flex: true, flexDirection: "row", gap: 1 }} width="20mm" height="20mm">
+    <board
+      schLayout={{ flex: true, flexDirection: "row", gap: 1 }}
+      width="20mm"
+      height="20mm"
+    >
       <resistor name="R1" resistance="10k" footprint="0402" />
       <resistor name="R2" resistance="10k" footprint="0402" />
       <resistor name="R3" resistance="10k" footprint="0402" />

--- a/tests/components/normal-components/board-flex-layout.test.tsx
+++ b/tests/components/normal-components/board-flex-layout.test.tsx
@@ -1,0 +1,29 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("board flex layout positions schematic components in a row", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board schLayout={{ flex: true, flexDirection: "row", gap: 1 }} width="20mm" height="20mm">
+      <resistor name="R1" resistance="10k" footprint="0402" />
+      <resistor name="R2" resistance="10k" footprint="0402" />
+      <resistor name="R3" resistance="10k" footprint="0402" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const r1 = circuit.selectOne(".R1")!
+  const r2 = circuit.selectOne(".R2")!
+  const r3 = circuit.selectOne(".R3")!
+
+  const c1 = circuit.db.schematic_component.get(r1.schematic_component_id!)!
+  const c2 = circuit.db.schematic_component.get(r2.schematic_component_id!)!
+  const c3 = circuit.db.schematic_component.get(r3.schematic_component_id!)!
+
+  const ys = new Set([c1.center.y, c2.center.y, c3.center.y])
+  expect(ys.size).toBe(1)
+  expect(c2.center.x).toBeGreaterThan(c1.center.x)
+  expect(c3.center.x).toBeGreaterThan(c2.center.x)
+})


### PR DESCRIPTION
## Summary
- support flex schematic layout for groups
- add tests for board flex layout

## Testing
- `bun test tests/components/normal-components/board-flex-layout.test.tsx`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_683fdf00181c832e965fe1b33095991f