### PR TITLE
Improve net name error message

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
+++ b/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
@@ -5,8 +5,10 @@ export const preprocessSelector = (selector: string) => {
     )
   }
   if (/net\.[0-9]/.test(selector)) {
+    const match = selector.match(/net\.([^ >]+)/)
+    const netName = match ? match[1] : ""
     throw new Error(
-      'Net names cannot start with a number, try using a prefix like "VBUS1"',
+      `Net name "${netName}" cannot start with a number, try using a prefix like "VBUS1"`,
     )
   }
   return selector

--- a/lib/utils/components/createNetsFromProps.ts
+++ b/lib/utils/components/createNetsFromProps.ts
@@ -13,8 +13,9 @@ export const createNetsFromProps = (
         )
       }
       if (/net\.[0-9]/.test(prop)) {
+        const netName = prop.split("net.")[1]
         throw new Error(
-          'Net names cannot start with a number, try using a prefix like "VBUS1"',
+          `Net name "${netName}" cannot start with a number, try using a prefix like "VBUS1"`,
         )
       }
       const subcircuit = component.getSubcircuit()

--- a/tests/sel/net-name-start-number.test.ts
+++ b/tests/sel/net-name-start-number.test.ts
@@ -3,6 +3,6 @@ import { test, expect } from "bun:test"
 
 test("preprocessSelector - net name starting with number throws", () => {
   expect(() => preprocessSelector("net.1V")).toThrow(
-    'Net names cannot start with a number, try using a prefix like "VBUS1"',
+    'Net name "1V" cannot start with a number, try using a prefix like "VBUS1"',
   )
 })


### PR DESCRIPTION
## Summary
- clarify which net name triggered the 'starts with number' error
- adjust affected test case

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6849c4952ca08327b7288e231817d603