### PR TITLE
Add validation for plus/minus in net names

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
+++ b/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
@@ -4,6 +4,11 @@ export const preprocessSelector = (selector: string) => {
       'Net names cannot contain a period, try using "sel.net..." to autocomplete with conventional net names, e.g. V3_3',
     )
   }
+  if (/net\.[^\s>]*[+-]/.test(selector)) {
+    throw new Error(
+      'Net names cannot contain "+" or "-", try using underscores instead, e.g. VCC_P',
+    )
+  }
   if (/net\.[0-9]/.test(selector)) {
     const match = selector.match(/net\.([^ >]+)/)
     const netName = match ? match[1] : ""

--- a/lib/components/primitive-components/Net.ts
+++ b/lib/components/primitive-components/Net.ts
@@ -7,7 +7,12 @@ import type { AnyCircuitElement, SourceTrace } from "circuit-json"
 import { autoroute } from "@tscircuit/infgrid-ijump-astar"
 
 export const netProps = z.object({
-  name: z.string(),
+  name: z
+    .string()
+    .refine(
+      (val) => !/[+-]/.test(val),
+      'Net names cannot contain "+" or "-", try using underscores instead, e.g. VCC_P',
+    ),
 })
 
 export class Net extends PrimitiveComponent<typeof netProps> {

--- a/lib/utils/components/createNetsFromProps.ts
+++ b/lib/utils/components/createNetsFromProps.ts
@@ -12,6 +12,11 @@ export const createNetsFromProps = (
           'Net names cannot contain a period, try using "sel.net..." to autocomplete with conventional net names, e.g. V3_3',
         )
       }
+      if (/net\.[^\s>]*[+-]/.test(prop)) {
+        throw new Error(
+          'Net names cannot contain "+" or "-", try using underscores instead, e.g. VCC_P',
+        )
+      }
       if (/net\.[0-9]/.test(prop)) {
         const netName = prop.split("net.")[1]
         throw new Error(

--- a/tests/sel/net-name-minus.test.ts
+++ b/tests/sel/net-name-minus.test.ts
@@ -1,0 +1,8 @@
+import { preprocessSelector } from "lib/components/base-components/PrimitiveComponent/preprocessSelector"
+import { test, expect } from "bun:test"
+
+test("preprocessSelector - minus sign in net name throws", () => {
+  expect(() => preprocessSelector("net.VCC-")).toThrow(
+    'Net names cannot contain "+" or "-", try using underscores instead, e.g. VCC_P',
+  )
+})

--- a/tests/sel/net-name-plus.test.ts
+++ b/tests/sel/net-name-plus.test.ts
@@ -1,0 +1,8 @@
+import { preprocessSelector } from "lib/components/base-components/PrimitiveComponent/preprocessSelector"
+import { test, expect } from "bun:test"
+
+test("preprocessSelector - plus sign in net name throws", () => {
+  expect(() => preprocessSelector("net.VCC+")).toThrow(
+    'Net names cannot contain "+" or "-", try using underscores instead, e.g. VCC_P',
+  )
+})


### PR DESCRIPTION
## Summary
- forbid `+` or `-` characters in net names
- validate `Net` props against plus/minus
- test errors when a net name contains a plus or minus

## Testing
- `bun test tests/sel`
- `bun test tests/components/primitive-components/net.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_685865976b70832ebf89849d457fc1c4