### PR TITLE
feat: handle worker origin in getClientOrigin

### DIFF
--- a/lib/RootCircuit.ts
+++ b/lib/RootCircuit.ts
@@ -239,11 +239,11 @@ export class RootCircuit {
     )
   }
   getClientOrigin(): string {
-    if (typeof window !== "undefined") {
+    if (typeof window !== "undefined" && window.location) {
       return window.location.origin
     }
-    if (typeof self !== "undefined") {
-      return self.origin
+    if (typeof self !== "undefined" && (self as any).location) {
+      return (self as any).location.origin
     }
     return ""
   }

--- a/tests/root-circuit/get-client-origin.test.ts
+++ b/tests/root-circuit/get-client-origin.test.ts
@@ -4,7 +4,6 @@ import { RootCircuit } from "lib/RootCircuit"
 test("returns window.location.origin when window is defined", () => {
   const originalWindow = (globalThis as any).window
   const originalSelf = (globalThis as any).self
-
   ;(globalThis as any).window = { location: { origin: "https://example.com" } }
   ;(globalThis as any).self = (globalThis as any).window
 
@@ -14,20 +13,19 @@ test("returns window.location.origin when window is defined", () => {
   if (originalWindow === undefined) {
     delete (globalThis as any).window
   } else {
-    (globalThis as any).window = originalWindow
+    ;(globalThis as any).window = originalWindow
   }
 
   if (originalSelf === undefined) {
     delete (globalThis as any).self
   } else {
-    (globalThis as any).self = originalSelf
+    ;(globalThis as any).self = originalSelf
   }
 })
 
 test("returns self.location.origin when window is undefined but self exists", () => {
   const originalWindow = (globalThis as any).window
   const originalSelf = (globalThis as any).self
-
   ;(globalThis as any).window = undefined
   ;(globalThis as any).self = { location: { origin: "https://worker.example" } }
 
@@ -37,12 +35,12 @@ test("returns self.location.origin when window is undefined but self exists", ()
   if (originalWindow === undefined) {
     delete (globalThis as any).window
   } else {
-    (globalThis as any).window = originalWindow
+    ;(globalThis as any).window = originalWindow
   }
 
   if (originalSelf === undefined) {
     delete (globalThis as any).self
   } else {
-    (globalThis as any).self = originalSelf
+    ;(globalThis as any).self = originalSelf
   }
 })

--- a/tests/root-circuit/get-client-origin.test.ts
+++ b/tests/root-circuit/get-client-origin.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { RootCircuit } from "lib/RootCircuit"
+
+test("returns window.location.origin when window is defined", () => {
+  const originalWindow = (globalThis as any).window
+  const originalSelf = (globalThis as any).self
+
+  ;(globalThis as any).window = { location: { origin: "https://example.com" } }
+  ;(globalThis as any).self = (globalThis as any).window
+
+  const circuit = new RootCircuit()
+  expect(circuit.getClientOrigin()).toBe("https://example.com")
+
+  if (originalWindow === undefined) {
+    delete (globalThis as any).window
+  } else {
+    (globalThis as any).window = originalWindow
+  }
+
+  if (originalSelf === undefined) {
+    delete (globalThis as any).self
+  } else {
+    (globalThis as any).self = originalSelf
+  }
+})
+
+test("returns self.location.origin when window is undefined but self exists", () => {
+  const originalWindow = (globalThis as any).window
+  const originalSelf = (globalThis as any).self
+
+  ;(globalThis as any).window = undefined
+  ;(globalThis as any).self = { location: { origin: "https://worker.example" } }
+
+  const circuit = new RootCircuit()
+  expect(circuit.getClientOrigin()).toBe("https://worker.example")
+
+  if (originalWindow === undefined) {
+    delete (globalThis as any).window
+  } else {
+    (globalThis as any).window = originalWindow
+  }
+
+  if (originalSelf === undefined) {
+    delete (globalThis as any).self
+  } else {
+    (globalThis as any).self = originalSelf
+  }
+})


### PR DESCRIPTION
## Summary
- handle worker `self.location.origin` in `getClientOrigin`
- add tests verifying origin selection in browser and worker contexts