### PR TITLE
Add AutorouterError with package version

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -32,6 +32,7 @@ import { Group_doInitialSchematicLayoutMatchAdapt } from "./Group_doInitialSchem
 import { Group_doInitialSourceAddConnectivityMapKey } from "./Group_doInitialSourceAddConnectivityMapKey"
 import { Group_doInitialSchematicLayoutGrid } from "./Group_doInitialSchematicLayoutGrid"
 import { Group_doInitialPcbLayoutGrid } from "./Group_doInitialPcbLayoutGrid"
+import { AutorouterError } from "lib/errors/AutorouterError"
 
 export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
   extends NormalComponent<Props>
@@ -318,12 +319,15 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       }
 
       if (job.has_error) {
+        const err = new AutorouterError(
+          `Autorouting job failed: ${JSON.stringify(job.error)}`,
+        )
         db.pcb_autorouting_error.insert({
           pcb_error_id: autorouting_job.autorouting_job_id,
           error_type: "pcb_autorouting_error",
-          message: job.error?.message ?? JSON.stringify(job.error),
+          message: err.message,
         })
-        throw new Error(`Autorouting job failed: ${JSON.stringify(job.error)}`)
+        throw err
       }
 
       // Wait before polling again

--- a/lib/errors/AutorouterError.ts
+++ b/lib/errors/AutorouterError.ts
@@ -1,0 +1,10 @@
+import packageJson from "@tscircuit/capacity-autorouter/package.json"
+
+const autorouterVersion = packageJson.version ?? "unknown"
+
+export class AutorouterError extends Error {
+  constructor(message: string) {
+    super(`${message} (capacity-autorouter@${autorouterVersion})`)
+    this.name = "AutorouterError"
+  }
+}

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,0 +1,2 @@
+export * from "./InvalidProps"
+export * from "./AutorouterError"

--- a/lib/utils/autorouting/CapacityMeshAutorouter.ts
+++ b/lib/utils/autorouting/CapacityMeshAutorouter.ts
@@ -1,4 +1,5 @@
 import { CapacityMeshSolver } from "@tscircuit/capacity-autorouter"
+import { AutorouterError } from "lib/errors/AutorouterError"
 import type { SimpleRouteJson, SimplifiedPcbTrace } from "./SimpleRouteJson"
 import type {
   AutorouterCompleteEvent,
@@ -74,7 +75,7 @@ export class CapacityMeshAutorouter implements GenericLocalAutorouter {
         if (this.solver.failed) {
           this.emitEvent({
             type: "error",
-            error: new Error(this.solver.error || "Routing failed"),
+            error: new AutorouterError(this.solver.error || "Routing failed"),
           })
         } else {
           this.emitEvent({
@@ -135,7 +136,10 @@ export class CapacityMeshAutorouter implements GenericLocalAutorouter {
       // Handle any errors during the step
       this.emitEvent({
         type: "error",
-        error: error instanceof Error ? error : new Error(String(error)),
+        error:
+          error instanceof Error
+            ? new AutorouterError(error.message)
+            : new AutorouterError(String(error)),
       })
       this.isRouting = false
     }
@@ -206,7 +210,7 @@ export class CapacityMeshAutorouter implements GenericLocalAutorouter {
     this.solver.solve()
 
     if (this.solver.failed) {
-      throw new Error(this.solver.error || "Routing failed")
+      throw new AutorouterError(this.solver.error || "Routing failed")
     }
 
     return this.solver.getOutputSimpleRouteJson().traces || []

--- a/tests/examples/example20-autorouting-error.test.tsx
+++ b/tests/examples/example20-autorouting-error.test.tsx
@@ -42,7 +42,7 @@ test("remote-autorouter-1 with legacy solve endpoint", async () => {
     [
       {
         "error_type": "pcb_autorouting_error",
-        "message": "Failed to compute first trace (failInFirstTrace simulated error)",
+        "message": "Autorouting job failed: {\"message\":\"Failed to compute first trace (failInFirstTrace simulated error)\"} (capacity-autorouter@0.0.71)",
         "pcb_autorouting_error_id": "pcb_autorouting_error_0",
         "pcb_error_id": "job_0",
         "type": "pcb_autorouting_error",


### PR DESCRIPTION
## Summary
- add `AutorouterError` class that reads `@tscircuit/capacity-autorouter` version
- use `AutorouterError` in local and remote autorouting paths
- update failing autorouting snapshot
- simplify package version import

## Testing
- `bun test tests/examples/example20-autorouting-error.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_684e0c3ec168832e8055bbdcb425c62c