### PR TITLE
refactor: handle invalid pin labels in normalcomponent

### DIFF
--- a/lib/components/normal-components/Chip.ts
+++ b/lib/components/normal-components/Chip.ts
@@ -3,31 +3,12 @@ import { NormalComponent } from "lib/components/base-components/NormalComponent"
 import { type SchematicBoxDimensions } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
 import { Trace } from "lib/components/primitive-components/Trace/Trace"
 import { Port } from "lib/components/primitive-components/Port"
-import { filterPinLabels } from "lib/utils/filterPinLabels"
-import type { z } from "zod"
 
 export class Chip<PinLabels extends string = never> extends NormalComponent<
   typeof chipProps,
   PinLabels
 > {
   schematicBoxDimensions: SchematicBoxDimensions | null = null
-  private _invalidPinLabelMessages: string[] = []
-
-  constructor(props: z.input<typeof chipProps>) {
-    const filteredProps = { ...props }
-    let invalidPinLabelsMessages: string[] = []
-
-    if (filteredProps.pinLabels) {
-      const { validPinLabels, invalidPinLabelsMessages: messages } =
-        filterPinLabels(filteredProps.pinLabels)
-      filteredProps.pinLabels = validPinLabels
-      invalidPinLabelsMessages = messages
-    }
-
-    // super needs to run before we can assign to `this`
-    super(filteredProps)
-    this._invalidPinLabelMessages = invalidPinLabelsMessages
-  }
 
   get config() {
     return {
@@ -83,34 +64,6 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
         }
       }
     }
-  }
-
-  doInitialSchematicComponentRender(): void {
-    const { _parsedProps: props } = this
-    // Early return if noSchematicRepresentation is true
-    if (props?.noSchematicRepresentation === true) return
-
-    if (this._invalidPinLabelMessages?.length && this.root?.db) {
-      for (const message of this._invalidPinLabelMessages) {
-        let property_name = "pinLabels"
-        const match = message.match(
-          /^Invalid pin label:\s*([^=]+)=\s*'([^']+)'/,
-        )
-        if (match) {
-          const label = match[2]
-          property_name = `pinLabels['${label}']`
-        }
-        this.root.db.source_property_ignored_warning.insert({
-          source_component_id: this.source_component_id!,
-          property_name,
-          message,
-          error_type: "source_property_ignored_warning",
-        })
-      }
-    }
-
-    // Continue with normal schematic rendering
-    super.doInitialSchematicComponentRender()
   }
 
   doInitialSourceRender(): void {


### PR DESCRIPTION
## Summary
- move pin label filtering to `NormalComponent`
- log invalid pin label warnings from `NormalComponent`
- simplify `Chip` to rely on base class handling

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/components/normal-components/chip-invalid-pin.test.tsx tests/repro/chip-pinlabel-leading-space.test.tsx tests/components/normal-components/chip-no-schematic-representation.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68b233d0e778832e87b4831958913db7