### PR TITLE
Support new pcb layout props

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -786,10 +786,14 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     if (props.pcbLayout?.flex) return "flex"
     if (props.pcbLayout?.grid) return "grid"
     if (props.pcbLayout?.pack) return "pack"
+
+    if (props.pcbFlex) return "flex"
+    if (props.pcbGrid) return "grid"
+    if (props.pack) return "pack"
     if (props.matchAdapt) return "match-adapt"
+
     if (props.flex) return "flex"
     if (props.grid) return "grid"
-    if (props.pack) return "pack"
     return "none"
   }
 

--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutFlex.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutFlex.ts
@@ -15,15 +15,23 @@ export const Group_doInitialPcbLayoutFlex = (group: Group) => {
           source_group_id: group.source_group_id!,
         })
 
+  const justify = props.pcbJustifyContent ?? props.justifyContent
+  const align = props.pcbAlignItems ?? props.alignItems
   const modifiedCircuitJson = layoutCircuitJsonWithFlex(circuitJson, {
     justifyContent:
-      props.justifyContent === "start"
+      justify === "start"
         ? "flex-start"
-        : props.justifyContent === "end"
+        : justify === "end"
           ? "flex-end"
-          : props.justifyContent === "stretch"
+          : justify === "stretch"
             ? "space-between"
-            : props.justifyContent,
+            : justify,
+    alignItems:
+      align === "start"
+        ? "flex-start"
+        : align === "end"
+          ? "flex-end"
+          : (align ?? "center"),
   })
 
   const pcbSmtPads = db.pcb_smtpad.list()

--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutGrid.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutGrid.ts
@@ -37,9 +37,9 @@ export function Group_doInitialPcbLayoutGrid(group: Group<any>) {
   if (maxCellWidth === 0 && pcbChildren.length > 0) maxCellWidth = 1
   if (maxCellHeight === 0 && pcbChildren.length > 0) maxCellHeight = 1
 
-  let gridColsOption = props.gridCols
-  let gridRowsOption: number | undefined = undefined
-  let gridGapOption = props.gridGap
+  let gridColsOption = props.pcbGridCols ?? props.gridCols
+  let gridRowsOption: number | undefined = props.pcbGridRows
+  let gridGapOption = props.pcbGridGap ?? props.gridGap
 
   if (props.pcbLayout?.grid) {
     gridColsOption = props.pcbLayout.grid.cols ?? gridColsOption

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tscircuit/infgrid-ijump-astar": "^0.0.33",
     "@tscircuit/log-soup": "^1.0.2",
     "@tscircuit/math-utils": "^0.0.18",
-    "@tscircuit/props": "^0.0.268",
+    "@tscircuit/props": "^0.0.271",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-corpus": "^0.0.52",
     "@tscircuit/schematic-match-adapt": "^0.0.16",

--- a/tests/group.test.ts
+++ b/tests/group.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test"
+import { baseGroupProps, type BaseGroupProps } from "@tscircuit/props"
+
+test("should parse pcb layout props", () => {
+  const raw: BaseGroupProps = {
+    name: "g",
+    pcbGrid: true,
+    pcbGridCols: 2,
+    pcbGridGap: "1mm",
+    pcbFlex: true,
+    pcbGap: "2mm",
+  }
+  const parsed = baseGroupProps.parse(raw)
+  expect(parsed.pcbGrid).toBe(true)
+  expect(parsed.pcbGridCols).toBe(2)
+  expect(parsed.pcbGridGap).toBe("1mm")
+  expect(parsed.pcbFlex).toBe(true)
+  expect(parsed.pcbGap).toBe("2mm")
+})


### PR DESCRIPTION
## Summary
- update @tscircuit/props dependency
- adjust pcb layout grid/flex logic for new prop names
- test parsing of pcb layout props

## Testing
- `bun test tests/group.test.ts tests/groups`

------
https://chatgpt.com/codex/tasks/task_b_6886ba1f6d54832e82d9b661c395560a