### PR TITLE
fix: Support externally connected pins with hidden schematic ports

### DIFF
--- a/lib/components/normal-components/Chip.ts
+++ b/lib/components/normal-components/Chip.ts
@@ -8,6 +8,7 @@ import {
   getAllDimensionsForSchematicBox,
 } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
 import { Trace } from "lib/components/primitive-components/Trace/Trace"
+import { Port } from "lib/components/primitive-components/Port"
 
 export class Chip<PinLabels extends string = never> extends NormalComponent<
   typeof chipProps,
@@ -20,6 +21,39 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
       componentName: "Chip",
       zodProps: chipProps,
       shouldRenderAsSchematicBox: true,
+    }
+  }
+
+  initPorts(opts = {}): void {
+    // First, call the parent initPorts to create ports normally
+    super.initPorts(opts)
+    
+    // Then, ensure that any pins referenced in externallyConnectedPins have ports created
+    const { _parsedProps: props } = this
+    if (props.externallyConnectedPins) {
+      const requiredPinNumbers = new Set<number>()
+      
+      // Collect all pin numbers that need ports
+      for (const [pin1, pin2] of props.externallyConnectedPins) {
+        const pin1Num = parseInt(pin1.replace('pin', ''))
+        const pin2Num = parseInt(pin2.replace('pin', ''))
+        if (!isNaN(pin1Num)) requiredPinNumbers.add(pin1Num)
+        if (!isNaN(pin2Num)) requiredPinNumbers.add(pin2Num)
+      }
+      
+      // Create ports for any missing pin numbers
+      for (const pinNumber of requiredPinNumbers) {
+        const existingPort = this.children.find(child => 
+          child instanceof Port && child._parsedProps.pinNumber === pinNumber
+        )
+        
+        if (!existingPort) {
+          this.add(new Port({ 
+            pinNumber,
+            aliases: [`pin${pinNumber}`]
+          }))
+        }
+      }
     }
   }
 

--- a/lib/components/normal-components/Chip.ts
+++ b/lib/components/normal-components/Chip.ts
@@ -27,31 +27,34 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
   initPorts(opts = {}): void {
     // First, call the parent initPorts to create ports normally
     super.initPorts(opts)
-    
+
     // Then, ensure that any pins referenced in externallyConnectedPins have ports created
     const { _parsedProps: props } = this
     if (props.externallyConnectedPins) {
       const requiredPinNumbers = new Set<number>()
-      
+
       // Collect all pin numbers that need ports
       for (const [pin1, pin2] of props.externallyConnectedPins) {
-        const pin1Num = parseInt(pin1.replace('pin', ''))
-        const pin2Num = parseInt(pin2.replace('pin', ''))
+        const pin1Num = parseInt(pin1.replace("pin", ""))
+        const pin2Num = parseInt(pin2.replace("pin", ""))
         if (!isNaN(pin1Num)) requiredPinNumbers.add(pin1Num)
         if (!isNaN(pin2Num)) requiredPinNumbers.add(pin2Num)
       }
-      
+
       // Create ports for any missing pin numbers
       for (const pinNumber of requiredPinNumbers) {
-        const existingPort = this.children.find(child => 
-          child instanceof Port && child._parsedProps.pinNumber === pinNumber
+        const existingPort = this.children.find(
+          (child) =>
+            child instanceof Port && child._parsedProps.pinNumber === pinNumber,
         )
-        
+
         if (!existingPort) {
-          this.add(new Port({ 
-            pinNumber,
-            aliases: [`pin${pinNumber}`]
-          }))
+          this.add(
+            new Port({
+              pinNumber,
+              aliases: [`pin${pinNumber}`],
+            }),
+          )
         }
       }
     }

--- a/lib/components/primitive-components/Trace/Trace_doInitialSchematicTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialSchematicTraceRender.ts
@@ -51,13 +51,15 @@ export const Trace_doInitialSchematicTraceRender = (trace: Trace) => {
   }
   const obstacles = getSchematicObstaclesForTrace(trace)
 
-  // Get port positions for later use
-  const portsWithPosition = connectedPorts.map(({ port }) => ({
-    port,
-    position: port._getGlobalSchematicPositionAfterLayout(),
-    schematic_port_id: port.schematic_port_id ?? undefined,
-    facingDirection: port.facingDirection,
-  }))
+  // Get port positions for later use, filter out ports without schematic representation
+  const portsWithPosition = connectedPorts
+    .filter(({ port }) => port.schematic_port_id !== null)
+    .map(({ port }) => ({
+      port,
+      position: port._getGlobalSchematicPositionAfterLayout(),
+      schematic_port_id: port.schematic_port_id ?? undefined,
+      facingDirection: port.facingDirection,
+    }))
 
   const isPortAndNetConnection =
     portsWithPosition.length === 1 && netsWithSelectors.length === 1

--- a/tests/repros/repro29-externally-connected-pins.test.tsx
+++ b/tests/repros/repro29-externally-connected-pins.test.tsx
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test"
 import { getTestFixture } from "../fixtures/get-test-fixture"
 
-test.skip("chip with externally connected pins repro", async () => {
+test("chip with externally connected pins repro", async () => {
   const { circuit } = getTestFixture()
   const pinLabels = {
     pin1: ["VDDIO", "V3_3"],


### PR DESCRIPTION
Fixes crash when `externallyConnectedPins` references pins not visible in `schPinArrangement`. 

**Problem:** 
- Chip components with `externallyConnectedPins={[["pin12", "pin13"]]}` would crash if pin13 wasn't included in `schPinArrangement` 
- Error: `Can't get schematic port position after layout for "pin13", no schematic_port_id` 

**Root Cause:** 
1. Ports were only created for pins explicitly listed in `schPinArrangement` 
2. Schematic trace rendering assumed all connected ports had schematic representations 

**Solution:** 
1. **Chip.initPorts()**: Ensure all pins referenced in `externallyConnectedPins` have port objects created, even if not visible in schematic 
2. **Trace rendering**: Filter out ports without `schematic_port_id` before attempting to get their positions