### PR TITLE
Improve Net Island Routing Handling for Empty Trace Cases

### DIFF
--- a/lib/components/primitive-components/Net.ts
+++ b/lib/components/primitive-components/Net.ts
@@ -119,23 +119,29 @@ export class Net extends PrimitiveComponent<typeof netProps> {
       (trace) => (trace._portsRoutedOnPcb?.length ?? 0) > 0,
     )
 
-    const islands: Array<{ ports: Port[]; traces: Trace[] }> = []
+    let islands: Array<{ ports: Port[]; traces: Trace[] }> = []
 
-    for (const trace of traces) {
-      const tracePorts = trace._portsRoutedOnPcb
-      const traceIsland = islands.find((island) =>
-        tracePorts.some((port) => island.ports.includes(port)),
-      )
-      if (!traceIsland) {
-        islands.push({ ports: [...tracePorts], traces: [trace] })
-        continue
+    if (traces.length === 0) {
+      const allPorts = this.getSubcircuit().selectAll("port") as Port[]
+      if (allPorts.length === 0) return
+      islands = allPorts.map((port) => ({ ports: [port], traces: [] }))
+    } else {
+      for (const trace of traces) {
+        const tracePorts = trace._portsRoutedOnPcb
+        const traceIsland = islands.find((island) =>
+          tracePorts.some((port) => island.ports.includes(port)),
+        )
+        if (!traceIsland) {
+          islands.push({ ports: [...tracePorts], traces: [trace] })
+          continue
+        }
+        traceIsland.traces.push(trace)
+        traceIsland.ports.push(...tracePorts)
       }
-      traceIsland.traces.push(trace)
-      traceIsland.ports.push(...tracePorts)
-    }
 
-    if (islands.length === 0) {
-      return
+      if (islands.length === 0) {
+        return
+      }
     }
 
     // Connect islands together by looking at each pair of islands and adding

--- a/tests/components/primitive-components/net-only-ports.test.tsx
+++ b/tests/components/primitive-components/net-only-ports.test.tsx
@@ -1,0 +1,20 @@
+import { it, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+it("routes traces between ports when net has no traces", () => {
+  const { project } = getTestFixture()
+
+  project.add(
+    <board width="10mm" height="10mm" autorouter="sequential-trace">
+      <net name="COM" />
+      <resistor name="R1" resistance="10k" footprint="0402" pcbX={-2} />
+      <resistor name="R2" resistance="10k" footprint="0402" pcbX={2} />
+    </board>,
+  )
+
+  project.render()
+
+  const pcbTraces = project.db.pcb_trace.list()
+
+  expect(pcbTraces.length).toBe(3)
+})


### PR DESCRIPTION
- Ensure Net creates routing islands from ports when no connected traces exist
- Keep existing behavior for trace-derived islands