### PR TITLE
Populate schematic_port.is_connected

### DIFF
--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -413,6 +413,7 @@ export class Port extends PrimitiveComponent<typeof portProps> {
       pin_number: props.pinNumber,
       true_ccw_index: localPortInfo?.trueIndex,
       display_pin_label: bestDisplayPinLabel,
+      is_connected: false,
     })
 
     this.schematic_port_id = schematic_port.schematic_port_id

--- a/lib/components/primitive-components/Trace/Trace_doInitialSchematicTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialSchematicTraceRender.ts
@@ -417,6 +417,12 @@ export const Trace_doInitialSchematicTraceRender = (trace: Trace) => {
   })
   trace.schematic_trace_id = dbTrace.schematic_trace_id
 
+  for (const { port } of connectedPorts) {
+    if (port.schematic_port_id) {
+      db.schematic_port.update(port.schematic_port_id, { is_connected: true })
+    }
+  }
+
   if (board?._connectedSchematicPortPairs)
     board._connectedSchematicPortPairs.add(portPairKey)
 }

--- a/tests/components/normal-components/schematic-port-is-connected.test.tsx
+++ b/tests/components/normal-components/schematic-port-is-connected.test.tsx
@@ -1,0 +1,37 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Ports should start disconnected and become connected after a trace links them
+
+test("schematic_port.is_connected is updated", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="10k" footprint="0402" pcbX={0} pcbY={0} />
+      <trace from=".R1 > .pin1" to=".R1 > .pin2" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const ports = circuit.db.schematic_port.list()
+  expect(ports).toHaveLength(2)
+  expect(ports.every((p) => p.is_connected)).toBe(true)
+})
+
+test("schematic_port.is_connected defaults to false", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="10k" footprint="0402" pcbX={0} pcbY={0} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const ports = circuit.db.schematic_port.list()
+  expect(ports).toHaveLength(2)
+  expect(ports.every((p) => p.is_connected === false)).toBe(true)
+})


### PR DESCRIPTION
## Summary
- default schematic_port.is_connected to `false`
- mark schematic ports as connected when traces are inserted
- add tests covering the new is_connected behavior

## Testing
- `bun test tests/components/normal-components/schematic-port-is-connected.test.tsx`
- `bun test tests/components/normal-components/resistor-schematic.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_6871b009c1a4832e8e7e8ac4835e7162