### PR TITLE
feat: retry bun tests on segfault

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -23,4 +23,18 @@ jobs:
         run: bun install
 
       - name: Run tests
-        run: bun test --timeout 10000
+        run: |
+          set +e
+          for i in 1 2 3; do
+            bun test --timeout 10000
+            code=$?
+            if [ $code -eq 0 ]; then
+              exit 0
+            fi
+            if [ $code -ne 139 ]; then
+              exit $code
+            fi
+            echo "Segmentation fault detected, retrying ($i/3)..."
+          done
+          echo "Tests failed due to segmentation fault after 3 attempts."
+          exit 139


### PR DESCRIPTION
## Summary
- rerun `bun test` in workflow when a segmentation fault occurs

## Testing
- `bun test` *(fails: subcircuit3-dependent-autorouting; group schematic matchpack respects schMarginX)*
- `bunx tsc --noEmit`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68c4d3f406b4832e8476d339e6e08c1e