### PR TITLE
Support projectUrl for RootCircuit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "@types/react-reconciler": "^0.28.9",
         "bun-match-svg": "0.0.8",
         "chokidar-cli": "^3.0.0",
-        "circuit-json": "^0.0.200",
+        "circuit-json": "^0.0.201",
         "circuit-json-to-connectivity-map": "^0.0.22",
         "circuit-json-to-simple-3d": "^0.0.2",
         "circuit-to-svg": "^0.0.151",
@@ -63,7 +63,7 @@
         "@tscircuit/props": "*",
         "@tscircuit/schematic-autolayout": "*",
         "@tscircuit/schematic-match-adapt": "*",
-        "circuit-json": "^0.0.200",
+        "circuit-json": "*",
         "circuit-json-to-connectivity-map": "*",
         "schematic-symbols": "*",
         "typescript": "^5.0.0",
@@ -379,7 +379,7 @@
 
     "chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
 
-    "circuit-json": ["circuit-json@0.0.200", "", { "dependencies": { "nanoid": "^5.0.7", "zod": "^3.23.6" } }, "sha512-OBqvE4/lhaiU4yuPPGK9dEU0MHKiqhHIXhu+W6dhsGW9GccZLmgkA59ZNiWbiHTse4IcYyho7zRHuQ2qeZQ7BQ=="],
+    "circuit-json": ["circuit-json@0.0.201", "", { "dependencies": { "nanoid": "^5.0.7", "zod": "^3.23.6" } }, "sha512-D+raM3wi/FoMDQW15AYDjbnV8jDg8LSmuMeWit9v3EaPA4BSyu5MEjP6IBG1i0yrh91eFrNH97vVI14ge2W0xg=="],
 
     "circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.22", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-HN8DiISjZZLTglGEkYNRpKeQ/DMG4dDo5j4Hck0UGSJbpux9aFwtJOGszMf06Inh/gu5oKBrpZJIeWxaNacKUg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "@types/react-reconciler": "^0.28.9",
         "bun-match-svg": "0.0.8",
         "chokidar-cli": "^3.0.0",
-        "circuit-json": "^0.0.199",
+        "circuit-json": "^0.0.200",
         "circuit-json-to-connectivity-map": "^0.0.22",
         "circuit-json-to-simple-3d": "^0.0.2",
         "circuit-to-svg": "^0.0.151",
@@ -63,7 +63,7 @@
         "@tscircuit/props": "*",
         "@tscircuit/schematic-autolayout": "*",
         "@tscircuit/schematic-match-adapt": "*",
-        "circuit-json": "*",
+        "circuit-json": "^0.0.200",
         "circuit-json-to-connectivity-map": "*",
         "schematic-symbols": "*",
         "typescript": "^5.0.0",
@@ -379,7 +379,7 @@
 
     "chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
 
