### PR TITLE
Remove TODO_REMOVE_THIS fallback

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -339,7 +339,7 @@ export class NormalComponent<
       const fpSoup = fp.string(footprint).soup()
       const fpComponents = createComponentsFromCircuitJson(
         {
-          componentName: this.name,
+          componentName: this.name ?? this.componentName,
           componentRotation: pcbRotation,
           footprint,
           pinLabels,

--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -112,11 +112,7 @@ export abstract class PrimitiveComponent<
   }
 
   get name() {
-    return (
-      (this._parsedProps as any).name ??
-      this.fallbackUnassignedName ??
-      "TODO_REMOVE_THIS"
-    )
+    return (this._parsedProps as any).name ?? this.fallbackUnassignedName
   }
 
   /**


### PR DESCRIPTION
## Summary
- remove TODO placeholder from PrimitiveComponent name getter
- ensure NormalComponent footprint generation uses a fallback name

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/repros/repro22-unnamed-component.test.tsx`

------
https://chatgpt.com/codex/tasks/task_b_685ed2bcc484832eaddca1676f960f55