### PR TITLE
Add sel.JP for jumper selector, add sel.USBC to chip selector

### DIFF
--- a/lib/sel/sel.ts
+++ b/lib/sel/sel.ts
@@ -80,11 +80,14 @@ type CommonNetNames =
 type TransistorSel = Record<`Q${Nums40}`, Record<TransistorPinNames, string>>
 
 type JumperSel = Record<
-  `J${Nums40}` | `CN${Nums40}`,
+  `J${Nums40}` | `JP${Nums40}` | `CN${Nums40}`,
   Record<PinNumbers100 | CommonPinNames, string> & ChipFnSel
 >
 
-type ChipSel = Record<`U${Nums40}`, Record<CommonPinNames, string> & ChipFnSel>
+type ChipSel = Record<
+  `U${Nums40}` | "USBC",
+  Record<CommonPinNames | PinNumbers100, string> & ChipFnSel
+>
 
 type NetSelFn<N extends string = CommonNetNames> = (<
   N2 extends string,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tscircuit/layout": "^0.0.28",
     "@tscircuit/log-soup": "^1.0.2",
     "@tscircuit/math-utils": "^0.0.18",
-    "@tscircuit/props": "^0.0.237",
+    "@tscircuit/props": "^0.0.238",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/simple-3d-svg": "^0.0.6",


### PR DESCRIPTION
## Summary
- allow `JP` jumpers and constant `USBC` in Sel selectors
- update @tscircuit/props

## Testing
- `bun x tsc --noEmit`
- `bun test tests/sel`

------
https://chatgpt.com/codex/tasks/task_b_685584aed008832e86dc6f6fb235f246