### PR TITLE
Enable generic sel.net

### DIFF
--- a/lib/sel/sel.ts
+++ b/lib/sel/sel.ts
@@ -86,7 +86,11 @@ type JumperSel = Record<
 
 type ChipSel = Record<`U${Nums40}`, Record<CommonPinNames, string> & ChipFnSel>
 
-type NetSel = Record<"net", Record<CommonNetNames, string>>
+type NetSelFn<N extends string = CommonNetNames> = (<N2 extends string>() =>
+  Record<N | N2, string>) &
+  Record<N, string>
+
+type NetSel<N extends string = CommonNetNames> = Record<"net", NetSelFn<N>>
 
 type ExplicitModuleSel = Record<
   "subcircuit" | "module" | "group",
@@ -190,6 +194,15 @@ export const sel: Sel = new Proxy(
         // - sel.U1(({ selectors: { U1: { GND: "GND", VCC: "VCC" } } }) => ...)
         // - sel.U1(({ connections: { GND: "GND", VCC: "VCC" } }) => ...)
         apply: (target, _, args: any[]) => {
+          if (prop1 === "net") {
+            return new Proxy(
+              {},
+              {
+                get: (_, netName: string) => `net.${netName}`,
+              },
+            )
+          }
+
           return new Proxy(
             {},
             {

--- a/tests/sel/sel-net-generic.test.ts
+++ b/tests/sel/sel-net-generic.test.ts
@@ -1,0 +1,12 @@
+import { sel } from "lib/sel"
+import { test, expect } from "bun:test"
+
+test("sel-net-generic - custom net names via generics", () => {
+  const customSel = sel.net<"CUSTOM1" | "CUSTOM2">()
+
+  expect(customSel.CUSTOM1).toBe("net.CUSTOM1")
+  expect(customSel.CUSTOM2).toBe("net.CUSTOM2")
+
+  // @ts-expect-error
+  customSel.DOES_NOT_EXIST
+})


### PR DESCRIPTION
## Summary
- support generic net selectors in `sel`
- add a unit test for generic nets

## Testing
- `bun test tests/sel/sel-net-generic.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684c744f2598832ea51459946158c989