### PR TITLE
fix: honor pcbMargin in pcb packing

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
@@ -29,11 +29,35 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
 
   const gap = pcbPackGap ?? pcbGap ?? gapProp
   const gapMm = length.parse(gap ?? DEFAULT_MIN_GAP)
+
+  const chipMarginsMap: Record<
+    string,
+    { left: number; right: number; top: number; bottom: number }
+  > = {}
+
+  const collectMargins = (comp: any) => {
+    if (comp?.pcb_component_id && comp?._parsedProps) {
+      const props = comp._parsedProps
+      const left = length.parse(props.pcbMarginLeft ?? props.pcbMarginX ?? 0)
+      const right = length.parse(props.pcbMarginRight ?? props.pcbMarginX ?? 0)
+      const top = length.parse(props.pcbMarginTop ?? props.pcbMarginY ?? 0)
+      const bottom = length.parse(
+        props.pcbMarginBottom ?? props.pcbMarginY ?? 0,
+      )
+      if (left || right || top || bottom) {
+        chipMarginsMap[comp.pcb_component_id] = { left, right, top, bottom }
+      }
+    }
+    if (comp?.children) comp.children.forEach(collectMargins)
+  }
+
+  collectMargins(group)
   const packInput: PackInput = {
     ...convertPackOutputToPackInput(
       convertCircuitJsonToPackOutput(db.toArray(), {
         source_group_id: group.source_group_id!,
         shouldAddInnerObstacles: true,
+        chipMarginsMap,
       }),
     ),
     // @ts-expect-error we're missing some pack order strategies

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "dependencies": {
     "@flatten-js/core": "^1.6.2",
     "@lume/kiwi": "^0.4.3",
-    "calculate-packing": "0.0.33",
+    "calculate-packing": "0.0.34",
     "css-select": "5.1.0",
     "format-si-unit": "^0.0.3",
     "nanoid": "^5.0.7",

--- a/tests/features/pcb-pack-layout/pcb-pack-chip-margin.test.tsx
+++ b/tests/features/pcb-pack-layout/pcb-pack-chip-margin.test.tsx
@@ -1,0 +1,37 @@
+import { test, expect, spyOn } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { length } from "circuit-json"
+import * as calc from "calculate-packing"
+
+// Ensure pcbMarginY is forwarded to calculate-packing via chipMarginsMap
+
+test("pcbPack forwards component pcbMargin to calculate-packing", () => {
+  const { circuit } = getTestFixture()
+  let captured: any = null
+  const original = calc.convertCircuitJsonToPackOutput
+  const spy = spyOn(calc, "convertCircuitJsonToPackOutput")
+  spy.mockImplementation((cj: any, opts: any) => {
+    captured = opts
+    return original(cj, opts)
+  })
+
+  circuit.add(
+    <board pcbPack pcbGap="0mm">
+      <resistor name="R1" resistance="1k" footprint="0402" pcbMarginY="3mm" />
+      <resistor name="R2" resistance="1k" footprint="0402" />
+    </board>,
+  )
+
+  circuit.render()
+  spy.mockRestore()
+
+  expect(captured?.chipMarginsMap).toBeDefined()
+  expect(Object.keys(captured.chipMarginsMap)).toHaveLength(1)
+  const margin = Object.values<any>(captured.chipMarginsMap)[0]
+  expect(margin).toEqual({
+    left: 0,
+    right: 0,
+    top: length.parse("3mm"),
+    bottom: length.parse("3mm"),
+  })
+})


### PR DESCRIPTION
## Summary
- pass component pcbMargin values to `calculate-packing` using `chipMarginsMap`
- add test ensuring pcbMargin reaches packing library

## Testing
- `bunx tsc --noEmit`
- `bun test tests/features/pcb-pack-layout`


------
https://chatgpt.com/codex/tasks/task_b_68c331c17fd0832e891fcce1ab485acb