-    "circuit-json": ["circuit-json@0.0.199", "", { "dependencies": { "nanoid": "^5.0.7", "zod": "^3.23.6" } }, "sha512-VtLDmVnDxmewWC0mE68wkCo3HzbFQaarK1n/X3guMhjOiZNfiZ03cpIgd2cusrFud0G3tPk2zjTiOzOhZ8UHHA=="],
+    "circuit-json": ["circuit-json@0.0.200", "", { "dependencies": { "nanoid": "^5.0.7", "zod": "^3.23.6" } }, "sha512-OBqvE4/lhaiU4yuPPGK9dEU0MHKiqhHIXhu+W6dhsGW9GccZLmgkA59ZNiWbiHTse4IcYyho7zRHuQ2qeZQ7BQ=="],
 
     "circuit-json-to-connectivity-map": ["circuit-json-to-connectivity-map@0.0.22", "", { "dependencies": { "@tscircuit/math-utils": "^0.0.9" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-HN8DiISjZZLTglGEkYNRpKeQ/DMG4dDo5j4Hck0UGSJbpux9aFwtJOGszMf06Inh/gu5oKBrpZJIeWxaNacKUg=="],
 

--- a/lib/RootCircuit.ts
+++ b/lib/RootCircuit.ts
@@ -122,11 +122,6 @@ export class RootCircuit {
         software_used_string: `@tscircuit/core@${this.getCoreVersion()}`,
         ...(this.projectUrl ? { project_url: this.projectUrl } : {}),
       })
-    } else if (this.projectUrl && !existing.project_url) {
-      this.db.source_project_metadata.update(
-        existing.source_project_metadata_id,
-        { project_url: this.projectUrl },
-      )
     }
 
     this.render()

--- a/lib/RootCircuit.ts
+++ b/lib/RootCircuit.ts
@@ -29,14 +29,25 @@ export class RootCircuit {
 
   platform?: PlatformConfig
 
+  /**
+   * Optional URL pointing to where this project is hosted or documented.
+   * When provided it is stored in the source_project_metadata.project_url field
+   * of the generated Circuit JSON.
+   */
+  projectUrl?: string
+
   _hasRenderedAtleastOnce = false
 
-  constructor({ platform }: { platform?: PlatformConfig } = {}) {
+  constructor({
+    platform,
+    projectUrl,
+  }: { platform?: PlatformConfig; projectUrl?: string } = {}) {
     this.children = []
     this.db = su([])
     // TODO rename to rootCircuit
     this.root = this
     this.platform = platform
+    this.projectUrl = projectUrl
   }
 
   add(componentOrElm: PrimitiveComponent | ReactElement) {
@@ -105,10 +116,17 @@ export class RootCircuit {
   }
 
   async renderUntilSettled(): Promise<void> {
-    if (!this.db.source_project_metadata.list()?.[0]) {
+    const existing = this.db.source_project_metadata.list()?.[0]
+    if (!existing) {
       this.db.source_project_metadata.insert({
         software_used_string: `@tscircuit/core@${this.getCoreVersion()}`,
+        ...(this.projectUrl ? { project_url: this.projectUrl } : {}),
       })
+    } else if (this.projectUrl && !existing.project_url) {
+      this.db.source_project_metadata.update(
+        existing.source_project_metadata_id,
+        { project_url: this.projectUrl },
+      )
     }
 
     this.render()

--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -806,7 +806,7 @@ export abstract class PrimitiveComponent<
       return super.renderError(message)
     }
     // TODO this needs to be cleaned up at some point!
-    this.root?.db.pcb_placement_error.insert(message)
+    this.root?.db.pcb_placement_error.insert(message as any)
   }
 
   getString(): string {

--- a/lib/components/primitive-components/ErrorPlaceholder.ts
+++ b/lib/components/primitive-components/ErrorPlaceholder.ts
@@ -32,6 +32,7 @@ class ErrorPlaceholderComponent extends PrimitiveComponent {
 
       this.root.db.source_failed_to_create_component_error.insert({
         component_name: this._parsedProps.component_name,
+        error_type: "source_failed_to_create_component_error",
         message:
           this._parsedProps.error?.formattedError?._errors?.join("; ") ||
           this._parsedProps.message,

--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -320,6 +320,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       if (job.has_error) {
         db.pcb_autorouting_error.insert({
           pcb_error_id: autorouting_job.autorouting_job_id,
+          error_type: "pcb_autorouting_error",
           message: job.error?.message ?? JSON.stringify(job.error),
         })
         throw new Error(`Autorouting job failed: ${JSON.stringify(job.error)}`)
@@ -425,6 +426,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       // Record the error
       db.pcb_autorouting_error.insert({
         pcb_error_id: `pcb_autorouter_error_subcircuit_${this.subcircuit_id}`,
+        error_type: "pcb_autorouting_error",
         message: error instanceof Error ? error.message : String(error),
       })
 

--- a/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutMatchAdapt.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutMatchAdapt.ts
@@ -56,6 +56,7 @@ export function Group_doInitialSchematicLayoutMatchAdapt<
   } catch (e: any) {
     db.schematic_layout_error.insert({
       message: `Match-adapt layout failed: ${e.toString()}`,
+      error_type: "schematic_layout_error",
       source_group_id: group.source_group_id!,
       schematic_group_id: group.schematic_group_id!,
     })

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/react-reconciler": "^0.28.9",
     "bun-match-svg": "0.0.8",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.200",
+    "circuit-json": "^0.0.201",
     "circuit-json-to-connectivity-map": "^0.0.22",
     "circuit-json-to-simple-3d": "^0.0.2",
     "circuit-to-svg": "^0.0.151",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/react-reconciler": "^0.28.9",
     "bun-match-svg": "0.0.8",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.199",
+    "circuit-json": "^0.0.200",
     "circuit-json-to-connectivity-map": "^0.0.22",
     "circuit-json-to-simple-3d": "^0.0.2",
     "circuit-to-svg": "^0.0.151",

--- a/tests/components/normal-components/missing-prop-error-parent-tranform.test.tsx
+++ b/tests/components/normal-components/missing-prop-error-parent-tranform.test.tsx
@@ -39,6 +39,7 @@ test("(ErrorPlaceholder) - missing prop error with parent transform", async () =
       [
         {
           "component_name": "R1",
+          "error_type": "source_failed_to_create_component_error",
           "message": "Invalid props for resistor "R1": resistance (Required)",
           "pcb_center": {
             "x": 3,

--- a/tests/components/normal-components/missing-prop-error.test.tsx
+++ b/tests/components/normal-components/missing-prop-error.test.tsx
@@ -22,6 +22,7 @@ test("(ErrorPlaceholder) - missing prop error", async () => {
     [
       {
         "component_name": "R1",
+        "error_type": "source_failed_to_create_component_error",
         "message": "Invalid props for resistor "R1": resistance (Required)",
         "pcb_center": {
           "x": 3,

--- a/tests/components/normal-components/source_project_metadata.test.tsx
+++ b/tests/components/normal-components/source_project_metadata.test.tsx
@@ -1,6 +1,8 @@
 import { test, expect } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 import { su } from "@tscircuit/circuit-json-util"
+import { RootCircuit } from "lib/RootCircuit"
+import "lib/register-catalogue"
 
 test("source_project_metadata added to circuit JSON output", async () => {
   const { circuit } = await getTestFixture()
@@ -18,4 +20,21 @@ test("source_project_metadata added to circuit JSON output", async () => {
 
   // Ensure that source_project_metadata is added
   expect(sourceProjectMetadata.length).toBeGreaterThan(0)
+})
+
+test("source_project_metadata project_url populated when provided", async () => {
+  const circuit = new RootCircuit({ projectUrl: "https://example.com" })
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const [metadata] = su(circuitJson).source_project_metadata.list()
+
+  expect(metadata.project_url).toBe("https://example.com")
 })

--- a/tests/examples/example20-autorouting-error.test.tsx
+++ b/tests/examples/example20-autorouting-error.test.tsx
@@ -41,6 +41,7 @@ test("remote-autorouter-1 with legacy solve endpoint", async () => {
   expect(autoroutingErrors).toMatchInlineSnapshot(`
     [
       {
+        "error_type": "pcb_autorouting_error",
         "message": "Failed to compute first trace (failInFirstTrace simulated error)",
         "pcb_autorouting_error_id": "pcb_autorouting_error_0",
         "pcb_error_id": "job_0",

--- a/tests/examples/example25-invalid-props-for-schematic-box.test.tsx
+++ b/tests/examples/example25-invalid-props-for-schematic-box.test.tsx
@@ -45,6 +45,7 @@ test("Schematic box with invalid props", async () => {
       [
         {
           "component_name": undefined,
+          "error_type": "source_failed_to_create_component_error",
           "message": "Must provide either both \`width\` and \`height\`, or a non-empty \`overlay\` array.",
           "pcb_center": {
             "x": 0,
@@ -59,6 +60,7 @@ test("Schematic box with invalid props", async () => {
         },
         {
           "component_name": undefined,
+          "error_type": "source_failed_to_create_component_error",
           "message": "Cannot provide both \`width\`/\`height\` and \`overlay\` at the same time.",
           "pcb_center": {
             "x": 0,


### PR DESCRIPTION
## Summary
- upgrade `circuit-json` dependency
- add `projectUrl` option for `RootCircuit`
- populate `source_project_metadata.project_url` when provided
- test project URL insertion

## Testing
- `bun test tests/components/normal-components/source_project_metadata.test.tsx`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68461518b380832e8de782ee71e5cb06