### PR TITLE
chore: remove circuit-json-flex dependency

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutFlex.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutFlex.ts
@@ -1,14 +1,13 @@
 import type { Group } from "./Group"
-import { layoutCircuitJsonWithFlex } from "@tscircuit/circuit-json-flex"
 import type { PcbSmtPad, PcbSilkscreenText, Size } from "circuit-json"
 import {
   getCircuitJsonTree,
   repositionPcbComponentTo,
   repositionPcbGroupTo,
+  getMinimumFlexContainer,
   type CircuitJsonUtilObjects,
 } from "@tscircuit/circuit-json-util"
 import { RootFlexBox, type Align, type Justify } from "@tscircuit/miniflex"
-import { getMinimumFlexContainer } from "@tscircuit/circuit-json-flex"
 import { length } from "circuit-json"
 
 type TreeNode = ReturnType<typeof getCircuitJsonTree>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@biomejs/biome": "^1.8.3",
     "@tscircuit/capacity-autorouter": "^0.0.100",
     "@tscircuit/checks": "^0.0.64",
-    "@tscircuit/circuit-json-util": "^0.0.63",
+    "@tscircuit/circuit-json-util": "^0.0.64",
     "@tscircuit/footprinter": "^0.0.208",
     "@tscircuit/import-snippet": "^0.0.4",
     "@tscircuit/infgrid-ijump-astar": "^0.0.33",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@biomejs/biome": "^1.8.3",
     "@tscircuit/capacity-autorouter": "^0.0.100",
     "@tscircuit/checks": "^0.0.64",
-    "@tscircuit/circuit-json-util": "^0.0.62",
+    "@tscircuit/circuit-json-util": "^0.0.63",
     "@tscircuit/footprinter": "^0.0.208",
     "@tscircuit/import-snippet": "^0.0.4",
     "@tscircuit/infgrid-ijump-astar": "^0.0.33",
@@ -63,7 +63,6 @@
     "react-dom": "^19.1.0",
     "schematic-symbols": "^0.0.180",
     "ts-expect": "^1.3.0",
-    "@tscircuit/circuit-json-flex": "^0.0.3",
     "tsup": "^8.2.4"
   },
   "peerDependencies": {
@@ -76,7 +75,6 @@
     "@tscircuit/props": "*",
     "@tscircuit/schematic-autolayout": "*",
     "@tscircuit/schematic-match-adapt": "*",
-    "@tscircuit/circuit-json-flex": "*",
     "@tscircuit/schematic-corpus": "*",
     "circuit-json-to-bpc": "*",
     "bpc-graph": "*",


### PR DESCRIPTION
## Summary
- remove `@tscircuit/circuit-json-flex` usage and dependency
- bump `@tscircuit/circuit-json-util` to latest and use its `getMinimumFlexContainer`

## Testing
- `bun run build`
- `CI=1 bun test`

------
https://chatgpt.com/codex/tasks/task_b_68976aea49948327bb863247cce67381