### PR TITLE
Handle netless netlabel gracefully

### DIFF
--- a/lib/components/primitive-components/NetLabel.ts
+++ b/lib/components/primitive-components/NetLabel.ts
@@ -94,23 +94,25 @@ export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
 
     const anchorPos = this._getGlobalSchematicPositionBeforeLayout()
 
-    const net = this.getSubcircuit()!.selectOne(
-      `net.${this._getNetName()!}`,
-    )! as Net
+    const netName = props.net
+    const net = netName
+      ? (this.getSubcircuit()!.selectOne(`net.${netName}`) as Net)
+      : undefined
 
     const anchorSide = props.anchorSide ?? "right"
+    const text = netName ?? "<empty>"
     const center = computeSchematicNetLabelCenter({
       anchor_position: anchorPos,
       anchor_side: anchorSide,
-      text: props.net!,
+      text,
     })
 
     const netLabel = db.schematic_net_label.insert({
-      text: props.net!,
-      source_net_id: net.source_net_id!,
+      text,
       anchor_position: anchorPos,
       center,
       anchor_side: this._getAnchorSide(),
+      ...(net ? { source_net_id: net.source_net_id! } : {}),
     })
 
     this.source_net_label_id = netLabel.source_net_id

--- a/tests/repros/repro33-netlabel-empty.test.tsx
+++ b/tests/repros/repro33-netlabel-empty.test.tsx
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("netlabel without net renders empty text", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      {/* netlabel without net or connectsTo should render with <empty> text */}
+      <netlabel name="hi" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const labels = circuit.db.schematic_net_label.list()
+  expect(labels).toHaveLength(1)
+  expect(labels[0].text).toBe("<empty>")
+})


### PR DESCRIPTION
## Summary
- Allow netlabel to render when no `net` or `connectsTo` is provided by defaulting label text to `<empty>`
- Add regression test ensuring netless netlabel no longer throws

## Testing
- `bun test tests/repros/repro33-netlabel-empty.test.tsx tests/components/primitive-components/netlabel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_6896411fff20832eaa98c284a710889f