### PR TITLE
fix autorouter preset config server override

### DIFF
--- a/lib/utils/autorouting/getPresetAutoroutingConfig.ts
+++ b/lib/utils/autorouting/getPresetAutoroutingConfig.ts
@@ -26,6 +26,9 @@ export function getPresetAutoroutingConfig(
       ? autorouterConfig.preset
       : autorouterConfig
 
+  const providedConfig =
+    typeof autorouterConfig === "object" ? autorouterConfig : {}
+
   switch (preset) {
     case "auto-local":
       return {
@@ -42,14 +45,20 @@ export function getPresetAutoroutingConfig(
         local: true,
         groupMode: "subcircuit",
       }
-    case "auto-cloud":
+    case "auto-cloud": {
+      const {
+        preset: _preset,
+        local: _local,
+        groupMode: _groupMode,
+        ...rest
+      } = providedConfig
       return {
         local: false,
         groupMode: "subcircuit",
-        serverUrl: defaults.serverUrl,
-        serverMode: defaults.serverMode,
-        serverCacheEnabled: true,
+        ...defaults,
+        ...rest,
       }
+    }
     default:
       return {
         local: true,


### PR DESCRIPTION
## Summary
- allow overriding server URL in `auto-cloud` preset via `autorouter` config

## Testing
- `bun test tests/features/remote-autorouting-7-preset-config.test.tsx`
- `bun test tests/features/remote-autorouting-*.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_689ac1c023f0832eb0b4589a1f0ff179