### PR TITLE
Support array connectsTo for netlabel

### DIFF
--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -863,6 +863,14 @@ export class Trace
         .find((nl: any) => {
           const conn = nl._parsedProps.connection ?? nl._parsedProps.connectsTo
           if (!conn) return false
+          if (Array.isArray(conn)) {
+            return conn.some((selector: string) => {
+              const targetPort = this.getSubcircuit().selectOne(selector, {
+                port: true,
+              }) as Port | null
+              return targetPort === port
+            })
+          }
           const targetPort = this.getSubcircuit().selectOne(conn, {
             port: true,
           }) as Port | null

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tscircuit/layout": "^0.0.28",
     "@tscircuit/log-soup": "^1.0.2",
     "@tscircuit/math-utils": "^0.0.18",
-    "@tscircuit/props": "^0.0.236",
+    "@tscircuit/props": "^0.0.237",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/simple-3d-svg": "^0.0.6",

--- a/tests/components/primitive-components/netlabel-connectsTo-array.test.tsx
+++ b/tests/components/primitive-components/netlabel-connectsTo-array.test.tsx
@@ -1,0 +1,50 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Verify netlabel connectsTo accepts an array of selectors
+
+test("netlabel connectsTo array", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board routingDisabled>
+      <chip
+        name="U1"
+        manufacturerPartNumber="I2C_SENSOR"
+        footprint="soic4"
+        pinLabels={{
+          pin1: "SCL",
+          pin2: "SDA",
+          pin3: "VCC",
+          pin4: "GND",
+        }}
+        schPinArrangement={{
+          leftSide: {
+            direction: "top-to-bottom",
+            pins: ["SCL", "SDA", "VCC", "GND"],
+          },
+        }}
+      />
+      <netlabel
+        schX={-2}
+        schY={0}
+        net="SCL"
+        connectsTo={["U1.SCL", "U1.SDA"]}
+        anchorSide="right"
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const traces = circuit.db.source_trace
+    .list()
+    .map((t) => t.display_name)
+    .sort()
+  expect(traces).toMatchInlineSnapshot(`
+    [
+      "U1.SCL to net.SCL",
+      "U1.SDA to net.SCL",
+    ]
+  `)
+})


### PR DESCRIPTION
## Summary
- update `@tscircuit/props`
- allow `netlabel.connectsTo` to be an array
- add test showing multiple connections

## Testing
- `bun test tests/components/primitive-components/netlabel-connectsTo-array.test.tsx`
- `bun test tests/components/primitive-components/netlabel-connection.test.tsx`
- `bun test tests/components/primitive-components/netlabel.test.tsx`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_6854e22fa688832e9d4df5f8569b70e8