### PR TITLE
fix(group/pack): solderjumper inherits matchpack group rotation (fixes #1226)

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack.ts
@@ -1,38 +1,39 @@
-import type { Group } from "./Group"
-import { buildSubtree } from "@tscircuit/circuit-json-util"
+import type { Group } from "./Group";
+import { buildSubtree } from "@tscircuit/circuit-json-util";
 import {
   pack,
   convertCircuitJsonToPackOutput,
   convertPackOutputToPackInput,
   getGraphicsFromPackOutput,
   type PackInput,
-} from "calculate-packing"
-import { length } from "circuit-json"
+} from "calculate-packing";
+import { length } from "circuit-json";
 import {
   transformPCBElements,
   getPrimaryId,
-} from "@tscircuit/circuit-json-util"
-import { translate, rotate, compose } from "transformation-matrix"
-import Debug from "debug"
+} from "@tscircuit/circuit-json-util";
+import { translate, rotate, compose } from "transformation-matrix";
+import Debug from "debug";
 
-const DEFAULT_MIN_GAP = "1mm"
-const debug = Debug("Group_doInitialPcbLayoutPack")
+const DEFAULT_MIN_GAP = "1mm";
+const debug = Debug("Group_doInitialPcbLayoutPack");
+const norm = (deg: number) => ((deg % 360) + 360) % 360;
 
 // Helper function to check if a group is a descendant of another group
 const isDescendantGroup = (
   db: any,
   groupId: string,
-  ancestorId: string,
+  ancestorId: string
 ): boolean => {
-  if (groupId === ancestorId) return true
-  const group = db.source_group.get(groupId)
-  if (!group || !group.parent_source_group_id) return false
-  return isDescendantGroup(db, group.parent_source_group_id, ancestorId)
-}
+  if (groupId === ancestorId) return true;
+  const group = db.source_group.get(groupId);
+  if (!group || !group.parent_source_group_id) return false;
+  return isDescendantGroup(db, group.parent_source_group_id, ancestorId);
+};
 
 export const Group_doInitialPcbLayoutPack = (group: Group) => {
-  const { db } = group.root!
-  const { _parsedProps: props } = group
+  const { db } = group.root!;
+  const { _parsedProps: props } = group;
 
   const {
     packOrderStrategy,
@@ -41,98 +42,107 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
     pcbGap,
     // @ts-expect-error remove when props introduces pcbPackGap
     pcbPackGap,
-  } = props
+  } = props;
 
-  const gap = pcbPackGap ?? pcbGap ?? gapProp
+  const gap = pcbPackGap ?? pcbGap ?? gapProp;
 
-  const gapMm = length.parse(gap ?? DEFAULT_MIN_GAP)
+  const gapMm = length.parse(gap ?? DEFAULT_MIN_GAP);
   const packInput: PackInput = {
     ...convertPackOutputToPackInput(
       convertCircuitJsonToPackOutput(db.toArray(), {
         source_group_id: group.source_group_id!,
         shouldAddInnerObstacles: true,
-      }),
+      })
     ),
     // @ts-expect-error we're missing some pack order strategies
     orderStrategy: packOrderStrategy ?? "largest_to_smallest",
     placementStrategy:
       packPlacementStrategy ?? "minimum_sum_squared_distance_to_network",
     minGap: gapMm,
-  }
+  };
 
   if (debug.enabled) {
     global.debugOutputs?.add(
       `packInput-circuitjson-${group.name}`,
-      JSON.stringify(db.toArray()),
-    )
-    global.debugOutputs?.add(`packInput-${group.name}`, packInput)
+      JSON.stringify(db.toArray())
+    );
+    global.debugOutputs?.add(`packInput-${group.name}`, packInput);
   }
 
