### PR TITLE
Detect mismatched React versions

### DIFF
--- a/lib/RootCircuit.ts
+++ b/lib/RootCircuit.ts
@@ -60,11 +60,10 @@ export class RootCircuit {
   add(componentOrElm: PrimitiveComponent | ReactElement) {
     let component: PrimitiveComponent
     if (isValidElement(componentOrElm)) {
-      if (componentOrElm.$$typeof !== CURRENT_REACT_ELEMENT_SYMBOL) {
+      const elmType = (componentOrElm as any).$$typeof
+      if (elmType !== CURRENT_REACT_ELEMENT_SYMBOL) {
         const otherVersion =
-          componentOrElm.$$typeof === REACT_TRANSITIONAL_SYMBOL
-            ? "19"
-            : "18 or earlier"
+          elmType === REACT_TRANSITIONAL_SYMBOL ? "19" : "18 or earlier"
         throw new ReactVersionMismatchError(otherVersion)
       }
       // TODO store subtree

--- a/lib/errors/ReactVersionMismatchError.ts
+++ b/lib/errors/ReactVersionMismatchError.ts
@@ -1,0 +1,10 @@
+import { version as reactVersion } from "react"
+
+export class ReactVersionMismatchError extends Error {
+  constructor(otherVersion: string) {
+    super(
+      `Multiple versions of React detected. @tscircuit/core is using React ${reactVersion} but a React ${otherVersion} element was provided. Ensure only one React version is installed.`,
+    )
+    this.name = "ReactVersionMismatchError"
+  }
+}

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,2 +1,3 @@
 export * from "./InvalidProps"
 export * from "./AutorouterError"
+export * from "./ReactVersionMismatchError"

--- a/tests/root-circuit/react-version-mismatch.test.tsx
+++ b/tests/root-circuit/react-version-mismatch.test.tsx
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test"
+import { Circuit } from "lib"
+
+// Construct a fake React element from an older React version
+const foreignElm = {
+  $$typeof: Symbol.for("react.element"),
+  type: "group",
+  key: null,
+  props: {},
+  _owner: null,
+  _store: {},
+} as any
+
+test("throws error when React element version mismatches", () => {
+  const circuit = new Circuit()
+  expect(() => circuit.add(foreignElm)).toThrowError(
+    /Multiple versions of React detected/,
+  )
+})


### PR DESCRIPTION
## Summary
- add `ReactVersionMismatchError` for clearer errors
- check React element compatibility when adding to a circuit
- export new error helper
- test React version mismatch detection

## Testing
- `bun test tests/root-circuit/react-version-mismatch.test.tsx`
- `bun test tests/root-circuit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68783d6a8c80832e8a8a47b328d87746