### PR TITLE
Support board layers in routing

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -33,8 +33,15 @@ export class Board extends Group<typeof boardProps> {
    * Get all available layers for the board
    */
   get allLayers() {
-    // TODO use the board numLayers prop
-    return ["top", "bottom", "inner1", "inner2"]
+    const layerCount = this._parsedProps.layers ?? 2
+    if (layerCount === 4) {
+      return ["top", "bottom", "inner1", "inner2"] as const
+    }
+    return ["top", "bottom"] as const
+  }
+
+  _getSubcircuitLayerCount(): number {
+    return this._parsedProps.layers ?? 2
   }
 
   doInitialPcbBoardAutoSize(): void {

--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -928,6 +928,11 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       this._parsedProps.autorouter || this.getInheritedProperty("autorouter")
     return getPresetAutoroutingConfig(autorouter)
   }
+
+  _getSubcircuitLayerCount(): number {
+    const layers = this.getInheritedProperty("layers")
+    return typeof layers === "number" ? layers : 2
+  }
   /**
    * Trace-by-trace autorouting is where each trace routes itself in a well-known
    * order. It's the most deterministic way to autoroute, because a new trace

--- a/lib/components/primitive-components/Group/ISubcircuit.ts
+++ b/lib/components/primitive-components/Group/ISubcircuit.ts
@@ -6,5 +6,6 @@ export interface ISubcircuit extends PrimitiveComponent {
   _shouldUseTraceByTraceRouting(): boolean
   _parsedProps: z.infer<typeof subcircuitGroupProps>
   _getAutorouterConfig(): AutorouterConfig
+  _getSubcircuitLayerCount(): number
   subcircuit_id: string | null
 }

--- a/lib/components/primitive-components/Trace/Trace_doInitialPcbTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialPcbTraceRender.ts
@@ -291,7 +291,7 @@ export function Trace_doInitialPcbTraceRender(trace: Trace) {
             ],
           },
         ],
-        layerCount: 2,
+        layerCount: trace.getSubcircuit()._getSubcircuitLayerCount(),
         bounds: {
           minX: Math.min(a.x, b.x) - BOUNDS_MARGIN,
           maxX: Math.max(a.x, b.x) + BOUNDS_MARGIN,

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -343,7 +343,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
       connections: allConns,
       // TODO add traces so that we don't run into things routed by another
       // subcircuit
-      layerCount: 2,
+      layerCount: board?.num_layers ?? 2,
       minTraceWidth,
     },
     connMap,


### PR DESCRIPTION
## Summary
- expose `_getSubcircuitLayerCount` on subcircuits
- use board `layers` prop to determine available layers
- include subcircuit layer count when autorouting traces
- return board layer count from `getSimpleRouteJsonFromCircuitJson`

## Testing
- `bun test tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter1.test.ts`
- `bun test tests/groups/group-simple-route-padding.test.tsx`
- `bun test tests/components/primitive-components/trace-schematic-obstacles-1.test.tsx`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_68839f404874832ea63f090f9cdc0fa8