-  const packOutput = pack(packInput)
+  const packOutput = pack(packInput);
 
   if (debug.enabled) {
-    const graphics = getGraphicsFromPackOutput(packOutput)
-    graphics.title = `packOutput-${group.name}`
-    global.debugGraphics?.push(graphics)
+    const graphics = getGraphicsFromPackOutput(packOutput);
+    graphics.title = `packOutput-${group.name}`;
+    global.debugGraphics?.push(graphics);
   }
 
   // Apply the pack output to the circuit json
   for (const packedComponent of packOutput.components) {
     const { center, componentId, ccwRotationOffset, ccwRotationDegrees } =
-      packedComponent
+      packedComponent;
 
-    const pcbComponent = db.pcb_component.get(componentId)
+    const pcbComponent = db.pcb_component.get(componentId);
     if (pcbComponent) {
       // Only transform components that belong to the current group or its children
       // to prevent cross-group interference
-      const currentGroupId = group.source_group_id
+      const currentGroupId = group.source_group_id;
 
       // Get the source component to find its group association
       const sourceComponent = db.source_component.get(
-        pcbComponent.source_component_id,
-      )
-      const componentGroupId = sourceComponent?.source_group_id
+        pcbComponent.source_component_id
+      );
+      const componentGroupId = sourceComponent?.source_group_id;
 
       // Skip if component doesn't belong to current group or its descendants
       if (
         componentGroupId !== undefined &&
         !isDescendantGroup(db, componentGroupId, currentGroupId!)
       ) {
-        continue
+        continue;
       }
 
-      const originalCenter = pcbComponent.center
-      const rotationDegrees = ccwRotationDegrees ?? ccwRotationOffset ?? 0
+      const originalCenter = pcbComponent.center;
+      const rotationDegrees = ccwRotationDegrees ?? ccwRotationOffset ?? 0;
       const transformMatrix = compose(
         group._computePcbGlobalTransformBeforeLayout(),
         translate(center.x, center.y),
         rotate((rotationDegrees * Math.PI) / 180),
-        translate(-originalCenter.x, -originalCenter.y),
-      )
+        translate(-originalCenter.x, -originalCenter.y)
+      );
 
       const related = db
         .toArray()
         .filter(
           (elm) =>
-            "pcb_component_id" in elm && elm.pcb_component_id === componentId,
-        )
-      transformPCBElements(related as any, transformMatrix)
-      continue
+            "pcb_component_id" in elm && elm.pcb_component_id === componentId
+        );
+      transformPCBElements(related as any, transformMatrix);
+      const groupRot = group._parsedProps?.pcbRotation ?? 0;
+      const packedRot = ccwRotationDegrees ?? ccwRotationOffset ?? 0;
+      const existingRot = pcbComponent.rotation ?? 0;
+      const finalRot =
+        (((groupRot + packedRot + existingRot) % 360) + 360) % 360;
+
+      db.pcb_component.update(componentId, {
+        rotation: finalRot,
+      });
+      continue;
     }
 
     const pcbGroup = db.pcb_group
       .list()
-      .find((g) => g.source_group_id === componentId)
-    if (!pcbGroup) continue
+      .find((g) => g.source_group_id === componentId);
+    if (!pcbGroup) continue;
 
-    const originalCenter = pcbGroup.center
-    const rotationDegrees = ccwRotationDegrees ?? ccwRotationOffset ?? 0
+    const originalCenter = pcbGroup.center;
+    const rotationDegrees = ccwRotationDegrees ?? ccwRotationOffset ?? 0;
     const transformMatrix = compose(
       group._computePcbGlobalTransformBeforeLayout(),
       translate(center.x, center.y),
       rotate((rotationDegrees * Math.PI) / 180),
-      translate(-originalCenter.x, -originalCenter.y),
-    )
+      translate(-originalCenter.x, -originalCenter.y)
+    );
 
     // Only transform elements that belong to this specific group or its descendants
     // This prevents cross-group interference while allowing nested group functionality
