### PR TITLE
Avoid solder paste on solder-masked SMT pads

### DIFF
--- a/tests/components/normal-components/smtpad-covered-with-soldermask.test.tsx
+++ b/tests/components/normal-components/smtpad-covered-with-soldermask.test.tsx
@@ -30,4 +30,5 @@ test("smtpad coveredWithSolderMask sets is_covered_with_solder_mask", () => {
 
   const pad = project.db.pcb_smtpad.list()[0]
   expect(pad.is_covered_with_solder_mask).toBe(true)
+  expect(project.db.pcb_solder_paste.list()).toHaveLength(0)
 })


### PR DESCRIPTION
## Summary
- avoid creating solder paste records when an SMT pad is covered with solder mask
- skip solder paste position updates when no paste entry exists for a pad
- extend the solder mask unit test to assert solder paste is not generated

## Testing
- bun test tests/components/normal-components/smtpad-covered-with-soldermask.test.tsx
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68dac122528c832ebad0af4223bebb4b