### PR TITLE
feat: store cad models from footprint libraries

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -7,6 +7,9 @@ import type {
   SchematicPortArrangement,
   SupplierPartNumbers,
   CadModelGltf,
+  CadModelGlb,
+  CadModelStep,
+  CadModelWrl,
 } from "@tscircuit/props"
 import {
   pcb_manual_edit_conflict_warning,
@@ -107,6 +110,7 @@ export class NormalComponent<
   }
 
   _asyncSupplierPartNumbers?: SupplierPartNumbers
+  _asyncFootprintCadModel?: CadModelProp
   pcb_missing_footprint_error_id?: string
   _hasStartedFootprintUrlLoad = false
 
@@ -1063,7 +1067,9 @@ export class NormalComponent<
   doInitialCadModelRender(): void {
     const { db } = this.root!
     const { boardThickness = 0 } = this.root?._getBoard() ?? {}
-    const cadModel = this._parsedProps.cadModel as CadModelProp | undefined
+    const cadModelProp = this._parsedProps.cadModel
+    const cadModel =
+      cadModelProp === undefined ? this._asyncFootprintCadModel : cadModelProp
     const footprint = this.props.footprint ?? this._getImpliedFootprintString()
 
     if (!this.pcb_component_id) return
@@ -1129,9 +1135,25 @@ export class NormalComponent<
         "objUrl" in (cadModel ?? {})
           ? this._addCachebustToModelUrl((cadModel as CadModelObj).objUrl)
           : undefined,
+      model_mtl_url:
+        "mtlUrl" in (cadModel ?? {})
+          ? this._addCachebustToModelUrl((cadModel as CadModelObj).mtlUrl)
+          : undefined,
       model_gltf_url:
         "gltfUrl" in (cadModel ?? {})
           ? this._addCachebustToModelUrl((cadModel as CadModelGltf).gltfUrl)
+          : undefined,
+      model_glb_url:
+        "glbUrl" in (cadModel ?? {})
+          ? this._addCachebustToModelUrl((cadModel as CadModelGlb).glbUrl)
+          : undefined,
+      model_step_url:
+        "stepUrl" in (cadModel ?? {})
+          ? this._addCachebustToModelUrl((cadModel as CadModelStep).stepUrl)
+          : undefined,
+      model_wrl_url:
+        "wrlUrl" in (cadModel ?? {})
+          ? this._addCachebustToModelUrl((cadModel as CadModelWrl).wrlUrl)
           : undefined,
       model_jscad:
         "jscad" in (cadModel ?? {})
@@ -1141,6 +1163,7 @@ export class NormalComponent<
       footprinter_string:
         typeof footprint === "string" && !cadModel ? footprint : undefined,
     })
+    this.cad_component_id = cad_model.cad_component_id
   }
 
   private _addCachebustToModelUrl(url?: string): string | undefined {

--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
@@ -4,6 +4,7 @@ import { isValidElement as isReactElement } from "react"
 import { Footprint } from "lib/components/primitive-components/Footprint"
 import { isFootprintUrl } from "./utils/isFoorprintUrl"
 import { parseLibraryFootprintRef } from "./utils/parseLibraryFootprintRef"
+import type { FootprintLibraryResult } from "@tscircuit/props"
 
 export function NormalComponent_doInitialPcbFootprintStringRender(
   component: NormalComponent<any, any>,
@@ -50,20 +51,25 @@ export function NormalComponent_doInitialPcbFootprintStringRender(
     const libMap = platform?.footprintLibraryMap?.[libRef.footprintLib]
 
     // Find resolver: library can be a function or an object of resolvers
-    let resolverFn: ((path: string) => Promise<any>) | undefined
+    let resolverFn:
+      | ((path: string) => Promise<FootprintLibraryResult | any[]>)
+      | undefined
     if (typeof libMap === "function") {
-      resolverFn = libMap as (path: string) => Promise<any>
+      resolverFn = libMap as (
+        path: string,
+      ) => Promise<FootprintLibraryResult | any[]>
     }
 
     if (!resolverFn) return
 
     queueAsyncEffect("load-lib-footprint", async () => {
       const result = await resolverFn!(libRef.footprintName)
-      const circuitJson = Array.isArray(result)
-        ? result
-        : Array.isArray((result as any)?.footprintCircuitJson)
-          ? (result as any).footprintCircuitJson
-          : null
+      let circuitJson: any[] | null = null
+      if (Array.isArray(result)) {
+        circuitJson = result
+      } else if (Array.isArray(result.footprintCircuitJson)) {
+        circuitJson = result.footprintCircuitJson
+      }
       if (!circuitJson) return
       const fpComponents = createComponentsFromCircuitJson(
         {
@@ -76,6 +82,9 @@ export function NormalComponent_doInitialPcbFootprintStringRender(
         circuitJson,
       )
       component.addAll(fpComponents)
+      if (!Array.isArray(result) && result.cadModel) {
+        component._asyncFootprintCadModel = result.cadModel
+      }
       // Ensure existing Ports re-run PcbPortRender now that pads exist
       for (const child of component.children) {
         if (child.componentName === "Port") {

--- a/lib/components/base-components/Renderable.ts
+++ b/lib/components/base-components/Renderable.ts
@@ -58,6 +58,7 @@ export type RenderPhase = (typeof orderedRenderPhases)[number]
 // current component's subtree.
 const asyncPhaseDependencies: Partial<Record<RenderPhase, RenderPhase[]>> = {
   PcbTraceRender: ["PcbFootprintStringRender"],
+  CadModelRender: ["PcbFootprintStringRender"],
 }
 
 export type RenderPhaseFn<K extends RenderPhase = RenderPhase> =

--- a/tests/footprint/footprint-library-map-cadmodel.test.tsx
+++ b/tests/footprint/footprint-library-map-cadmodel.test.tsx
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import external0402Footprint from "tests/fixtures/assets/external-0402-footprint.json"
+
+test("footprint library map cadModel", async () => {
+  const { circuit } = getTestFixture({
+    platform: {
+      footprintLibraryMap: {
+        kicad: async () => ({
+          footprintCircuitJson: external0402Footprint,
+          cadModel: { wrlUrl: "https://example.com/model.wrl" },
+        }),
+      },
+    },
+  })
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor
+        name="R1"
+        resistance="10k"
+        footprint="kicad:R_0402_1005Metric"
+        pcbX={0}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const cad_component = circuit
+    .getCircuitJson()
+    .find((el) => el.type === "cad_component")
+
+  expect(cad_component?.model_wrl_url).toBe("https://example.com/model.wrl")
+})


### PR DESCRIPTION
## Summary
- preserve cadModel returned by platform footprint library resolvers
- support additional cad model formats when creating cad components
- defer cad model rendering until footprint resolution completes
- type footprint library resolver responses to remove casts

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/footprint`


------
https://chatgpt.com/codex/tasks/task_b_68bfa2d5f1b8832ea29e19a5a7cc573d