### PR TITLE
Fix subcircuit net label lookup

### DIFF
--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -171,16 +171,33 @@ export class Trace
     }
   }
 
+  _resolveNet(selector: string): Net | null {
+    const direct = this.getSubcircuit().selectOne(selector, { type: "net" }) as
+      | Net
+      | null
+    if (direct) return direct
+
+    // Fallback: search all descendants for a net with the same name
+    const match = selector.match(/^net\.(.+)$/)
+    const netName = match ? match[1] : null
+    if (!netName) return null
+
+    const allDescendants = this.root!._getBoard().getDescendants()
+    return (
+      (allDescendants.find(
+        (d) => d.componentName === "Net" && d._parsedProps.name === netName,
+      ) as Net | undefined) || null
+    )
+  }
+
   _findConnectedNets(): {
     nets: Net[]
     netsWithSelectors: Array<{ selector: string; net: Net }>
   } {
-    const netsWithSelectors = this.getTracePathNetSelectors().map(
-      (selector) => ({
-        selector,
-        net: this.getSubcircuit().selectOne(selector, { type: "net" }) as Net,
-      }),
-    )
+    const netsWithSelectors = this.getTracePathNetSelectors().map((selector) => ({
+      selector,
+      net: this._resolveNet(selector) as Net,
+    }))
 
     const undefinedNets = netsWithSelectors.filter((n) => !n.net)
     if (undefinedNets.length > 0) {

--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -172,9 +172,9 @@ export class Trace
   }
 
   _resolveNet(selector: string): Net | null {
-    const direct = this.getSubcircuit().selectOne(selector, { type: "net" }) as
-      | Net
-      | null
+    const direct = this.getSubcircuit().selectOne(selector, {
+      type: "net",
+    }) as Net | null
     if (direct) return direct
 
     // Fallback: search all descendants for a net with the same name
@@ -194,10 +194,12 @@ export class Trace
     nets: Net[]
     netsWithSelectors: Array<{ selector: string; net: Net }>
   } {
-    const netsWithSelectors = this.getTracePathNetSelectors().map((selector) => ({
-      selector,
-      net: this._resolveNet(selector) as Net,
-    }))
+    const netsWithSelectors = this.getTracePathNetSelectors().map(
+      (selector) => ({
+        selector,
+        net: this._resolveNet(selector) as Net,
+      }),
+    )
 
     const undefinedNets = netsWithSelectors.filter((n) => !n.net)
     if (undefinedNets.length > 0) {

--- a/tests/components/normal-components/chip-with-subcircuit-net-label.test.tsx
+++ b/tests/components/normal-components/chip-with-subcircuit-net-label.test.tsx
@@ -2,7 +2,7 @@ import { it, expect } from "bun:test"
 import "lib/register-catalogue"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-it.skip("subcircuit having a net label GND makes the circuit fail to use GND in other part of circuit", async () => {
+it("subcircuit having a net label GND makes the circuit fail to use GND in other part of circuit", async () => {
   const { circuit } = getTestFixture()
 
   circuit.add(


### PR DESCRIPTION
## Summary
- fix trace net selector lookup to search descendant subcircuits
- unskip chip-with-subcircuit-net-label test

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_685134e291648327934c74d541da07bd