### PR TITLE
Add dynamic refdes to sel, sel<"CUSTOM1" | "CUSTOM2">("U1").CUSTOM1

### DIFF
--- a/lib/sel/sel.ts
+++ b/lib/sel/sel.ts
@@ -143,10 +143,18 @@ type ChipFnSel = <T extends ChipFn<any> | string>(
       : never
 >
 
-export type Sel = ExplicitModuleSel & SelWithoutSubcircuit
+type SelFn = <P extends string>(refdes: string) => Record<P, string>
+
+export type Sel = SelFn & ExplicitModuleSel & SelWithoutSubcircuit
 
 export const sel: Sel = new Proxy(
-  {},
+  (refdes: string) =>
+    new Proxy(
+      {},
+      {
+        get: (_, pin: string) => `.${refdes} > .${pin}`,
+      },
+    ),
   {
     get: (_, prop1: string) => {
       // Create a function that will be our proxy target

--- a/tests/sel/sel2.test.tsx
+++ b/tests/sel/sel2.test.tsx
@@ -86,3 +86,7 @@ test('sel2 - sel.J1<"custompin1">().custompin1 = .J1 > .custompin1', () => {
   // @ts-expect-error
   sel.J1<"custompin1">().doesnotexist
 })
+
+test('sel2 - dynamic refdes sel<"custompin">("SJ1")', () => {
+  expect(sel<"custompin">("SJ1").custompin.toString()).toBe(".SJ1 > .custompin")
+})


### PR DESCRIPTION
## Summary
- allow `sel` to be invoked as a function
- support generic pins for any reference designator
- test dynamic reference designator usage

## Testing
- `bun test tests/sel/sel2.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68556e74ff08832eb485d27ec546d182