### PR TITLE
Improve port-not-found error details

### DIFF
--- a/tests/components/base-components/shorthand-selector.test.tsx
+++ b/tests/components/base-components/shorthand-selector.test.tsx
@@ -34,6 +34,6 @@ test("shorthand selector errors use original selector", () => {
   )
 
   expect(() => circuit.render()).toThrow(
-    /Could not find port for selector "R1\.3"/,
+    /Component "R1" found, but does not have pin "3"/,
   )
 })

--- a/tests/components/base-components/trace-port-selector-errors.test.tsx
+++ b/tests/components/base-components/trace-port-selector-errors.test.tsx
@@ -1,0 +1,68 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// These tests ensure the detailed error messages for unresolved trace ports
+
+/** Component not found */
+test("error when component is missing", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="10k" footprint="0402" />
+      <trace from="R2.1" to="net.GND" />
+    </board>,
+  )
+
+  expect(() => circuit.render()).toThrow(
+    'Could not find port for selector "R2.1". Component "R2" not found',
+  )
+})
+
+/** Component found but has no ports */
+test("error when component has no ports", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <group name="G1" />
+      <trace from="G1.1" to="net.GND" />
+    </board>,
+  )
+
+  expect(() => circuit.render()).toThrow(
+    'Could not find port for selector "G1.1". Component "G1" found, but does not have pin "1". It has no ports',
+  )
+})
+
+/** Component has only numbered pins and no labels */
+test("error when component has numeric pins only", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <pinheader name="J1" pinCount={2} />
+      <trace from="J1.3" to="net.GND" />
+    </board>,
+  )
+
+  expect(() => circuit.render()).toThrow(
+    'Could not find port for selector "J1.3". Component "J1" found, but does not have pin "3". It has 2 pins and no pinLabels (consider adding pinLabels)',
+  )
+})
+
+/** Component has labeled pins */
+test("error lists available labeled pins", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="10k" footprint="0402" />
+      <trace from="R1.foo" to="net.GND" />
+    </board>,
+  )
+
+  expect(() => circuit.render()).toThrow(
+    /Could not find port for selector "R1\.foo"\. Component "R1" found, but does not have pin "foo"\. It has \[anode, pos, left, pin1, 1, cathode, neg, right, pin2, 2\]/,
+  )
+})


### PR DESCRIPTION
## Summary
- provide clearer messages when a port selector can't resolve a pin
- add tests covering all error scenarios when port lookup fails

## Testing
- `bun test tests/components/base-components/trace-port-selector-errors.test.tsx`
- `bun test tests/components/base-components/shorthand-selector.test.tsx`
- `bun test tests/subcircuits/subcircuit1-isolated-refdes.test.tsx`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68557d1ae0bc832ea727a82bc1a9810f