### PR TITLE
Fix jumper to resistor trace angles

### DIFF
--- a/lib/components/primitive-components/Trace/Trace_doInitialSchematicTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialSchematicTraceRender.ts
@@ -1,6 +1,7 @@
 import { MultilayerIjump } from "@tscircuit/infgrid-ijump-astar"
 import { type SchematicNetLabel, type SchematicTrace } from "circuit-json"
 import { calculateElbow } from "calculate-elbow"
+import { patchElbowInsideAngles } from "lib/utils/schematic/patchElbowInsideAngles"
 import { doesLineIntersectLine, type Point } from "@tscircuit/math-utils"
 import { DirectLineRouter } from "lib/utils/autorouting/DirectLineRouter"
 import type {
@@ -177,7 +178,20 @@ export const Trace_doInitialSchematicTraceRender = (trace: Trace) => {
     for (let i = 0; i < portsWithPosition.length - 1; i++) {
       const start = portsWithPosition[i]
       const end = portsWithPosition[i + 1]
-      const path = calculateElbow(
+      let path = calculateElbow(
+        {
+          x: start.position.x,
+          y: start.position.y,
+          facingDirection: start.facingDirection as any,
+        },
+        {
+          x: end.position.x,
+          y: end.position.y,
+          facingDirection: end.facingDirection as any,
+        },
+      )
+      path = patchElbowInsideAngles(
+        path,
         {
           x: start.position.x,
           y: start.position.y,

--- a/lib/utils/schematic/patchElbowInsideAngles.ts
+++ b/lib/utils/schematic/patchElbowInsideAngles.ts
@@ -1,0 +1,61 @@
+export interface ElbowPoint {
+  x: number
+  y: number
+  facingDirection?: "x+" | "x-" | "y+" | "y-"
+}
+
+export const patchElbowInsideAngles = (
+  path: Array<{ x: number; y: number }>,
+  start: ElbowPoint,
+  end: ElbowPoint,
+): Array<{ x: number; y: number }> => {
+  if (
+    start.facingDirection === "x+" &&
+    end.facingDirection === "y+" &&
+    start.x < end.x &&
+    start.y > end.y
+  ) {
+    return [
+      { x: start.x, y: start.y },
+      { x: start.x, y: end.y },
+      { x: end.x, y: end.y },
+    ]
+  }
+  if (
+    start.facingDirection === "x-" &&
+    end.facingDirection === "y+" &&
+    start.x > end.x &&
+    start.y > end.y
+  ) {
+    return [
+      { x: start.x, y: start.y },
+      { x: start.x, y: end.y },
+      { x: end.x, y: end.y },
+    ]
+  }
+  if (
+    start.facingDirection === "x+" &&
+    end.facingDirection === "y-" &&
+    start.x < end.x &&
+    start.y < end.y
+  ) {
+    return [
+      { x: start.x, y: start.y },
+      { x: start.x, y: end.y },
+      { x: end.x, y: end.y },
+    ]
+  }
+  if (
+    start.facingDirection === "x-" &&
+    end.facingDirection === "y-" &&
+    start.x > end.x &&
+    start.y < end.y
+  ) {
+    return [
+      { x: start.x, y: start.y },
+      { x: start.x, y: end.y },
+      { x: end.x, y: end.y },
+    ]
+  }
+  return path
+}


### PR DESCRIPTION
## Summary
- tweak elbow calculation to avoid outside angles when a jumper connects to resistors
- apply patched elbow route in Trace rendering

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_6882e63d6f608331bf29e2c94e65698b