### PR TITLE
Add SourceGroupRender phase

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,9 +36,7 @@ has a specific purpose.
 For each render phase, every single class instance in the project gets a call
 to the `doInitial*` method for each render phase (if it's defined for the class)
 
-For example, one of the early render phases is `SourceSubcircuitRender`,
-followed by `SourceRender`. `SourceSubcircuitRender` creates subcircuits and
-assigns `subcircuit_id` values while `SourceRender` is where
+For example, one of the first render phases is `SourceRender`. This is where
 `source_*` [circuit json/soup elements](https://github.com/tscircuit/soup) are
 added to the projects output.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,7 +36,9 @@ has a specific purpose.
 For each render phase, every single class instance in the project gets a call
 to the `doInitial*` method for each render phase (if it's defined for the class)
 
-For example, one of the first render phases is `SourceRender`. This is where
+For example, one of the early render phases is `SourceSubcircuitRender`,
+followed by `SourceRender`. `SourceSubcircuitRender` creates subcircuits and
+assigns `subcircuit_id` values while `SourceRender` is where
 `source_*` [circuit json/soup elements](https://github.com/tscircuit/soup) are
 added to the projects output.
 

--- a/docs/RENDER_PHASES.md
+++ b/docs/RENDER_PHASES.md
@@ -10,7 +10,7 @@ The render phases in @tscircuit/core are defined in the `Renderable` class (`Ren
 
 5. CreateTracesFromProps: Creates traces based on the component's properties.
 
-6. SourceSubcircuitRender: Creates the source group for subcircuits and assigns a `subcircuit_id`.
+6. SourceGroupRender: Creates the source group for subcircuits and assigns a `subcircuit_id`.
 
 7. SourceRender: Renders the source component, which is the basic representation of the component.
 

--- a/docs/RENDER_PHASES.md
+++ b/docs/RENDER_PHASES.md
@@ -10,9 +10,11 @@ The render phases in @tscircuit/core are defined in the `Renderable` class (`Ren
 
 5. CreateTracesFromProps: Creates traces based on the component's properties.
 
-6. SourceRender: Renders the source component, which is the basic representation of the component.
+6. SourceSubcircuitRender: Creates the source group for subcircuits and assigns a `subcircuit_id`.
 
-7. SourceParentAttachment: Attaches the source component to its parent.
+7. SourceRender: Renders the source component, which is the basic representation of the component.
+
+8. SourceParentAttachment: Attaches the source component to its parent.
 
 8. PortMatching: Matches ports with their corresponding elements.
 

--- a/lib/components/base-components/Renderable.ts
+++ b/lib/components/base-components/Renderable.ts
@@ -15,7 +15,7 @@ export const orderedRenderPhases = [
   "CreateTracesFromProps",
   "CreateTracesFromNetLabels",
   "CreateTraceHintsFromProps",
-  "SourceSubcircuitRender",
+  "SourceGroupRender",
   "SourceRender",
   "SourceParentAttachment",
   "PortMatching",

--- a/lib/components/base-components/Renderable.ts
+++ b/lib/components/base-components/Renderable.ts
@@ -15,6 +15,7 @@ export const orderedRenderPhases = [
   "CreateTracesFromProps",
   "CreateTracesFromNetLabels",
   "CreateTraceHintsFromProps",
+  "SourceSubcircuitRender",
   "SourceRender",
   "SourceParentAttachment",
   "PortMatching",

--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -51,7 +51,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     }
   }
 
-  doInitialSourceSubcircuitRender() {
+  doInitialSourceGroupRender() {
     const { db } = this.root!
     const source_group = db.source_group.insert({
       name: this._parsedProps.name,

--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -51,7 +51,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     }
   }
 
-  doInitialSourceRender() {
+  doInitialSourceSubcircuitRender() {
     const { db } = this.root!
     const source_group = db.source_group.insert({
       name: this._parsedProps.name,
@@ -62,6 +62,10 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     db.source_group.update(source_group.source_group_id, {
       subcircuit_id: this.subcircuit_id!,
     })
+  }
+
+  doInitialSourceRender() {
+    const { db } = this.root!
 
     for (const child of this.children) {
       db.source_component.update(child.source_component_id!, {

--- a/tests/components/base-components/render-lifecycle-events.test.tsx
+++ b/tests/components/base-components/render-lifecycle-events.test.tsx
@@ -37,6 +37,7 @@ test("render lifecycle events are emitted", () => {
     "PcbFootprintStringRender",
     "InitializePortsFromChildren",
     "CreateNetsFromProps",
+    "SourceSubcircuitRender",
     "SourceRender",
   ] as RenderPhase[]
 

--- a/tests/components/base-components/render-lifecycle-events.test.tsx
+++ b/tests/components/base-components/render-lifecycle-events.test.tsx
@@ -37,7 +37,7 @@ test("render lifecycle events are emitted", () => {
     "PcbFootprintStringRender",
     "InitializePortsFromChildren",
     "CreateNetsFromProps",
-    "SourceSubcircuitRender",
+    "SourceGroupRender",
     "SourceRender",
   ] as RenderPhase[]
 


### PR DESCRIPTION
## Summary
- add new render phase `SourceSubcircuitRender`
- initialise subcircuits in `Group.doInitialSourceSubcircuitRender`
- document the new phase in docs
- verify render lifecycle event test now includes new phase

## Testing
- `bun run format`
- `bun x tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6855b8a9a9a8832793ffdbf3bbc94d8a