### PR TITLE
Improve pin label error message

### DIFF
--- a/lib/errors/InvalidProps.ts
+++ b/lib/errors/InvalidProps.ts
@@ -10,8 +10,34 @@ export class InvalidProps extends Error {
     const propsWithError = Object.keys(formattedError).filter(
       (k) => k !== "_errors",
     )
+
+    const invalidPinLabelMessages: string[] = []
+    const pinLabels = originalProps.pinLabels as
+      | Record<string, string | string[]>
+      | undefined
+    if (pinLabels) {
+      for (const [pin, labelOrLabels] of Object.entries(pinLabels)) {
+        const labels = Array.isArray(labelOrLabels)
+          ? labelOrLabels
+          : [labelOrLabels]
+        for (const label of labels) {
+          if (
+            typeof label === "string" &&
+            (label.startsWith(" ") || label.endsWith(" "))
+          ) {
+            invalidPinLabelMessages.push(
+              `pinLabels.${pin} ("${label}" has leading or trailing spaces)`,
+            )
+          }
+        }
+      }
+    }
+
     const propMessage = propsWithError
       .map((k) => {
+        if (k === "pinLabels" && invalidPinLabelMessages.length > 0) {
+          return invalidPinLabelMessages.join(", ")
+        }
         if ((formattedError as any)[k]._errors[0]) {
           return `${k} (${(formattedError as any)[k]._errors[0]})`
         }

--- a/tests/repro/chip-pinlabel-leading-space.test.tsx
+++ b/tests/repro/chip-pinlabel-leading-space.test.tsx
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Reproduce issue with pin label containing trailing space
+
+test("chip pinLabels should not allow leading or trailing spaces", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip name="U1" pinLabels={{ pin1: ["A1 "] }} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const errors = circuit
+    .getCircuitJson()
+    .filter((e) => e.type === "source_failed_to_create_component_error")
+
+  expect(errors[0].message).toMatch(
+    /pinLabels\.pin1 \("A1 " has leading or trailing spaces\)/,
+  )
+})


### PR DESCRIPTION
## Summary
- handle pinLabels with leading/trailing spaces in InvalidProps
- add regression test for chip pinLabels with spaces

## Testing
- `bun run build`
- `bunx tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_688b72b123648327886a31a675bd62ce