### PR TITLE
Fix netlabel center positioning

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutMatchAdapt.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutMatchAdapt.ts
@@ -20,6 +20,7 @@ import { getOtherSchematicTraces } from "../Trace/get-other-schematic-traces"
 import { deriveSourceTraceIdFromMatchAdaptPath } from "lib/utils/schematic/deriveSourceTraceIdFromMatchAdaptPath"
 import { cju } from "@tscircuit/circuit-json-util"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { computeSchematicNetLabelCenter } from "lib/utils/schematic/computeSchematicNetLabelCenter"
 
 export function Group_doInitialSchematicLayoutMatchAdapt<
   Props extends z.ZodType<any, any, any>,
@@ -147,7 +148,11 @@ export function Group_doInitialSchematicLayoutMatchAdapt<
       text: nl.netId,
       source_net_id: srcNet?.source_net_id,
       anchor_position: { x: nl.x, y: nl.y },
-      center: { x: nl.x, y: nl.y },
+      center: computeSchematicNetLabelCenter({
+        anchor_position: { x: nl.x, y: nl.y },
+        anchor_side: nl.anchorPosition as any,
+        text: nl.netId,
+      }),
       anchor_side: nl.anchorPosition as any,
     } as any)
   }

--- a/lib/components/primitive-components/NetLabel.ts
+++ b/lib/components/primitive-components/NetLabel.ts
@@ -4,6 +4,7 @@ import { Port } from "./Port"
 import { Trace } from "./Trace/Trace"
 import { Net } from "./Net"
 import { createNetsFromProps } from "lib/utils/components/createNetsFromProps"
+import { computeSchematicNetLabelCenter } from "lib/utils/schematic/computeSchematicNetLabelCenter"
 
 export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
   source_net_label_id?: string
@@ -22,14 +23,19 @@ export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
 
     const anchorPos = { x: props.schX ?? 0, y: props.schY ?? 0 }
 
+    const anchorSide = props.anchorSide ?? "right"
+    const center = computeSchematicNetLabelCenter({
+      anchor_position: anchorPos,
+      anchor_side: anchorSide,
+      text: props.net!,
+    })
+
     const netLabel = db.schematic_net_label.insert({
       text: props.net!,
       source_net_id: props.net!,
       anchor_position: anchorPos,
-
-      // TODO compute the center based on the text size
-      center: anchorPos,
-      anchor_side: props.anchorSide ?? "right",
+      center,
+      anchor_side: anchorSide,
     })
 
     this.source_net_label_id = netLabel.source_net_id

--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -24,6 +24,7 @@ import { pairs } from "lib/utils/pairs"
 import { countComplexElements } from "lib/utils/schematic/countComplexElements"
 import { getEnteringEdgeFromDirection } from "lib/utils/schematic/getEnteringEdgeFromDirection"
 import { getStubEdges } from "lib/utils/schematic/getStubEdges"
+import { computeSchematicNetLabelCenter } from "lib/utils/schematic/computeSchematicNetLabelCenter"
 import { tryNow } from "lib/utils/try-now"
 import { z } from "zod"
 import { PrimitiveComponent } from "../../base-components/PrimitiveComponent"
@@ -801,23 +802,33 @@ export class Trace
     }
 
     if (!existingToNetLabel) {
+      const toSide =
+        getEnteringEdgeFromDirection(toPort.facingDirection!) ?? "bottom"
       db.schematic_net_label.insert({
         text: this.props.schDisplayLabel! ?? pinFullName,
         source_net_id: toPort.source_port_id!,
         anchor_position: toAnchorPos,
-        center: toAnchorPos,
-        anchor_side:
-          getEnteringEdgeFromDirection(toPort.facingDirection!) ?? "bottom",
+        center: computeSchematicNetLabelCenter({
+          anchor_position: toAnchorPos,
+          anchor_side: toSide,
+          text: this.props.schDisplayLabel! ?? pinFullName,
+        }),
+        anchor_side: toSide,
       })
     }
     if (!existingFromNetLabel) {
+      const fromSide =
+        getEnteringEdgeFromDirection(fromPort.facingDirection!) ?? "bottom"
       db.schematic_net_label.insert({
         text: this.props.schDisplayLabel! ?? pinFullName,
         source_net_id: fromPort.source_port_id!,
         anchor_position: fromAnchorPos,
-        center: fromAnchorPos,
-        anchor_side:
-          getEnteringEdgeFromDirection(fromPort.facingDirection!) ?? "bottom",
+        center: computeSchematicNetLabelCenter({
+          anchor_position: fromAnchorPos,
+          anchor_side: fromSide,
+          text: this.props.schDisplayLabel! ?? pinFullName,
+        }),
+        anchor_side: fromSide,
       })
     }
   }
