### PR TITLE
throw when source trace lacks pcb trace

### DIFF
--- a/lib/components/primitive-components/Trace/Trace_doInitialPcbTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialPcbTraceRender.ts
@@ -1,4 +1,3 @@
-import type { Trace } from "./Trace"
 import { MultilayerIjump } from "@tscircuit/infgrid-ijump-astar"
 import { type LayerRef, type PcbTrace, type RouteHintPoint } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
@@ -6,12 +5,13 @@ import type { SimplifiedPcbTrace } from "lib/utils/autorouting/SimpleRouteJson"
 import { findPossibleTraceLayerCombinations } from "lib/utils/autorouting/findPossibleTraceLayerCombinations"
 import { mergeRoutes } from "lib/utils/autorouting/mergeRoutes"
 import { getClosest } from "lib/utils/getClosest"
+import { getObstaclesFromCircuitJson } from "lib/utils/obstacles/getObstaclesFromCircuitJson"
 import { pairs } from "lib/utils/pairs"
 import { tryNow } from "lib/utils/try-now"
 import type { Port } from "../Port"
 import type { TraceHint } from "../TraceHint"
+import type { Trace } from "./Trace"
 import { getTraceLength } from "./trace-utils/compute-trace-length"
-import { getObstaclesFromCircuitJson } from "lib/utils/obstacles/getObstaclesFromCircuitJson"
 
 type PcbRouteObjective =
   | RouteHintPoint
@@ -205,7 +205,12 @@ export function Trace_doInitialPcbTraceRender(trace: Trace) {
   // Cache the PCB obstacles, they'll be needed for each segment between
   // ports/hints
   const [obstacles, errGettingObstacles] = tryNow(
-    () => getObstaclesFromCircuitJson(trace.root!.db.toArray() as any), // Remove as any when autorouting-dataset gets updated
+    () =>
+      getObstaclesFromCircuitJson(
+        trace
+          .root!.db.toArray()
+          .filter((e) => e.type !== "source_trace") as any,
+      ), // Remove as any when autorouting-dataset gets updated
   )
 
   if (errGettingObstacles) {

--- a/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
+++ b/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
@@ -1,12 +1,12 @@
-import { getObstaclesFromRoute } from "./getObstaclesFromRoute"
-import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type { AnyCircuitElement } from "circuit-json"
-import {
-  generateApproximatingRects,
-  type RotatedRect,
-} from "./generateApproximatingRects"
-import { fillPolygonWithRects } from "./fillPolygonWithRects"
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import { fillCircleWithRects } from "./fillCircleWithRects"
+import { fillPolygonWithRects } from "./fillPolygonWithRects"
+import {
+  type RotatedRect,
+  generateApproximatingRects,
+} from "./generateApproximatingRects"
+import { getObstaclesFromRoute } from "./getObstaclesFromRoute"
 import type { Obstacle } from "./types"
 
 const EVERY_LAYER = ["top", "inner1", "inner2", "bottom"]
@@ -22,6 +22,23 @@ export const getObstaclesFromCircuitJson = (
         )
       : idList
   const obstacles: Obstacle[] = []
+
+  const sourceTraceIds = new Set(
+    soup
+      .filter((e) => e.type === "source_trace")
+      .map((e) => (e as any).source_trace_id),
+  )
+  const pcbTraceSourceIds = new Set(
+    soup
+      .filter((e) => e.type === "pcb_trace" && (e as any).source_trace_id)
+      .map((e) => (e as any).source_trace_id as string),
+  )
+
+  for (const id of sourceTraceIds) {
+    if (!pcbTraceSourceIds.has(id)) {
+      throw new Error(`Missing pcb_trace for source_trace ${id}`)
+    }
+  }
   for (const element of soup) {
     if (element.type === "pcb_smtpad") {
       if (element.shape === "circle") {

--- a/tests/utils/obstacles/source-trace-missing-pcb-trace.test.ts
+++ b/tests/utils/obstacles/source-trace-missing-pcb-trace.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { getObstaclesFromCircuitJson } from "lib/utils/obstacles/getObstaclesFromCircuitJson"
+
+test("throws when source_trace lacks matching pcb_trace", () => {
+  const soup = [
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: [],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  expect(() => getObstaclesFromCircuitJson(soup)).toThrow()
+})


### PR DESCRIPTION
## Summary
- ensure `getObstaclesFromCircuitJson` throws if a source_trace has no matching pcb_trace
- exclude source traces when generating obstacles during trace rendering
- add regression test for missing pcb_trace on source_trace

## Testing
- `bunx biome check lib/utils/obstacles/getObstaclesFromCircuitJson.ts lib/components/primitive-components/Trace/Trace_doInitialPcbTraceRender.ts tests/utils/obstacles/source-trace-missing-pcb-trace.test.ts`
- `bun test tests/utils/obstacles/source-trace-missing-pcb-trace.test.ts tests/components/primitive-components/cutout-obstacles.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_689caacc0e58832c9d36f71453871320