@@ -141,44 +151,46 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
       if ("source_group_id" in elm && elm.source_group_id) {
         // Include if element belongs to the specific group being processed
         if (elm.source_group_id === componentId) {
-          return true
+          return true;
         }
 
         // Include if element belongs to a descendant group
         if (isDescendantGroup(db, elm.source_group_id, componentId)) {
-          return true
+          return true;
         }
       }
 
       // Check elements that belong to components
       if ("source_component_id" in elm && elm.source_component_id) {
-        const sourceComponent = db.source_component.get(elm.source_component_id)
+        const sourceComponent = db.source_component.get(
+          elm.source_component_id
+        );
         if (sourceComponent?.source_group_id) {
           // Include if component belongs to the specific group being processed
           if (sourceComponent.source_group_id === componentId) {
-            return true
+            return true;
           }
 
           // Include if component belongs to a descendant group
           if (
             isDescendantGroup(db, sourceComponent.source_group_id, componentId)
           ) {
-            return true
+            return true;
           }
         }
       }
 
       // Check pcb elements that reference components
       if ("pcb_component_id" in elm && elm.pcb_component_id) {
-        const pcbComponent = db.pcb_component.get(elm.pcb_component_id)
+        const pcbComponent = db.pcb_component.get(elm.pcb_component_id);
         if (pcbComponent?.source_component_id) {
           const sourceComponent = db.source_component.get(
-            pcbComponent.source_component_id,
-          )
+            pcbComponent.source_component_id
+          );
           if (sourceComponent?.source_group_id) {
             // Include if component belongs to the specific group being processed
             if (sourceComponent.source_group_id === componentId) {
-              return true
+              return true;
             }
 
             // Include if component belongs to a descendant group
@@ -186,19 +198,19 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
               isDescendantGroup(
                 db,
                 sourceComponent.source_group_id,
-                componentId,
+                componentId
               )
             ) {
-              return true
+              return true;
             }
           }
         }
       }
 
-      return false
-    })
+      return false;
+    });
 
-    transformPCBElements(relatedElements as any, transformMatrix)
-    db.pcb_group.update(pcbGroup.pcb_group_id, { center })
+    transformPCBElements(relatedElements as any, transformMatrix);
+    db.pcb_group.update(pcbGroup.pcb_group_id, { center });
   }
-}
+};

--- a/tests/repro/matchpack-rotation.solderjumper.test.tsx
+++ b/tests/repro/matchpack-rotation.solderjumper.test.tsx
@@ -1,0 +1,36 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/**
+ * Repro for Issue #1226:
+ * Ensure solderjumpers placed in a rotated group inherit the group's rotation
+ */
+test("matchpack: solderjumper should inherit group rotation", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <group name="G1" pcbRotation={90}>
+        <chip name="U1" />
+        <resistor name="R1" resistance="10k" />
+        <solderjumper name="SJ1" />
+      </group>
+    </board>,
+  )
+
+  circuit.render()
+
+  // Grab source elements
+  const u1 = circuit.selectOne("chip.U1") as any
+  const r1 = circuit.selectOne("resistor.R1") as any
+  const sj1 = circuit.selectOne("solderjumper.SJ1") as any
+
+  // Look up their PCB components to check actual rotations
+  const pcbU1 = circuit.db.pcb_component.get(u1.pcb_component_id)!
+  const pcbR1 = circuit.db.pcb_component.get(r1.pcb_component_id)!
+  const pcbSJ1 = circuit.db.pcb_component.get(sj1.pcb_component_id)!
+
+  // Assert solderjumper inherits the same rotation as other parts in the group
+  expect(pcbSJ1.rotation).toBe(pcbU1.rotation)
+  expect(pcbSJ1.rotation).toBe(pcbR1.rotation)
+})


### PR DESCRIPTION
/claim #1226

**Fix**
- Compose group rotation + pack rotation + existing child rotation into `pcb_component.rotation`
  in `Group_doInitialPcbLayoutPack.ts`.

**Why**
- Solderjumpers (and chips) placed by matchpack were not inheriting the group's rotation.

**Tests**
- Repro test: `tests/repro/matchpack-rotation.solderjumper.test.tsx` now passes.
- Full suite green.
