### PR TITLE
chore: update minicssgrid to 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "howfat": "^0.3.8",
     "live-server": "^1.2.2",
     "looks-same": "^9.0.1",
-    "minicssgrid": "^0.0.8",
+    "minicssgrid": "^0.0.9",
     "pkg-pr-new": "^0.0.37",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",


### PR DESCRIPTION
## Summary
- bump minicssgrid to version 0.0.9

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests`


------
https://chatgpt.com/codex/tasks/task_b_68b206df47dc832e8af5a92436948f90