### PR TITLE
Fix netlabel anchor defaults

### DIFF
--- a/lib/components/primitive-components/NetLabel.ts
+++ b/lib/components/primitive-components/NetLabel.ts
@@ -5,6 +5,12 @@ import { Trace } from "./Trace/Trace"
 import { Net } from "./Net"
 import { createNetsFromProps } from "lib/utils/components/createNetsFromProps"
 import { computeSchematicNetLabelCenter } from "lib/utils/schematic/computeSchematicNetLabelCenter"
+import {
+  applyToPoint,
+  identity,
+  translate,
+  type Matrix,
+} from "transformation-matrix"
 
 export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
   source_net_label_id?: string
@@ -60,6 +66,25 @@ export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
     }
 
     return connectedPorts
+  }
+
+  computeSchematicPropsTransform(): Matrix {
+    const { _parsedProps: props } = this
+
+    if (props.schX === undefined && props.schY === undefined) {
+      const connectedPorts = this._getConnectedPorts()
+      if (connectedPorts.length > 0) {
+        const portPos =
+          connectedPorts[0]._getGlobalSchematicPositionBeforeLayout()
+        const parentCenter = applyToPoint(
+          this.parent?.computeSchematicGlobalTransform?.() ?? identity(),
+          { x: 0, y: 0 },
+        )
+        return translate(portPos.x - parentCenter.x, portPos.y - parentCenter.y)
+      }
+    }
+
+    return super.computeSchematicPropsTransform()
   }
 
   doInitialSchematicPrimitiveRender(): void {

--- a/tests/repros/repro27-netlabel-default-position.test.tsx
+++ b/tests/repros/repro27-netlabel-default-position.test.tsx
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { Port } from "lib/components/primitive-components/Port/Port"
+
+// Reproduction for netlabel default anchor position when connected to a schematic port
+
+test("netlabel defaults anchor to connected port position", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <netlabel net="A" connection="R1.pin1" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const port = circuit.selectOne("resistor.R1 > port.1") as Port
+  const portPos = port._getGlobalSchematicPositionAfterLayout()
+  const label = circuit.db.schematic_net_label.list()[0]
+  expect(label.anchor_position).toEqual(portPos)
+})


### PR DESCRIPTION
## Summary
- default `<netlabel />` position to the connected schematic port when no `schX`/`schY` given
- test netlabel anchor defaults to port position

## Testing
- `bun test tests/repros/repro27-netlabel-default-position.test.tsx`
- `npx tsc --noEmit` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_b_686c47dd8ab4833198d561c9366d0cc0