### PR TITLE
fix: cad_component not having the accumulated group rotation

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -1247,7 +1247,8 @@ export class NormalComponent<
     // Get the accumulated rotation from the global transform
     const globalTransform = this._computePcbGlobalTransformBeforeLayout()
     const decomposedTransform = decomposeTSR(globalTransform)
-    const accumulatedRotation = (decomposedTransform.rotation.angle * 180) / Math.PI
+    const accumulatedRotation =
+      (decomposedTransform.rotation.angle * 180) / Math.PI
 
     const cad_model = db.cad_component.insert({
       // TODO z maybe depends on layer

--- a/lib/components/primitive-components/CadModel.ts
+++ b/lib/components/primitive-components/CadModel.ts
@@ -34,7 +34,8 @@ export class CadModel extends PrimitiveComponent<typeof cadmodelProps> {
     // Get the accumulated rotation from the parent's global transform
     const parentTransform = parent._computePcbGlobalTransformBeforeLayout()
     const decomposedTransform = decomposeTSR(parentTransform)
-    const accumulatedRotation = (decomposedTransform.rotation.angle * 180) / Math.PI
+    const accumulatedRotation =
+      (decomposedTransform.rotation.angle * 180) / Math.PI
 
     const rotationOffset = rotation3.parse({ x: 0, y: 0, z: 0 })
     if (typeof props.rotationOffset === "number") {

--- a/lib/components/primitive-components/CadModel.ts
+++ b/lib/components/primitive-components/CadModel.ts
@@ -3,6 +3,7 @@ import { PrimitiveComponent } from "../base-components/PrimitiveComponent"
 import type { CadModelProps } from "@tscircuit/props"
 import { z } from "zod"
 import type { CadComponent } from "circuit-json"
+import { decomposeTSR } from "transformation-matrix"
 
 const rotation = z.union([z.number(), z.string()])
 const rotation3 = z.object({ x: rotation, y: rotation, z: rotation })
@@ -29,6 +30,11 @@ export class CadModel extends PrimitiveComponent<typeof cadmodelProps> {
     const props = this._parsedProps as CadModelProps
 
     if (!props || typeof props.modelUrl !== "string") return
+
+    // Get the accumulated rotation from the parent's global transform
+    const parentTransform = parent._computePcbGlobalTransformBeforeLayout()
+    const decomposedTransform = decomposeTSR(parentTransform)
+    const accumulatedRotation = (decomposedTransform.rotation.angle * 180) / Math.PI
 
     const rotationOffset = rotation3.parse({ x: 0, y: 0, z: 0 })
     if (typeof props.rotationOffset === "number") {
@@ -78,8 +84,8 @@ export class CadModel extends PrimitiveComponent<typeof cadmodelProps> {
         y: (layer === "top" ? 0 : 180) + Number(rotationOffset.y),
         z:
           layer === "bottom"
-            ? -((pcb_component?.rotation ?? 0) + Number(rotationOffset.z)) + 180
-            : (pcb_component?.rotation ?? 0) + Number(rotationOffset.z),
+            ? -(accumulatedRotation + Number(rotationOffset.z)) + 180
+            : accumulatedRotation + Number(rotationOffset.z),
       },
       pcb_component_id: parent.pcb_component_id,
       source_component_id: parent.source_component_id,

--- a/tests/components/primitive-components/group-rotation-for-cad-component.test.tsx
+++ b/tests/components/primitive-components/group-rotation-for-cad-component.test.tsx
@@ -1,0 +1,51 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("group rotation on the cad model", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <group name="group1" pcbRotation={45}>
+      <chip
+        name="U1"
+        footprint="soic8"
+        cadModel={{
+          stlUrl: "https://example.com/test.stl"
+        }}
+      />
+    </group>,
+  )
+
+  circuit.render()
+
+  const cad_component = circuit.db.cad_component.list()[0]
+  expect(cad_component).toMatchInlineSnapshot(`
+    {
+      "cad_component_id": "cad_component_0",
+      "footprinter_string": undefined,
+      "model_glb_url": undefined,
+      "model_gltf_url": undefined,
+      "model_jscad": undefined,
+      "model_mtl_url": undefined,
+      "model_obj_url": undefined,
+      "model_step_url": undefined,
+      "model_stl_url": "https://example.com/test.stl",
+      "model_unit_to_mm_scale_factor": undefined,
+      "model_wrl_url": undefined,
+      "pcb_component_id": "pcb_component_0",
+      "position": {
+        "x": 0,
+        "y": 0,
+        "z": 0,
+      },
+      "rotation": {
+        "x": 0,
+        "y": 0,
+        "z": 45,
+      },
+      "source_component_id": "source_component_0",
+      "type": "cad_component",
+    }
+  `)
+
+})

--- a/tests/components/primitive-components/group-rotation-for-cad-component.test.tsx
+++ b/tests/components/primitive-components/group-rotation-for-cad-component.test.tsx
@@ -10,7 +10,7 @@ test("group rotation on the cad model", async () => {
         name="U1"
         footprint="soic8"
         cadModel={{
-          stlUrl: "https://example.com/test.stl"
+          stlUrl: "https://example.com/test.stl",
         }}
       />
     </group>,
@@ -47,5 +47,4 @@ test("group rotation on the cad model", async () => {
       "type": "cad_component",
     }
   `)
-
 })


### PR DESCRIPTION
Before

<img width="1156" height="840" alt="image" src="https://github.com/user-attachments/assets/ba5ff596-1c48-4424-8b7f-791ff08049a5" />


After

<img width="1104" height="1166" alt="image" src="https://github.com/user-attachments/assets/6935be21-d2ba-43cd-aca2-aad4d14bb643" />
