### PR TITLE
Respect platform pcbDisabled option

### DIFF
--- a/lib/RootCircuit.ts
+++ b/lib/RootCircuit.ts
@@ -49,6 +49,7 @@ export class RootCircuit {
     this.root = this
     this.platform = platform
     this.projectUrl = projectUrl
+    this.pcbDisabled = platform?.pcbDisabled ?? false
   }
 
   add(componentOrElm: PrimitiveComponent | ReactElement) {

--- a/tests/root-circuit/platform-pcb-disabled.test.tsx
+++ b/tests/root-circuit/platform-pcb-disabled.test.tsx
@@ -1,0 +1,9 @@
+import { test, expect } from "bun:test"
+import { RootCircuit } from "lib/RootCircuit"
+
+// Verify that pcbDisabled is initialized from platform config
+
+test("pcbDisabled is set from platform config", () => {
+  const circuit = new RootCircuit({ platform: { pcbDisabled: true } })
+  expect(circuit.pcbDisabled).toBe(true)
+})


### PR DESCRIPTION
## Summary
- respect `platform.pcbDisabled` in RootCircuit constructor
- add test for `pcbDisabled` platform option

## Testing
- `bun test tests/root-circuit/platform-pcb-disabled.test.tsx`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68579a5fc4a0832ea4525b45f25a818c