### PR TITLE
Validate net selector names (no starting digits, e.g. net.5V is invalid)

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
+++ b/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
@@ -4,6 +4,11 @@ export const preprocessSelector = (selector: string) => {
       'Net names cannot contain a period, try using "sel.net..." to autocomplete with conventional net names, e.g. V3_3',
     )
   }
+  if (/net\.[0-9]/.test(selector)) {
+    throw new Error(
+      'Net names cannot start with a number, try using a prefix like "VBUS1"',
+    )
+  }
   return selector
     .replace(/ pin/g, " port")
     .replace(/ subcircuit\./g, " group[isSubcircuit=true]")

--- a/lib/utils/components/createNetsFromProps.ts
+++ b/lib/utils/components/createNetsFromProps.ts
@@ -12,6 +12,11 @@ export const createNetsFromProps = (
           'Net names cannot contain a period, try using "sel.net..." to autocomplete with conventional net names, e.g. V3_3',
         )
       }
+      if (/net\.[0-9]/.test(prop)) {
+        throw new Error(
+          'Net names cannot start with a number, try using a prefix like "VBUS1"',
+        )
+      }
       const subcircuit = component.getSubcircuit()
       if (!subcircuit.selectOne(prop)) {
         const net = new Net({

--- a/tests/examples/example1.test.tsx
+++ b/tests/examples/example1.test.tsx
@@ -17,7 +17,7 @@ test("example1", async () => {
         footprint="0402"
         resistance="10k"
         pullupFor=".U1 port.2"
-        pullupTo="net.5v"
+        pullupTo="net.V5"
         pcbX={-4}
         pcbY={0}
         pcbRotation={-90}
@@ -34,10 +34,10 @@ test("example1", async () => {
       />
       <jumper pcbX={0} pcbY={-4} name="J1" footprint="pinrow4" />
 
-      <trace from=".U1 .PWR" to="net.5v" />
+      <trace from=".U1 .PWR" to="net.V5" />
       <trace from=".U1 .GND" to="net.gnd" />
 
-      <trace from=".J1 pin.1" to="net.5v" />
+      <trace from=".J1 pin.1" to="net.V5" />
       <trace from=".J1 pin.2" to=".U1 port.2" />
       <trace from=".J1 pin.3" to=".U1 port.3" />
       <trace from=".J1 pin.4" to="net.gnd" />

--- a/tests/sel/net-name-start-number.test.ts
+++ b/tests/sel/net-name-start-number.test.ts
@@ -1,0 +1,8 @@
+import { preprocessSelector } from "lib/components/base-components/PrimitiveComponent/preprocessSelector"
+import { test, expect } from "bun:test"
+
+test("preprocessSelector - net name starting with number throws", () => {
+  expect(() => preprocessSelector("net.1V")).toThrow(
+    'Net names cannot start with a number, try using a prefix like "VBUS1"',
+  )
+})


### PR DESCRIPTION
## Summary
- disallow net selector names starting with numbers
- cover with tests
- update Example 1 test to use `net.V5`

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684077083824832e9f61b7a7ab55fc78