### PR TITLE
Fix pack shifting imported board outlines

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -311,7 +311,12 @@ export class Board extends Group<typeof boardProps> {
         y: point.y + (props.outlineOffsetY ?? 0),
       })),
       material: props.material,
-    })
+      is_subcircuit: this.isSubcircuit,
+      subcircuit_id: this.subcircuit_id ?? this.getSubcircuit()?.subcircuit_id,
+      // Associate the board outline with the board's source group so it can
+      // follow pack transformations applied to child groups.
+      source_group_id: this.source_group_id!,
+    } as any)
 
     this.pcb_board_id = pcb_board.pcb_board_id!
 

--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/applyPackOutput.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/applyPackOutput.ts
@@ -104,12 +104,24 @@ export const applyPackOutput = (
       translate(-originalCenter.x, -originalCenter.y),
     )
 
+    const componentGroup = db.source_group.get(componentId)
+    const parentGroupId = componentGroup?.parent_source_group_id
+    const parentGroup = parentGroupId
+      ? db.source_group.get(parentGroupId)
+      : undefined
+
     const relatedElements = db.toArray().filter((elm) => {
       if ("source_group_id" in elm && elm.source_group_id) {
         if (elm.source_group_id === componentId) {
           return true
         }
         if (isDescendantGroup(db, elm.source_group_id, componentId)) {
+          return true
+        }
+        if (
+          parentGroup?.is_subcircuit &&
+          elm.source_group_id === parentGroupId
+        ) {
           return true
         }
       }


### PR DESCRIPTION
## Summary
- associate pcb_board entries with their board groups so they follow pack transforms
- include parent subcircuit elements when applying packed group transforms to keep board outlines aligned

## Testing
- bun test tests/pcb-packing/repros/repro1-packing-imported-board.test.tsx
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e1b1782fd4832e96c7de9381400868