### PR TITLE
Add support for new group layout props

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -789,6 +789,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
 
     if (props.pcbFlex) return "flex"
     if (props.pcbGrid) return "grid"
+    if (props.pcbPack) return "pack"
     if (props.pack) return "pack"
     if (props.matchAdapt) return "match-adapt"
 

--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutGrid.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutGrid.ts
@@ -40,11 +40,15 @@ export function Group_doInitialPcbLayoutGrid(group: Group<any>) {
   let gridColsOption = props.pcbGridCols ?? props.gridCols
   let gridRowsOption: number | undefined = props.pcbGridRows
   let gridGapOption = props.pcbGridGap ?? props.gridGap
+  let gridRowGapOption = props.pcbGridRowGap ?? props.gridRowGap
+  let gridColumnGapOption = props.pcbGridColumnGap ?? props.gridColumnGap
 
   if (props.pcbLayout?.grid) {
     gridColsOption = props.pcbLayout.grid.cols ?? gridColsOption
     gridRowsOption = props.pcbLayout.grid.rows
     gridGapOption = props.pcbLayout.gridGap ?? gridGapOption
+    gridRowGapOption = props.pcbLayout.gridRowGap ?? gridRowGapOption
+    gridColumnGapOption = props.pcbLayout.gridColumnGap ?? gridColumnGapOption
   }
 
   let numCols: number
@@ -69,7 +73,25 @@ export function Group_doInitialPcbLayoutGrid(group: Group<any>) {
 
   let gridGapX: number
   let gridGapY: number
-  if (typeof gridGapOption === "number") {
+
+  const parseGap = (val: number | string | undefined): number | undefined => {
+    if (val === undefined) return undefined
+    return typeof val === "number" ? val : length.parse(val)
+  }
+
+  if (gridRowGapOption !== undefined || gridColumnGapOption !== undefined) {
+    const fallbackX =
+      typeof gridGapOption === "object" && gridGapOption !== null
+        ? (gridGapOption as any).x
+        : gridGapOption
+    const fallbackY =
+      typeof gridGapOption === "object" && gridGapOption !== null
+        ? (gridGapOption as any).y
+        : gridGapOption
+
+    gridGapX = parseGap(gridColumnGapOption ?? fallbackX) ?? 1
+    gridGapY = parseGap(gridRowGapOption ?? fallbackY) ?? 1
+  } else if (typeof gridGapOption === "number") {
     gridGapX = gridGapOption
     gridGapY = gridGapOption
   } else if (typeof gridGapOption === "string") {

--- a/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutGrid.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutGrid.ts
@@ -32,11 +32,15 @@ export function Group_doInitialSchematicLayoutGrid(group: Group<any>) {
   let gridColsOption = props.gridCols
   let gridRowsOption: number | undefined = undefined // Not directly supported by old props, but can be via schLayout
   let gridGapOption = props.gridGap
+  let gridRowGapOption = props.gridRowGap
+  let gridColumnGapOption = props.gridColumnGap
 
   if (props.schLayout?.grid) {
     gridColsOption = props.schLayout.grid.cols ?? gridColsOption
     gridRowsOption = props.schLayout.grid.rows // New option from schLayout
     gridGapOption = props.schLayout.gridGap ?? gridGapOption
+    gridRowGapOption = props.schLayout.gridRowGap ?? gridRowGapOption
+    gridColumnGapOption = props.schLayout.gridColumnGap ?? gridColumnGapOption
   }
 
   let numCols: number
@@ -63,7 +67,25 @@ export function Group_doInitialSchematicLayoutGrid(group: Group<any>) {
 
   let gridGapX: number
   let gridGapY: number
-  if (typeof gridGapOption === "number") {
+
+  const parseGap = (val: number | string | undefined): number | undefined => {
+    if (val === undefined) return undefined
+    return typeof val === "number" ? val : length.parse(val)
+  }
+
+  if (gridRowGapOption !== undefined || gridColumnGapOption !== undefined) {
+    const fallbackX =
+      typeof gridGapOption === "object" && gridGapOption !== null
+        ? (gridGapOption as any).x
+        : gridGapOption
+    const fallbackY =
+      typeof gridGapOption === "object" && gridGapOption !== null
+        ? (gridGapOption as any).y
+        : gridGapOption
+
+    gridGapX = parseGap(gridColumnGapOption ?? fallbackX) ?? 1
+    gridGapY = parseGap(gridRowGapOption ?? fallbackY) ?? 1
+  } else if (typeof gridGapOption === "number") {
     gridGapX = gridGapOption
     gridGapY = gridGapOption
   } else if (typeof gridGapOption === "string") {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@tscircuit/infgrid-ijump-astar": "^0.0.33",
     "@tscircuit/log-soup": "^1.0.2",
     "@tscircuit/math-utils": "^0.0.18",
-    "@tscircuit/props": "^0.0.274",
+    "@tscircuit/props": "^0.0.275",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-corpus": "^0.0.110",
     "@tscircuit/schematic-match-adapt": "^0.0.16",


### PR DESCRIPTION
## Summary
- update @tscircuit/props to latest
- expose pcbPack in PCB layout mode selection
- support pcbGridRowGap/gridRowGap and pcbGridColumnGap/gridColumnGap
- test parsing of the new props
- remove group-props.test which belonged to another repo

## Testing
- `bun test tests/components/normal-components/board-grid-layout.test.tsx`
- `bun test tests/features/pcb-pack-layout`


------
https://chatgpt.com/codex/tasks/task_b_688a5f116130832eb978ce3a7aaeb061