### PR TITLE
Improve unsupported component error message

### DIFF
--- a/docs/CREATING_NEW_COMPONENTS.md
+++ b/docs/CREATING_NEW_COMPONENTS.md
@@ -2,6 +2,8 @@
 
 If you got an error like `Unsupported component type (not registered in @tscircuit/core catalogue)`, you'll probably need to create a new component.
 
+Before creating a new component, double-check that it isn't already provided in the core library. You can browse the list of built-in elements at <https://docs.tscircuit.com/category/built-in-elements>.
+
 ## Steps to creating a new component
 
 - Determine if the component is a normal component or a primitive component

--- a/lib/fiber/create-instance-from-react-element.ts
+++ b/lib/fiber/create-instance-from-react-element.ts
@@ -68,7 +68,9 @@ const hostConfig: HostConfig<
         )
       }
       throw new Error(
-        `Unsupported component type (not registered in @tscircuit/core catalogue): "${type}" See CREATING_NEW_COMPONENTS.md`,
+        `Unsupported component type "${type}". No element with this name is registered in the @tscircuit/core catalogue. ` +
+          `Check for typos or see https://docs.tscircuit.com/category/built-in-elements for a list of valid components. ` +
+          `To add your own component, see docs/CREATING_NEW_COMPONENTS.md`,
       )
     }
 

--- a/tests/fiber/unsupported-component-error.test.tsx
+++ b/tests/fiber/unsupported-component-error.test.tsx
@@ -1,0 +1,9 @@
+import { it, expect } from "bun:test"
+import "lib/register-catalogue"
+import { createInstanceFromReactElement } from "lib/fiber/create-instance-from-react-element"
+
+it("throws a helpful error for unknown components", () => {
+  expect(() => createInstanceFromReactElement(<header />)).toThrow(
+    /built-in-elements/,
+  )
+})


### PR DESCRIPTION
## Summary
- enhance unsupported component error with link to docs and hints
- guide users to built-in component docs in CREATING_NEW_COMPONENTS.md
- test error output when an unknown component is used

## Testing
- `bun test tests/fiber/unsupported-component-error.test.tsx`

------
https://chatgpt.com/codex/tasks/task_b_6881c10f3b30832eb100d66caff4397b