### PR TITLE
Fix schematic text positioning within translated groups

### DIFF
--- a/lib/components/primitive-components/SchematicText.ts
+++ b/lib/components/primitive-components/SchematicText.ts
@@ -18,14 +18,16 @@ export class SchematicText extends PrimitiveComponent<
     const { db } = this.root!
     const { _parsedProps: props } = this
 
+    const globalPos = this._getGlobalSchematicPositionBeforeLayout()
+
     db.schematic_text.insert({
       anchor: props.anchor ?? "center",
       text: props.text,
       font_size: props.fontSize,
       color: props.color || "#000000",
       position: {
-        x: props.schX ?? 0,
-        y: props.schY ?? 0,
+        x: globalPos.x,
+        y: globalPos.y,
       },
       rotation: props.schRotation ?? 0,
     })

--- a/tests/components/primitive-components/schematic-text-group-translation.test.tsx
+++ b/tests/components/primitive-components/schematic-text-group-translation.test.tsx
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Regression test: schematictext global position should include parent group schX/schY
+
+test("schematictext inside translated group has global position offset", () => {
+  const { project } = getTestFixture()
+
+  project.add(
+    <board width="10mm" height="10mm">
+      <group name="G" schX={5} schY={7}>
+        <schematictext text="hello" schX={2} schY={3} />
+      </group>
+    </board>,
+  )
+
+  project.render()
+
+  const texts = project.db.schematic_text.list()
+  expect(texts.length).toBe(1)
+  expect(texts[0].position.x).toBe(7)
+  expect(texts[0].position.y).toBe(10)
+})


### PR DESCRIPTION
## Summary
- remove redundant board-level schematic text translation test
- compute schematic text position using global coordinates
- update group translation regression test

## Testing
- `bun test tests/components/primitive-components/schematic-text-group-translation.test.tsx`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68655f4810248327b2b3ca66521ca457