### PR TITLE
test: add repro for solderjumper not inheriting matchpack rotation (Issue #1226)

### DIFF
--- a/tests/repro/matchpack-rotation.solderjumper.test.tsx
+++ b/tests/repro/matchpack-rotation.solderjumper.test.tsx
@@ -1,0 +1,36 @@
+import { it, expect } from "bun:test";
+import { getTestFixture } from "tests/fixtures/get-test-fixture";
+
+/**
+ * Repro for Issue #1226:
+ * Solderjumpers placed by matchpack should inherit group rotation
+ */
+it("matchpack: solderjumper should inherit group rotation", async () => {
+  const { circuit } = getTestFixture();
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <group name="G1" pcbRotation={90}>
+        <chip name="U1" />
+        <resistor name="R1" resistance="10k" />
+        <solderjumper name="SJ1" />
+      </group>
+    </board>
+  );
+
+  circuit.render();
+
+  // Grab components
+  const u1 = circuit.selectOne("chip.U1") as any;
+  const r1 = circuit.selectOne("resistor.R1") as any;
+  const sj1 = circuit.selectOne("solderjumper.SJ1") as any;
+
+  const rot = (el: any) =>
+    el?.pcb_rotation ?? el?.ccw_rotation ?? el?.rotation ?? el?.pcb?.rotation;
+
+  expect(rot(u1)).toBe(90);
+  expect(rot(r1)).toBe(90);
+
+  // Expected to fail right now (bug): SJ1 does not inherit rotation
+  expect(rot(sj1)).toBe(90);
+});

--- a/tests/repro/matchpack-rotation.solderjumper.test.tsx
+++ b/tests/repro/matchpack-rotation.solderjumper.test.tsx
@@ -1,11 +1,11 @@
-import { it, expect } from "bun:test";
+import { test, expect } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture";
 
 /**
  * Repro for Issue #1226:
  * Solderjumpers placed by matchpack should inherit group rotation
  */
-it("matchpack: solderjumper should inherit group rotation", async () => {
+test("matchpack: solderjumper should inherit group rotation", async () => {
   const { circuit } = getTestFixture();
 
   circuit.add(


### PR DESCRIPTION
**Title:**
`test: add repro for solderjumper not inheriting matchpack rotation (Issue #1226)`

**Description:**
Adds a failing test case showing that solderjumpers placed inside a rotated matchpack group do not inherit the group’s rotation.

* Builds a small board with a chip, resistor, and solderjumper in a rotated group.
* Asserts that all components should have the group’s rotation (90°).
* Currently fails for the solderjumper, reproducing Issue 
#1226.

This locks down the bug so the next step is to fix the matchpack placement logic.
