### PR TITLE
Validate net selectors

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
+++ b/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
@@ -1,4 +1,9 @@
 export const preprocessSelector = (selector: string) => {
+  if (/net\.[^\s>]*\./.test(selector)) {
+    throw new Error(
+      'Net names cannot contain a period, try using "sel.net..." to autocomplete with conventional net names, e.g. V3_3',
+    )
+  }
   return selector
     .replace(/ pin/g, " port")
     .replace(/ subcircuit\./g, " group[isSubcircuit=true]")

--- a/lib/utils/components/createNetsFromProps.ts
+++ b/lib/utils/components/createNetsFromProps.ts
@@ -7,6 +7,11 @@ export const createNetsFromProps = (
 ) => {
   for (const prop of props) {
     if (typeof prop === "string" && prop.startsWith("net.")) {
+      if (/net\.[^\s>]*\./.test(prop)) {
+        throw new Error(
+          'Net names cannot contain a period, try using "sel.net..." to autocomplete with conventional net names, e.g. V3_3',
+        )
+      }
       const subcircuit = component.getSubcircuit()
       if (!subcircuit.selectOne(prop)) {
         const net = new Net({

--- a/tests/sel/net-name-period.test.ts
+++ b/tests/sel/net-name-period.test.ts
@@ -1,0 +1,8 @@
+import { preprocessSelector } from "lib/components/base-components/PrimitiveComponent/preprocessSelector"
+import { test, expect } from "bun:test"
+
+test("preprocessSelector - dot after net prefix throws", () => {
+  expect(() => preprocessSelector("net.VCC.extra")).toThrow(
+    'Net names cannot contain a period, try using "sel.net..." to autocomplete with conventional net names, e.g. V3_3',
+  )
+})


### PR DESCRIPTION
## Summary
- prevent periods in net selectors
- create nets from props with invalid net names throw an error
- add test for invalid net selectors

## Testing
- `npm run format`
- `bun test tests/sel/net-name-period.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68406cb56bc8832e9313eef08afa72cf