### PR TITLE
feat: respect pcb pack bounds

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
@@ -66,6 +66,17 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
     minGap: gapMm,
   }
 
+  if (props.width !== undefined && props.height !== undefined) {
+    const width = length.parse(props.width)
+    const height = length.parse(props.height)
+    packInput.bounds = {
+      minX: -width / 2,
+      minY: -height / 2,
+      maxX: width / 2,
+      maxY: height / 2,
+    }
+  }
+
   const clusterMap = applyComponentConstraintClusters(group, packInput)
 
   if (debug.enabled) {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "dependencies": {
     "@flatten-js/core": "^1.6.2",
     "@lume/kiwi": "^0.4.3",
-    "calculate-packing": "0.0.37",
+    "calculate-packing": "0.0.40",
     "css-select": "5.1.0",
     "format-si-unit": "^0.0.3",
     "nanoid": "^5.0.7",

--- a/tests/features/pcb-pack-layout/pcb-pack-bounds.test.tsx
+++ b/tests/features/pcb-pack-layout/pcb-pack-bounds.test.tsx
@@ -1,0 +1,27 @@
+import { test, expect, vi } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import * as cp from "calculate-packing"
+
+test("pcbPack uses bounds when width and height are defined", () => {
+  const packSpy = vi.spyOn(cp, "pack")
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board pcbPack width="30mm" height="20mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <resistor name="R2" resistance="1k" footprint="0402" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const call = packSpy.mock.calls.find(
+    ([input]) => input.components.length === 2,
+  )
+  expect(call?.[0].bounds).toEqual({
+    minX: -15,
+    minY: -10,
+    maxX: 15,
+    maxY: 10,
+  })
+})


### PR DESCRIPTION
## Summary
- support packing bounds when group width and height are set
- update calculate-packing to 0.0.40
- add regression test for bounds

## Testing
- `bunx tsc --noEmit`
- `bun test tests/features/pcb-pack-layout`

------
https://chatgpt.com/codex/tasks/task_b_68c75ca6e638832e832e7dba2bd5a287