### PR TITLE
Prevent nested boards

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -515,6 +515,13 @@ export abstract class PrimitiveComponent<
   }
 
   add(component: PrimitiveComponent) {
+    // Disallow nesting boards inside of boards
+    if (
+      this.lowercaseComponentName === "board" &&
+      component.lowercaseComponentName === "board"
+    ) {
+      throw new Error("Nested boards are not supported")
+    }
     if (!component.onAddToParent) {
       throw new Error(
         `Invalid JSX Element: Expected a React component but received "${JSON.stringify(component)}"`,

--- a/tests/components/normal-components/board-nested.test.tsx
+++ b/tests/components/normal-components/board-nested.test.tsx
@@ -8,7 +8,7 @@ test("error when board nested inside board", () => {
     circuit.add(
       <board>
         <board>
-          <resistor name="R1" />
+          <resistor name="R1" resistance={100} />
         </board>
       </board>,
     ),

--- a/tests/components/normal-components/board-nested.test.tsx
+++ b/tests/components/normal-components/board-nested.test.tsx
@@ -1,0 +1,16 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("error when board nested inside board", () => {
+  const { circuit } = getTestFixture()
+
+  expect(() =>
+    circuit.add(
+      <board>
+        <board>
+          <resistor name="R1" />
+        </board>
+      </board>,
+    ),
+  ).toThrow("Nested boards are not supported")
+})


### PR DESCRIPTION
## Summary
- disallow adding a board inside another board
- test nested board error

## Testing
- `bun test tests/components/normal-components/board-nested.test.tsx`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_e_6849b11482c083328d78a067a290719d