### PR TITLE
refactor: move pin label validation from Chip to NormalComponent (base class)

### DIFF
--- a/lib/components/normal-components/Chip.ts
+++ b/lib/components/normal-components/Chip.ts
@@ -3,7 +3,6 @@ import { NormalComponent } from "lib/components/base-components/NormalComponent"
 import { type SchematicBoxDimensions } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
 import { Trace } from "lib/components/primitive-components/Trace/Trace"
 import { Port } from "lib/components/primitive-components/Port"
-import { filterPinLabels } from "lib/utils/filterPinLabels"
 import type { z } from "zod"
 
 export class Chip<PinLabels extends string = never> extends NormalComponent<
@@ -11,22 +10,9 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
   PinLabels
 > {
   schematicBoxDimensions: SchematicBoxDimensions | null = null
-  private _invalidPinLabelMessages: string[] = []
 
   constructor(props: z.input<typeof chipProps>) {
-    const filteredProps = { ...props }
-    let invalidPinLabelsMessages: string[] = []
-
-    if (filteredProps.pinLabels) {
-      const { validPinLabels, invalidPinLabelsMessages: messages } =
-        filterPinLabels(filteredProps.pinLabels)
-      filteredProps.pinLabels = validPinLabels
-      invalidPinLabelsMessages = messages
-    }
-
-    // super needs to run before we can assign to `this`
-    super(filteredProps)
-    this._invalidPinLabelMessages = invalidPinLabelsMessages
+    super(props)
   }
 
   get config() {
@@ -89,25 +75,6 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
     const { _parsedProps: props } = this
     // Early return if noSchematicRepresentation is true
     if (props?.noSchematicRepresentation === true) return
-
-    if (this._invalidPinLabelMessages?.length && this.root?.db) {
-      for (const message of this._invalidPinLabelMessages) {
-        let property_name = "pinLabels"
-        const match = message.match(
-          /^Invalid pin label:\s*([^=]+)=\s*'([^']+)'/,
-        )
-        if (match) {
-          const label = match[2]
-          property_name = `pinLabels['${label}']`
-        }
-        this.root.db.source_property_ignored_warning.insert({
-          source_component_id: this.source_component_id!,
-          property_name,
-          message,
-          error_type: "source_property_ignored_warning",
-        })
-      }
-    }
 
     // Continue with normal schematic rendering
     super.doInitialSchematicComponentRender()


### PR DESCRIPTION

- Centralize invalid pin label filtering logic in NormalComponent constructor
- Support all pinLabel formats: objects, arrays, and mixed formats  

/claim #1249
/fixes #1249 