### PR TITLE
Add shorthand selector support

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
+++ b/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
@@ -3,5 +3,12 @@ export const preprocessSelector = (selector: string) => {
     .replace(/ pin/g, " port")
     .replace(/ subcircuit\./g, " group[isSubcircuit=true]")
     .replace(/([^ ])\>([^ ])/g, "$1 > $2")
+    .replace(
+      /(^|[ >])(?!pin\.)(?!port\.)(?!net\.)([A-Z][A-Za-z0-9_-]*)\.([A-Za-z0-9_-]+)/g,
+      (_, sep, name, pin) => {
+        const pinPart = /^\d+$/.test(pin) ? `pin${pin}` : pin
+        return `${sep}.${name} > .${pinPart}`
+      },
+    )
     .trim()
 }

--- a/tests/components/base-components/shorthand-selector.test.tsx
+++ b/tests/components/base-components/shorthand-selector.test.tsx
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Verify that shorthand selectors like "R1.1" or "LED1.pos" work
+
+test("shorthand selectors resolve correctly", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="10k" footprint="0402" />
+      <led name="LED1" footprint="0402" />
+      <trace from="R1.1" to="LED1.pos" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const shorthandPort = circuit.selectOne("R1.1") as any
+  const explicitPort = circuit.selectOne(".R1 > .pin1") as any
+  expect(shorthandPort).not.toBeNull()
+  expect(explicitPort).not.toBeNull()
+  expect(shorthandPort!.pcb_port_id).toBe(explicitPort!.pcb_port_id)
+})
+
+test("shorthand selector errors use original selector", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="10k" footprint="0402" />
+      <trace from="R1.3" to="net.GND" />
+    </board>,
+  )
+
+  expect(() => circuit.render()).toThrow(
+    /Could not find port for selector "R1\.3"/,
+  )
+})


### PR DESCRIPTION
## Summary
- extend selector preprocessor to handle shorthand like `U1.1`
- add tests covering shorthand selector behavior

## Testing
- `bun run format`
- `bun x tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68406d78524c832e9f34db7167ccd64b