### PR TITLE
feat: surface external footprint load errors

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
@@ -5,6 +5,7 @@ import { Footprint } from "lib/components/primitive-components/Footprint"
 import { isFootprintUrl } from "./utils/isFoorprintUrl"
 import { parseLibraryFootprintRef } from "./utils/parseLibraryFootprintRef"
 import type { CadModelProp } from "@tscircuit/props"
+import { external_footprint_load_error } from "circuit-json"
 
 interface FootprintLibraryResult {
   footprintCircuitJson: any[]
@@ -26,20 +27,44 @@ export function NormalComponent_doInitialPcbFootprintStringRender(
     component._hasStartedFootprintUrlLoad = true
     const url = footprint
     queueAsyncEffect("load-footprint-url", async () => {
-      const res = await fetch(url)
-      const soup = await res.json()
-      const fpComponents = createComponentsFromCircuitJson(
-        {
-          componentName: component.name,
-          componentRotation: pcbRotation,
-          footprint: url,
-          pinLabels,
-          pcbPinLabels,
-        },
-        soup as any,
-      )
-      component.addAll(fpComponents)
-      component._markDirty("InitializePortsFromChildren")
+      try {
+        const res = await fetch(url)
+        if (!res.ok) {
+          throw new Error(`Failed to fetch footprint: ${res.status}`)
+        }
+        const soup = await res.json()
+        const fpComponents = createComponentsFromCircuitJson(
+          {
+            componentName: component.name,
+            componentRotation: pcbRotation,
+            footprint: url,
+            pinLabels,
+            pcbPinLabels,
+          },
+          soup as any,
+        )
+        component.addAll(fpComponents)
+        component._markDirty("InitializePortsFromChildren")
+      } catch (err) {
+        const db = component.root?.db
+        if (db && component.source_component_id && component.pcb_component_id) {
+          const subcircuit = component.getSubcircuit()
+          const errorMsg =
+            `${component.getString()} failed to load external footprint "${url}": ` +
+            (err instanceof Error ? err.message : String(err))
+          const errorObj = external_footprint_load_error.parse({
+            type: "external_footprint_load_error",
+            message: errorMsg,
+            pcb_component_id: component.pcb_component_id,
+            source_component_id: component.source_component_id,
+            subcircuit_id: subcircuit.subcircuit_id ?? undefined,
+            pcb_group_id: component.getGroup()?.pcb_group_id ?? undefined,
+            footprinter_string: url,
+          })
+          db.external_footprint_load_error.insert(errorObj)
+        }
+        throw err
+      }
     })
     return
   }
@@ -68,35 +93,56 @@ export function NormalComponent_doInitialPcbFootprintStringRender(
     if (!resolverFn) return
 
     queueAsyncEffect("load-lib-footprint", async () => {
-      const result = await resolverFn!(libRef.footprintName)
-      let circuitJson: any[] | null = null
-      if (Array.isArray(result)) {
-        circuitJson = result
-      } else if (Array.isArray(result.footprintCircuitJson)) {
-        circuitJson = result.footprintCircuitJson
-      }
-      if (!circuitJson) return
-      const fpComponents = createComponentsFromCircuitJson(
-        {
-          componentName: component.name,
-          componentRotation: pcbRotation,
-          footprint,
-          pinLabels,
-          pcbPinLabels,
-        },
-        circuitJson,
-      )
-      component.addAll(fpComponents)
-      if (!Array.isArray(result) && result.cadModel) {
-        component._asyncFootprintCadModel = result.cadModel
-      }
-      // Ensure existing Ports re-run PcbPortRender now that pads exist
-      for (const child of component.children) {
-        if (child.componentName === "Port") {
-          child._markDirty?.("PcbPortRender")
+      try {
+        const result = await resolverFn!(libRef.footprintName)
+        let circuitJson: any[] | null = null
+        if (Array.isArray(result)) {
+          circuitJson = result
+        } else if (Array.isArray(result.footprintCircuitJson)) {
+          circuitJson = result.footprintCircuitJson
         }
+        if (!circuitJson) return
+        const fpComponents = createComponentsFromCircuitJson(
+          {
+            componentName: component.name,
+            componentRotation: pcbRotation,
+            footprint,
+            pinLabels,
+            pcbPinLabels,
+          },
+          circuitJson,
+        )
+        component.addAll(fpComponents)
+        if (!Array.isArray(result) && result.cadModel) {
+          component._asyncFootprintCadModel = result.cadModel
+        }
+        // Ensure existing Ports re-run PcbPortRender now that pads exist
+        for (const child of component.children) {
+          if (child.componentName === "Port") {
+            child._markDirty?.("PcbPortRender")
+          }
+        }
+        component._markDirty("InitializePortsFromChildren")
+      } catch (err) {
+        const db = component.root?.db
+        if (db && component.source_component_id && component.pcb_component_id) {
+          const subcircuit = component.getSubcircuit()
+          const errorMsg =
+            `${component.getString()} failed to load external footprint "${footprint}": ` +
+            (err instanceof Error ? err.message : String(err))
+          const errorObj = external_footprint_load_error.parse({
+            type: "external_footprint_load_error",
+            message: errorMsg,
+            pcb_component_id: component.pcb_component_id,
+            source_component_id: component.source_component_id,
+            subcircuit_id: subcircuit.subcircuit_id ?? undefined,
+            pcb_group_id: component.getGroup()?.pcb_group_id ?? undefined,
+            footprinter_string: footprint,
+          })
+          db.external_footprint_load_error.insert(errorObj)
+        }
+        throw err
       }
-      component._markDirty("InitializePortsFromChildren")
     })
     return
   }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bun-match-svg": "0.0.12",
     "calculate-elbow": "^0.0.12",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.246",
+    "circuit-json": "^0.0.247",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.22",
     "circuit-json-to-simple-3d": "^0.0.6",

--- a/tests/external_footprint_load_error.test.ts
+++ b/tests/external_footprint_load_error.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test"
+import {
+  external_footprint_load_error,
+  any_circuit_element,
+} from "circuit-json"
+
+test("external_footprint_load_error parses", () => {
+  const error = external_footprint_load_error.parse({
+    type: "external_footprint_load_error",
+    message: "failed to load footprint",
+    pcb_component_id: "pcb1",
+    source_component_id: "src1",
+  })
+  expect(error.external_footprint_load_error_id).toBeDefined()
+  expect(
+    error.external_footprint_load_error_id.startsWith(
+      "external_footprint_load_error",
+    ),
+  ).toBe(true)
+})
+
+test("any_circuit_element includes external_footprint_load_error", () => {
+  const parsed = any_circuit_element.parse({
+    type: "external_footprint_load_error",
+    message: "failed to load footprint",
+    pcb_component_id: "pcb1",
+    source_component_id: "src1",
+  })
+  expect(parsed.type).toBe("external_footprint_load_error")
+})

--- a/tests/footprint/footprint-library-map-error.test.tsx
+++ b/tests/footprint/footprint-library-map-error.test.tsx
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("footprint library map error attaches to db", async () => {
+  const { circuit } = getTestFixture({
+    platform: {
+      footprintLibraryMap: {
+        kicad: async () => {
+          throw new Error("footprint not found")
+        },
+      },
+    },
+  })
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor
+        name="R1"
+        resistance="10k"
+        footprint="kicad:Resistor_SMD.pretty/R_0402_1005Metric"
+        pcbX={0}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.external_footprint_load_error.list()
+  expect(errors).toHaveLength(1)
+  const r1 = circuit.selectOne(".R1") as any
+  expect(errors[0].message).toContain("footprint not found")
+  expect(errors[0].message).toContain(
+    "kicad:Resistor_SMD.pretty/R_0402_1005Metric",
+  )
+  expect(errors[0].message).toContain(r1.getString())
+  expect(errors[0].footprinter_string).toBe(
+    "kicad:Resistor_SMD.pretty/R_0402_1005Metric",
+  )
+})


### PR DESCRIPTION
## Summary
- handle async footprint URL and library failures by inserting `external_footprint_load_error` into the circuit DB
- add tests for `external_footprint_load_error` and footprint library map errors
- update `circuit-json` dependency to latest
- include component identifier and footprint source in error messages

## Testing
- `bun test tests/external_footprint_load_error.test.ts`
- `bun test tests/footprint`


------
https://chatgpt.com/codex/tasks/task_b_68bfbb644b18832e95b9a2cc4559e06c