@@ -936,26 +947,35 @@ export class Trace
       }
 
       if (this.props.schDisplayLabel) {
+        const side =
+          getEnteringEdgeFromDirection(port.facingDirection!) ?? "bottom"
         db.schematic_net_label.insert({
           text: this.props.schDisplayLabel,
           source_net_id: net.source_net_id!,
           anchor_position: anchorPos,
-          center: anchorPos,
-          anchor_side:
-            getEnteringEdgeFromDirection(port.facingDirection!) ?? "bottom",
+          center: computeSchematicNetLabelCenter({
+            anchor_position: anchorPos,
+            anchor_side: side,
+            text: this.props.schDisplayLabel,
+          }),
+          anchor_side: side,
         })
 
         return
       }
 
+      const side =
+        getEnteringEdgeFromDirection(port.facingDirection!) ?? "bottom"
       const netLabel = db.schematic_net_label.insert({
         text: net._parsedProps.name,
         source_net_id: net.source_net_id!,
         anchor_position: anchorPos,
-        // TODO compute the center based on the text size
-        center: anchorPos,
-        anchor_side:
-          getEnteringEdgeFromDirection(port.facingDirection!) ?? "bottom",
+        center: computeSchematicNetLabelCenter({
+          anchor_position: anchorPos,
+          anchor_side: side,
+          text: net._parsedProps.name,
+        }),
+        anchor_side: side,
       })
 
       return

--- a/lib/utils/schematic/computeSchematicNetLabelCenter.ts
+++ b/lib/utils/schematic/computeSchematicNetLabelCenter.ts
@@ -1,0 +1,31 @@
+export const computeSchematicNetLabelCenter = ({
+  anchor_position,
+  anchor_side,
+  text,
+  font_size = 0.18,
+}: {
+  anchor_position: { x: number; y: number }
+  anchor_side: "top" | "bottom" | "left" | "right"
+  text: string
+  font_size?: number
+}) => {
+  const charWidth = 0.1 * (font_size / 0.18)
+  const width = text.length * charWidth
+  const height = font_size
+  const center = { ...anchor_position }
+  switch (anchor_side) {
+    case "right":
+      center.x -= width / 2
+      break
+    case "left":
+      center.x += width / 2
+      break
+    case "top":
+      center.y -= height / 2
+      break
+    case "bottom":
+      center.y += height / 2
+      break
+  }
+  return center
+}

--- a/tests/components/primitive-components/netlabel-center.test.tsx
+++ b/tests/components/primitive-components/netlabel-center.test.tsx
@@ -1,0 +1,31 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Verify that net label center is offset based on anchor side
+
+test("netlabel center offset", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board routingDisabled>
+      <resistor schX={4} name="R1" resistance="1k" />
+      <chip
+        name="U1"
+        footprint="soic8"
+        connections={{
+          pin1: "R1.1",
+          pin2: "net.TESTNET",
+          pin6: "R1.2",
+        }}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const labels = circuit.db.schematic_net_label.list()
+  expect(labels).toHaveLength(1)
+  const label = labels[0]
+  expect(label.anchor_side).toBe("right")
+  expect(label.center.x).toBeLessThan(label.anchor_position.x)
+})


### PR DESCRIPTION
## Summary
- compute schematic net label center relative to anchor using named parameters
- apply new helper when generating net labels
- add regression test for net label center offset
- update call sites to use named parameters

## Testing
- `bun test tests/components/primitive-components/netlabel-center.test.tsx`
- `bun test tests/components/primitive-components/netlabel-connection.test.tsx`
- `bun test tests/components/primitive-components/netlabel*test.tsx`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_685c9177aee0832ea3dd7f22206b9042