### PR TITLE
Allow circuits without top-level board

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "@tscircuit/layout": "^0.0.28",
         "@tscircuit/log-soup": "^1.0.2",
         "@tscircuit/math-utils": "^0.0.18",
-        "@tscircuit/props": "^0.0.220",
+        "@tscircuit/props": "^0.0.222",
         "@tscircuit/schematic-autolayout": "^0.0.6",
         "@tscircuit/schematic-match-adapt": "^0.0.16",
         "@tscircuit/simple-3d-svg": "^0.0.6",
@@ -60,7 +60,7 @@
         "@tscircuit/footprinter": "*",
         "@tscircuit/infgrid-ijump-astar": "*",
         "@tscircuit/math-utils": "*",
-        "@tscircuit/props": "*",
+        "@tscircuit/props": "^0.0.222",
         "@tscircuit/schematic-autolayout": "*",
         "@tscircuit/schematic-match-adapt": "*",
         "circuit-json": "*",
@@ -249,7 +249,7 @@
 
     "@tscircuit/mm": ["@tscircuit/mm@0.0.8", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-nl7nxE7AhARbKuobflI0LUzoir7+wJyvwfPw6bzA/O0Q3YTcH3vBkU/Of+V/fp6ht+AofiCXj7YAH9E446138Q=="],
 
-    "@tscircuit/props": ["@tscircuit/props@0.0.220", "", { "peerDependencies": { "@tscircuit/layout": "*", "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-3KvbZ3bUqc0Yt7+JaSxgGx6igrx2zUgYpJ00fJFtq3E+b8uoU1/pwP7p1mGzT/G5wr1fh6EgHLN/b3nLVn9k/w=="],
+    "@tscircuit/props": ["@tscircuit/props@0.0.222", "", { "peerDependencies": { "@tscircuit/layout": "*", "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-48h85KVeGYAloGSqGuu7ZBzfRhhEi98KdxoBCTt/8Pj0sI1/ExcwGgShltxFEJA7+G0i7muvEdGTJpCCOZwXqA=="],
 
     "@tscircuit/schematic-autolayout": ["@tscircuit/schematic-autolayout@0.0.6", "", { "dependencies": { "@tscircuit/soup-util": "^0.0.38", "transformation-matrix": "^2.16.1" } }, "sha512-34cQxtlSylBKyHkzaMBCynaWJgN9c/mWm7cz63StTYIafKmfFs383K8Xoc4QX8HXCvVrHYl1aK15onZua9MxeA=="],
 

--- a/lib/RootCircuit.ts
+++ b/lib/RootCircuit.ts
@@ -9,6 +9,7 @@ import type { RenderPhase } from "./components/base-components/Renderable"
 import pkgJson from "../package.json"
 import type { RootCircuitEventName } from "./events"
 import type { PlatformConfig } from "@tscircuit/props"
+import { Group } from "./components/primitive-components/Group"
 
 export class RootCircuit {
   firstChild: PrimitiveComponent | null = null
@@ -99,9 +100,11 @@ export class RootCircuit {
         return
       }
     }
-    throw new Error(
-      "Not able to guess root component: RootCircuit has multiple children and no board",
-    )
+    // If there's no board, wrap all children in an implicit group so a board is not required
+    const group = new Group({ subcircuit: false })
+    group.addAll(this.children)
+    this.children = [group]
+    this.firstChild = group
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tscircuit/layout": "^0.0.28",
     "@tscircuit/log-soup": "^1.0.2",
     "@tscircuit/math-utils": "^0.0.18",
-    "@tscircuit/props": "^0.0.220",
+    "@tscircuit/props": "^0.0.222",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/simple-3d-svg": "^0.0.6",

--- a/tests/features/no-top-level-board.test.tsx
+++ b/tests/features/no-top-level-board.test.tsx
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Validate that a circuit can render without a top level board element
+
+test("render circuit without top level board", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(<resistor name="R1" resistance="10k" footprint="0402" />)
+  circuit.add(<led name="LED1" footprint="0402" />)
+
+  expect(() => circuit.render()).not.toThrow()
+  expect(circuit.db.source_component.select(".R1")?.name).toBe("R1")
+  expect(circuit.db.source_component.select(".LED1")?.name).toBe("LED1")
+})


### PR DESCRIPTION
## Summary
- don't require a `<board>` element when multiple children are added to a circuit
- test that multiple top-level elements render correctly
- update `@tscircuit/props` to latest

## Testing
- `bun test tests/features/no-top-level-board.test.tsx`
- `bun test tests/components/normal-components/resistor-with-footprint.test.tsx`
- `bun test tests/createElementUsage.test.tsx`
- `bun test tests/selector-index/selector-index1.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_684d97749370832e91f508c3120168e0