### PR TITLE
Fix default chip names

### DIFF
--- a/lib/components/normal-components/Chip.ts
+++ b/lib/components/normal-components/Chip.ts
@@ -1,4 +1,5 @@
 import { chipProps } from "@tscircuit/props"
+import { z } from "zod"
 import type { SchematicPortArrangement } from "circuit-json"
 import { NormalComponent } from "lib/components/base-components/NormalComponent"
 import { underscorifyPinStyles } from "lib/soup/underscorifyPinStyles"
@@ -13,7 +14,16 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
   typeof chipProps,
   PinLabels
 > {
+  static unnamedCounter = 1
   schematicBoxDimensions: SchematicBoxDimensions | null = null
+
+  constructor(props: z.input<typeof chipProps>) {
+    const propsWithName = {
+      name: props?.name ?? `U${Chip.unnamedCounter++}`,
+      ...props,
+    } as z.input<typeof chipProps>
+    super(propsWithName)
+  }
 
   get config() {
     return {

--- a/tests/components/normal-components/chip-default-name.test.tsx
+++ b/tests/components/normal-components/chip-default-name.test.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { Chip } from "lib/components/normal-components/Chip"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("chip renders with default name when none provided", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip footprint="soic8" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const chip = circuit.selectOne("chip") as Chip
+  expect(chip).not.toBeNull()
+  expect(chip.props.name).toBeDefined()
+
+  const errors = circuit
+    .getCircuitJson()
+    .filter((e) => e.type === "source_failed_to_create_component_error")
+  expect(errors.length).toBe(0)
+  expect(chip.pcb_component_id).not.toBeNull()
+  expect(chip.schematic_component_id).not.toBeNull()
+})


### PR DESCRIPTION
## Summary
- ensure `Chip` generates a default name when none provided
- test that chips without a name still render

## Testing
- `bun test tests/components/normal-components/chip-default-name.test.tsx`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68514395ddac8327813a8010a1e6a74b