### PR TITLE
Handle whitespace text nodes in <group>

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -542,10 +542,21 @@ export abstract class PrimitiveComponent<
     // The react reconciler will try to add text nodes as children, but
     // we don't have a text component, so we just ignore them. The text is
     // passed as a prop to the parent component anyway.
-    if (Object.keys(component).length === 0) {
-      if (this.canHaveTextChildren) {
+    const textContent = (component as any).__text
+    if (typeof textContent === "string") {
+      // Components that support text children already receive the text via
+      // their props. Simply ignore the generated text node.
+      if (this.canHaveTextChildren || textContent.trim() === "") {
         return
       }
+      // Otherwise this is likely accidental text in the JSX tree.
+      throw new Error(
+        `Invalid JSX Element: Expected a React component but received text "${textContent}"`,
+      )
+    }
+    if (Object.keys(component).length === 0) {
+      // Ignore empty objects produced by the reconciler in edge cases
+      return
     }
     // Disallow nesting boards inside of boards
     if (

--- a/lib/fiber/create-instance-from-react-element.ts
+++ b/lib/fiber/create-instance-from-react-element.ts
@@ -79,9 +79,13 @@ const hostConfig: HostConfig<
       return createErrorPlaceholderComponent(props, error)
     }
   },
-  createTextInstance() {
-    // We don't need to handle text nodes for this use case
-    return {}
+  createTextInstance(text: string) {
+    // Preserve the raw text so parent components can decide how to handle it.
+    // This allows PrimitiveComponent.add to differentiate between whitespace
+    // (which should be ignored) and meaningful text which should cause an
+    // error. Returning an object mirrors the structure of component instances
+    // created elsewhere in this reconciler.
+    return { __text: text }
   },
   appendInitialChild(parentInstance: any, child: any) {
     parentInstance.add(child)

--- a/tests/repro/group-whitespace.test.tsx
+++ b/tests/repro/group-whitespace.test.tsx
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Reproduce issue: whitespace immediately after <group> tag should be ignored
+
+test("group with whitespace after tag does not crash", () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board>
+      <group>
+        {" "}
+        {/* comment */}
+        <resistor name="R1" footprint="0402" resistance={1000} />
+      </group>
+    </board>,
+  )
+  expect(() => circuit.render()).not.toThrow()
+})


### PR DESCRIPTION
## Summary
- handle text nodes in React reconciler
- ignore whitespace text nodes and still error on real text
- add regression test for whitespace after `<group>` tag

## Testing
- `bun test tests/repro/group-whitespace.test.tsx`
- `bun test tests/components/primitive-components/invalid-jsx.test.tsx`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_687559659d68832ea18101c361f5d204