### PR TITLE
fix pinheader cad component creation when footprint omitted

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -1005,9 +1005,10 @@ export class NormalComponent<
     const { db } = this.root!
     const { boardThickness = 0 } = this.root?._getBoard() ?? {}
     const cadModel = this._parsedProps.cadModel as CadModelProp | undefined
+    const footprint = this.props.footprint ?? this._getImpliedFootprintString()
 
     if (!this.pcb_component_id) return
-    if (!cadModel && !this.props.footprint) return
+    if (!cadModel && !footprint) return
     if (cadModel === null) return
 
     // Use post-layout bounds
@@ -1075,9 +1076,7 @@ export class NormalComponent<
           : undefined,
 
       footprinter_string:
-        typeof this.props.footprint === "string" && !cadModel
-          ? this.props.footprint
-          : undefined,
+        typeof footprint === "string" && !cadModel ? footprint : undefined,
     })
   }
 

--- a/tests/components/normal-components/pin-header-cad-component.test.tsx
+++ b/tests/components/normal-components/pin-header-cad-component.test.tsx
@@ -1,0 +1,17 @@
+import { it, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+it("should render a pinheader with a cad component", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <pinheader name="P1" gender="male" pinCount={4} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const cadComponent = circuit.db.cad_component.list()[0]
+  expect(cadComponent).toBeDefined()
+})


### PR DESCRIPTION
## Summary
- create cad component for pinheaders using implied footprint when explicit footprint is absent
- add test covering cad component creation without specified footprint

## Testing
- `bun test tests/components/normal-components/pin-header-cad-component.test.tsx`
- `bun test` *(fails: 365 passed, 90 failed, 15 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68b20514d3f08327a09940cf5c6dcb9d