### PR TITLE
chore(test): add thresholded svg snapshot matcher

### DIFF
--- a/tests/fixtures/extend-expect-any-svg.ts
+++ b/tests/fixtures/extend-expect-any-svg.ts
@@ -7,10 +7,11 @@ const DIFF_THRESHOLD_PERCENT = 1 // only update snapshot if >1% difference
 
 async function toMatchSvgSnapshot(
   this: any,
-  received: string,
+  received: string | Promise<string>,
   testPathOriginal: string,
   svgName?: string,
 ): Promise<MatcherResult> {
+  const svg = await received
   const testPath = testPathOriginal.replace(/\.test\.tsx?$/, "")
   const snapshotDir = path.join(path.dirname(testPath), "__snapshots__")
   const snapshotName = svgName
@@ -31,7 +32,7 @@ async function toMatchSvgSnapshot(
 
   if (!fileExists) {
     console.log("Writing snapshot to", filePath)
-    fs.writeFileSync(filePath, received)
+    fs.writeFileSync(filePath, svg)
     return {
       message: () => `Snapshot created at ${filePath}`,
       pass: true,
@@ -41,7 +42,7 @@ async function toMatchSvgSnapshot(
   const existingSnapshot = fs.readFileSync(filePath, "utf-8")
 
   const result: any = await looksSame(
-    Buffer.from(received),
+    Buffer.from(svg),
     Buffer.from(existingSnapshot),
     {
       strict: false,
@@ -68,7 +69,7 @@ async function toMatchSvgSnapshot(
       }
     }
     console.log("Updating snapshot at", filePath)
-    fs.writeFileSync(filePath, received)
+    fs.writeFileSync(filePath, svg)
     return {
       message: () => `Snapshot updated at ${filePath}`,
       pass: true,
@@ -85,7 +86,7 @@ async function toMatchSvgSnapshot(
   const diffPath = filePath.replace(".snap.svg", ".diff.png")
   await looksSame.createDiff({
     reference: Buffer.from(existingSnapshot),
-    current: Buffer.from(received),
+    current: Buffer.from(svg),
     diff: diffPath,
     highlightColor: "#ff00ff",
   })

--- a/tests/fixtures/extend-expect-any-svg.ts
+++ b/tests/fixtures/extend-expect-any-svg.ts
@@ -3,6 +3,8 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 import looksSame from "looks-same"
 
+const DIFF_THRESHOLD_PERCENT = 1 // only update snapshot if >1% difference
+
 async function toMatchSvgSnapshot(
   this: any,
   received: string,
@@ -25,7 +27,9 @@ async function toMatchSvgSnapshot(
     process.argv.includes("-u") ||
     Boolean(process.env.BUN_UPDATE_SNAPSHOTS)
 
-  if (!fs.existsSync(filePath) || updateSnapshot) {
+  const fileExists = fs.existsSync(filePath)
+
+  if (!fileExists) {
     console.log("Writing snapshot to", filePath)
     fs.writeFileSync(filePath, received)
     return {
@@ -36,16 +40,42 @@ async function toMatchSvgSnapshot(
 
   const existingSnapshot = fs.readFileSync(filePath, "utf-8")
 
-  const result = await looksSame(
+  const result: any = await looksSame(
     Buffer.from(received),
     Buffer.from(existingSnapshot),
     {
       strict: false,
       tolerance: 2,
+      shouldCluster: true,
+      clustersSize: 10,
     },
   )
 
-  if (result.equal) {
+  const totalPixels =
+    result.metaInfo.refImg.size.width * result.metaInfo.refImg.size.height
+  const diffPixels = result.diffClusters.reduce(
+    (sum: number, cluster: any) =>
+      sum + (cluster.right - cluster.left) * (cluster.bottom - cluster.top),
+    0,
+  )
+  const diffPercent = (diffPixels / totalPixels) * 100
+
+  if (updateSnapshot) {
+    if (result.equal || diffPercent <= DIFF_THRESHOLD_PERCENT) {
+      return {
+        message: () => "Snapshot matches",
+        pass: true,
+      }
+    }
+    console.log("Updating snapshot at", filePath)
+    fs.writeFileSync(filePath, received)
+    return {
+      message: () => `Snapshot updated at ${filePath}`,
+      pass: true,
+    }
+  }
+
+  if (result.equal || diffPercent <= DIFF_THRESHOLD_PERCENT) {
     return {
       message: () => "Snapshot matches",
       pass: true,
@@ -61,7 +91,8 @@ async function toMatchSvgSnapshot(
   })
 
   return {
-    message: () => `Snapshot does not match. Diff saved at ${diffPath}`,
+    message: () =>
+      `Snapshot does not match (diff ${diffPercent.toFixed(2)}%). Diff saved at ${diffPath}`,
     pass: false,
   }
 }

--- a/tests/fixtures/preload.ts
+++ b/tests/fixtures/preload.ts
@@ -1,4 +1,5 @@
 import "bun-match-svg"
+import "./extend-expect-any-svg"
 import "lib/register-catalogue"
 
 declare module "bun:test" {


### PR DESCRIPTION
## Summary
- prevent trivial snapshot churn by checking SVG diff percentage
- preload custom matcher to apply threshold globally

## Testing
- `bun test tests/components/primitive-components/multilayer-obstacle-route.test.tsx`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/components/primitive-components/multilayer-obstacle-route.test.tsx`
- `bun test tests/utils/schematic/getAllDimensionsForSchematicBox.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68bf99464124832e99d7e966500a459d