### PR TITLE
feat: support pcb position anchor

### DIFF
--- a/docs/RENDER_PHASES.md
+++ b/docs/RENDER_PHASES.md
@@ -50,6 +50,8 @@ The render phases in @tscircuit/core are defined in the `Renderable` class (`Ren
 
 24. PcbComponentSizeCalculation: Calculates the size of PCB components.
 
-25. CadModelRender: Renders 3D CAD models of components.
+25. PcbComponentAnchorAlignment: Aligns PCB component center based on a specified anchor point.
+
+26. CadModelRender: Renders 3D CAD models of components.
 
 Each of these phases is executed in order for every component in the project during the rendering process. Components can implement specific logic for each phase by defining methods like `doInitial<PhaseName>`, `update<PhaseName>`, or `remove<PhaseName>`.

--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -58,6 +58,7 @@ import { NormalComponent_doInitialSourceDesignRuleChecks } from "./NormalCompone
 import { NormalComponent_doInitialSilkscreenOverlapAdjustment } from "./NormalComponent_doInitialSilkscreenOverlapAdjustment"
 import { filterPinLabels } from "lib/utils/filterPinLabels"
 import { NormalComponent_doInitialPcbFootprintStringRender } from "./NormalComponent_doInitialPcbFootprintStringRender"
+import { NormalComponent_doInitialPcbComponentAnchorAlignment } from "./NormalComponent_doInitialPcbComponentAnchorAlignment"
 import { isFootprintUrl } from "./utils/isFoorprintUrl"
 import { parseLibraryFootprintRef } from "./utils/parseLibraryFootprintRef"
 
@@ -764,6 +765,14 @@ export class NormalComponent<
 
   updatePcbComponentSizeCalculation(): void {
     this.doInitialPcbComponentSizeCalculation()
+  }
+
+  doInitialPcbComponentAnchorAlignment(): void {
+    NormalComponent_doInitialPcbComponentAnchorAlignment(this)
+  }
+
+  updatePcbComponentAnchorAlignment(): void {
+    this.doInitialPcbComponentAnchorAlignment()
   }
 
   _renderReactSubtree(element: ReactElement): ReactSubtree {

--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbComponentAnchorAlignment.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbComponentAnchorAlignment.ts
@@ -1,0 +1,101 @@
+import { NormalComponent } from "./NormalComponent"
+import { getBoundsOfPcbComponents } from "lib/utils/get-bounds-of-pcb-components"
+import { Port } from "../../primitive-components/Port"
+
+export function NormalComponent_doInitialPcbComponentAnchorAlignment(
+  component: NormalComponent<any, any>,
+): void {
+  if (component.root?.pcbDisabled) return
+  if (!component.pcb_component_id) return
+
+  const { pcbX, pcbY } = component._parsedProps as any
+  const pcbPositionAnchor = (component.props as any)?.pcbPositionAnchor
+  if (!pcbPositionAnchor) return
+  if (pcbX === undefined && pcbY === undefined) return
+
+  const bounds = getBoundsOfPcbComponents(component.children)
+
+  if (bounds.width === 0 || bounds.height === 0) return
+
+  const center = {
+    x: (bounds.minX + bounds.maxX) / 2,
+    y: (bounds.minY + bounds.maxY) / 2,
+  }
+
+  const currentCenter = { ...center }
+  let anchorPos: { x: number; y: number } | null = null
+
+  const ninePointAnchors = new Set([
+    "center",
+    "top_left",
+    "top_center",
+    "top_right",
+    "center_left",
+    "center_right",
+    "bottom_left",
+    "bottom_center",
+    "bottom_right",
+  ])
+
+  if (ninePointAnchors.has(pcbPositionAnchor)) {
+    const b = {
+      left: bounds.minX,
+      right: bounds.maxX,
+      top: bounds.minY,
+      bottom: bounds.maxY,
+    }
+    switch (pcbPositionAnchor) {
+      case "center":
+        anchorPos = currentCenter
+        break
+      case "top_left":
+        anchorPos = { x: b.left, y: b.top }
+        break
+      case "top_center":
+        anchorPos = { x: currentCenter.x, y: b.top }
+        break
+      case "top_right":
+        anchorPos = { x: b.right, y: b.top }
+        break
+      case "center_left":
+        anchorPos = { x: b.left, y: currentCenter.y }
+        break
+      case "center_right":
+        anchorPos = { x: b.right, y: currentCenter.y }
+        break
+      case "bottom_left":
+        anchorPos = { x: b.left, y: b.bottom }
+        break
+      case "bottom_center":
+        anchorPos = { x: currentCenter.x, y: b.bottom }
+        break
+      case "bottom_right":
+        anchorPos = { x: b.right, y: b.bottom }
+        break
+    }
+  } else {
+    try {
+      const port = (component.portMap as any)[pcbPositionAnchor as any] as
+        | Port
+        | undefined
+      if (port) {
+        anchorPos = port._getGlobalPcbPositionBeforeLayout()
+      }
+    } catch {
+      // ignore if port not found
+    }
+  }
+
+  if (!anchorPos) return
+
+  const newCenter = { ...currentCenter }
+  if (pcbX !== undefined) newCenter.x += pcbX - anchorPos.x
+  if (pcbY !== undefined) newCenter.y += pcbY - anchorPos.y
+
+  if (
+    Math.abs(newCenter.x - currentCenter.x) > 1e-6 ||
+    Math.abs(newCenter.y - currentCenter.y) > 1e-6
+  ) {
+    component._repositionOnPcb(newCenter)
+  }
+}

--- a/lib/components/base-components/Renderable.ts
+++ b/lib/components/base-components/Renderable.ts
@@ -39,6 +39,7 @@ export const orderedRenderPhases = [
   "PcbPortRender",
   "PcbPortAttachment",
   "PcbComponentSizeCalculation",
+  "PcbComponentAnchorAlignment",
   "PcbLayout",
   "PcbBoardAutoSize",
   "PcbTraceHintRender",
@@ -69,6 +70,7 @@ const asyncPhaseDependencies: Partial<Record<RenderPhase, RenderPhase[]>> = {
   SilkscreenOverlapAdjustment: ["PcbFootprintStringRender"],
   CadModelRender: ["PcbFootprintStringRender"],
   PartsEngineRender: ["PcbFootprintStringRender"],
+  PcbComponentAnchorAlignment: ["PcbFootprintStringRender"],
 }
 
 export type RenderPhaseFn<K extends RenderPhase = RenderPhase> =

--- a/tests/components/normal-components/pcb-position-anchor-nine-point.test.tsx
+++ b/tests/components/normal-components/pcb-position-anchor-nine-point.test.tsx
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Ensure pcbPositionAnchor aligns component by specified NinePointAnchor
+
+test("pcbPositionAnchor with NinePointAnchor", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0402"
+      pcbX={10}
+      pcbY={20}
+      pcbPositionAnchor="top_left"
+    />,
+  )
+
+  circuit.render()
+
+  const resistor = circuit.selectOne(".R1")
+  const bounds = resistor!._getPcbCircuitJsonBounds().bounds
+
+  expect(bounds.left).toBeCloseTo(10)
+  expect(bounds.top).toBeCloseTo(20)
+})

--- a/tests/components/normal-components/pcb-position-anchor-pin-label.test.tsx
+++ b/tests/components/normal-components/pcb-position-anchor-pin-label.test.tsx
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Ensure pcbPositionAnchor aligns to a specific pin label
+
+test("pcbPositionAnchor with pin label", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0402"
+      pcbX={15}
+      pcbY={5}
+      pcbPositionAnchor="pin1"
+    />,
+  )
+
+  circuit.render()
+
+  const resistor = circuit.selectOne(".R1")
+  const pin1Pos =
+    (resistor as any)!.portMap.pin1._getGlobalPcbPositionAfterLayout()
+
+  expect(pin1Pos.x).toBeCloseTo(15)
+  expect(pin1Pos.y).toBeCloseTo(5)
+})


### PR DESCRIPTION
## Summary
- allow components to anchor pcbX/pcbY to pins or nine-point positions via `pcbPositionAnchor`
- align components during new `PcbComponentAnchorAlignment` render phase
- test pcbPositionAnchor with pin labels and nine-point anchors

## Testing
- `bunx tsc --noEmit && echo tsc_success`
- `bun test tests/components/normal-components/pcb-position-anchor-nine-point.test.tsx`
- `bun test tests/components/normal-components/pcb-position-anchor-pin-label.test.tsx`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68c458dad954832ebb139ad497df0344