### PR TITLE
feat: warn on unconnected required pins

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -48,6 +48,7 @@ import type { INormalComponent } from "./INormalComponent"
 import { Trace } from "lib/components/primitive-components/Trace/Trace"
 import { NormalComponent__getMinimumFlexContainerSize } from "./NormalComponent__getMinimumFlexContainerSize"
 import { NormalComponent__repositionOnPcb } from "./NormalComponent__repositionOnPcb"
+import { NormalComponent_doInitialSourceDesignRuleChecks } from "./NormalComponent_doInitialSourceDesignRuleChecks"
 
 const debug = Debug("tscircuit:core")
 
@@ -1215,6 +1216,10 @@ export class NormalComponent<
         }
       }
     }
+  }
+
+  doInitialSourceDesignRuleChecks(): void {
+    NormalComponent_doInitialSourceDesignRuleChecks(this)
   }
 
   /**

--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialSourceDesignRuleChecks.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialSourceDesignRuleChecks.ts
@@ -1,0 +1,65 @@
+import type { NormalComponent } from "./NormalComponent"
+import type { Port } from "../../primitive-components/Port"
+
+export const NormalComponent_doInitialSourceDesignRuleChecks = (
+  component: NormalComponent,
+): void => {
+  const { db } = component.root!
+  if (!component.source_component_id) return
+
+  const ports = component.selectAll("port") as Port[]
+  const traces = db.source_trace.list()
+
+  const connected = new Set<string>()
+  for (const trace of traces) {
+    for (const id of trace.connected_source_port_ids) {
+      connected.add(id)
+    }
+  }
+
+  const internalGroups = component._getInternallyConnectedPins()
+  for (const group of internalGroups) {
+    if (
+      group.some((p) => p.source_port_id && connected.has(p.source_port_id))
+    ) {
+      for (const p of group) {
+        if (p.source_port_id) connected.add(p.source_port_id)
+      }
+    }
+  }
+
+  for (const port of ports) {
+    if (!port.source_port_id) continue
+    if (!shouldCheckPortForMissingTrace(component, port)) continue
+    if (connected.has(port.source_port_id)) continue
+    db.source_pin_missing_trace_warning.insert({
+      message: `Port ${port.getNameAndAliases()[0]} on ${component.props.name} is missing a trace`,
+      source_component_id: component.source_component_id,
+      source_port_id: port.source_port_id,
+      subcircuit_id: component.getSubcircuit().subcircuit_id ?? undefined,
+      warning_type: "source_pin_missing_trace_warning",
+    })
+  }
+}
+
+export const shouldCheckPortForMissingTrace = (
+  component: NormalComponent,
+  port: Port,
+): boolean => {
+  if (component.config.componentName === "Chip") {
+    const pinAttributes = (component.props as any).pinAttributes
+    if (!pinAttributes) return false
+    for (const alias of port.getNameAndAliases()) {
+      const attrs = pinAttributes[alias]
+      if (
+        attrs?.requiresPower ||
+        attrs?.requiresGround ||
+        attrs?.requiresVoltage !== undefined
+      ) {
+        return true
+      }
+    }
+    return false
+  }
+  return true
+}

--- a/lib/components/base-components/Renderable.ts
+++ b/lib/components/base-components/Renderable.ts
@@ -24,6 +24,7 @@ export const orderedRenderPhases = [
   "OptimizeSelectorCache",
   "SourceTraceRender",
   "SourceAddConnectivityMapKey",
+  "SourceDesignRuleChecks",
   "SimulationRender",
   "SchematicComponentRender",
   "SchematicPortRender",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bun-match-svg": "0.0.12",
     "calculate-elbow": "^0.0.9",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.233",
+    "circuit-json": "^0.0.235",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.22",
     "circuit-json-to-simple-3d": "^0.0.6",

--- a/tests/components/normal-components/chip-pin-missing-trace-warning-noattr.test.tsx
+++ b/tests/components/normal-components/chip-pin-missing-trace-warning-noattr.test.tsx
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("chip unconnected pins do not emit warning", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin2: "GND" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const warnings = circuit
+    .getCircuitJson()
+    .filter((e) => e.type === "source_pin_missing_trace_warning")
+
+  expect(warnings).toHaveLength(0)
+})

--- a/tests/components/normal-components/chip-pin-missing-trace-warning-requirespower.test.tsx
+++ b/tests/components/normal-components/chip-pin-missing-trace-warning-requirespower.test.tsx
@@ -1,0 +1,25 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("chip pin with requiresPower emits warning when unconnected", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin2: "GND" }}
+        pinAttributes={{ VCC: { requiresPower: true } }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const warnings = circuit
+    .getCircuitJson()
+    .filter((e) => e.type === "source_pin_missing_trace_warning")
+
+  expect(warnings).toHaveLength(1)
+})

--- a/tests/components/normal-components/resistor-pin-missing-trace-warning.test.tsx
+++ b/tests/components/normal-components/resistor-pin-missing-trace-warning.test.tsx
@@ -1,0 +1,20 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("resistor with unconnected pins emits source_pin_missing_trace_warning", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="10k" footprint="0402" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const warnings = circuit
+    .getCircuitJson()
+    .filter((e) => e.type === "source_pin_missing_trace_warning")
+
+  expect(warnings).toHaveLength(2)
+})


### PR DESCRIPTION
## Summary
- warn when required pins are missing trace connections
- skip chip pins unless pinAttributes mark them as required
- move design rule check logic to helper and rename render phase to SourceDesignRuleChecks
- add tests for resistor and chip pin connection warnings

## Testing
- `bun test tests/components/normal-components/resistor-pin-missing-trace-warning.test.tsx`
- `bun test tests/components/normal-components/chip-pin-missing-trace-warning-noattr.test.tsx`
- `bun test tests/components/normal-components/chip-pin-missing-trace-warning-requirespower.test.tsx`
- `bunx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68b13438fdb4832e8200565355ea2ff7