### PR TITLE
Add subcircuit padding to simple route json

### DIFF
--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -112,6 +112,24 @@ export const getSimpleRouteJsonFromCircuitJson = ({
     }
   }
 
+  if (subcircuit_id) {
+    const group = db.pcb_group.getWhere({ subcircuit_id })
+    if (group) {
+      const groupBounds = {
+        minX: group.center.x - group.width / 2,
+        maxX: group.center.x + group.width / 2,
+        minY: group.center.y - group.height / 2,
+        maxY: group.center.y + group.height / 2,
+      }
+      bounds = {
+        minX: Math.min(bounds.minX, groupBounds.minX),
+        maxX: Math.max(bounds.maxX, groupBounds.maxX),
+        minY: Math.min(bounds.minY, groupBounds.minY),
+        maxY: Math.max(bounds.maxY, groupBounds.maxY),
+      }
+    }
+  }
+
   // Create connections from traces
   const directTraceConnections = db.source_trace
     .list()

--- a/tests/groups/group-simple-route-padding.test.tsx
+++ b/tests/groups/group-simple-route-padding.test.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+
+test("simple route json uses subcircuit padding", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <group name="G1" subcircuit pcbLayout={{ padding: 10 }}>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-2} pcbY={0} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={2} pcbY={0} />
+    </group>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const subcircuitId = circuit.db.source_group.list()[0].subcircuit_id!
+  const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
+    db: circuit.db,
+    subcircuit_id: subcircuitId,
+  })
+  const group = circuit.db.pcb_group.getWhere({ subcircuit_id: subcircuitId })!
+
+  const routeWidth = simpleRouteJson.bounds.maxX - simpleRouteJson.bounds.minX
+  const routeHeight = simpleRouteJson.bounds.maxY - simpleRouteJson.bounds.minY
+
+  expect(routeWidth).toBeCloseTo(group.width, 1)
+  expect(routeHeight).toBeCloseTo(group.height, 1)
+})


### PR DESCRIPTION
## Summary
- expand simple route json bounds by padded pcb group size
- add test checking padding is applied when computing simple route json

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6855a4d3c1648327ad972c41e8f1b920