### PR TITLE
Fix testpoint selector handling

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -754,6 +754,29 @@ export abstract class PrimitiveComponent<
       cssSelectOptionsInsideSubcircuit,
     ) as T | null
 
+    if (options?.port) {
+      if (result && result.componentName !== "Port") {
+        const ports = (result as PrimitiveComponent).selectAll("port")
+        if (ports.length === 1) {
+          result = ports[0] as T
+        }
+      }
+
+      if (!result && !selector.startsWith(".")) {
+        const comp = selectOne(
+          `.${selector}`,
+          this,
+          cssSelectOptionsInsideSubcircuit,
+        ) as PrimitiveComponent | null
+        if (comp) {
+          const ports = comp.selectAll("port")
+          if (ports.length === 1) {
+            result = ports[0] as T
+          }
+        }
+      }
+    }
+
     if (result) {
       this._cachedSelectOneQueries.set(selectorRaw, result as any)
       return result

--- a/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
+++ b/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
@@ -21,9 +21,7 @@ export function Trace__findConnectedPorts(trace: Trace):
 
   const portsWithSelectors = portSelectors.map((selector) => ({
     selector,
-    port:
-      (trace.getSubcircuit().selectOne(selector, { type: "port" }) as Port) ??
-      null,
+    port: (trace.root?.selectOne(selector, { port: true }) as Port) ?? null,
   }))
 
   for (const { selector, port } of portsWithSelectors) {

--- a/lib/sel/sel.ts
+++ b/lib/sel/sel.ts
@@ -126,8 +126,6 @@ export type GenericConnectionsAndSelectorsSel = Record<
         : never
     : never
 >
-type TestPointSel = Record<`TP${Nums40}`, { pin1: string }>
-
 type SelWithoutSubcircuit = NonPolarizedSel &
   PolarizedSel &
   TransistorSel &
@@ -135,7 +133,6 @@ type SelWithoutSubcircuit = NonPolarizedSel &
   ChipSel &
   SwSel &
   NetSel &
-  TestPointSel &
   GenericConnectionsAndSelectorsSel
 
 type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (

--- a/tests/repros/repro31-testpoint-trace-autopin.test.tsx
+++ b/tests/repros/repro31-testpoint-trace-autopin.test.tsx
@@ -1,0 +1,16 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "../fixtures/get-test-fixture"
+
+/** Reproduction for selecting a testpoint by refdes when tracing */
+test("trace connects to testpoint refdes", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <testpoint name="TP1" />
+      <trace from="TP1" to="net.GND" />
+    </board>,
+  )
+
+  expect(() => circuit.render()).not.toThrow()
+})


### PR DESCRIPTION
## Summary
- remove special-case TP selectors
- return single port when selecting with `{port: true}`
- resolve ports from root circuit
- add repro test for testpoint trace selectors

## Testing
- `bun test tests/repros/repro31-testpoint-trace-autopin.test.tsx`
- `bun test tests/sel/sel1.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_687fb99f9840832e9e0b0182c414133a