### PR TITLE
Update circuit-json and record auto-named source groups

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -62,9 +62,14 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
 
   doInitialSourceGroupRender() {
     const { db } = this.root!
+    const hasExplicitName =
+      typeof (this._parsedProps as { name?: unknown }).name === "string" &&
+      (this._parsedProps as { name?: string }).name!.length > 0
+
     const source_group = db.source_group.insert({
       name: this.name,
       is_subcircuit: this.isSubcircuit,
+      was_automatically_named: !hasExplicitName,
     })
     this.source_group_id = source_group.source_group_id
     if (this.isSubcircuit) {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "bun-match-svg": "0.0.12",
     "calculate-elbow": "^0.0.12",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.272",
+    "circuit-json": "^0.0.273",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.22",
     "circuit-json-to-gltf": "^0.0.7",

--- a/tests/components/primitive-components/group-subcircuit-id.test.tsx
+++ b/tests/components/primitive-components/group-subcircuit-id.test.tsx
@@ -26,6 +26,7 @@ test("Subcircuit group should have subcircuit_id", async () => {
     "source_group_id": "source_group_0",
     "subcircuit_id": "subcircuit_source_group_0",
     "type": "source_group",
+    "was_automatically_named": false,
   },
 ]
 `)

--- a/tests/components/primitive-components/parent-source-group-id.test.tsx
+++ b/tests/components/primitive-components/parent-source-group-id.test.tsx
@@ -27,6 +27,7 @@ test("nested group has parent_source_group_id", async () => {
         "parent_source_group_id": "source_group_1",
         "source_group_id": "source_group_0",
         "type": "source_group",
+        "was_automatically_named": false,
       },
       {
         "is_subcircuit": undefined,
@@ -34,6 +35,7 @@ test("nested group has parent_source_group_id", async () => {
         "parent_source_group_id": "source_group_2",
         "source_group_id": "source_group_1",
         "type": "source_group",
+        "was_automatically_named": false,
       },
       {
         "is_subcircuit": true,
@@ -41,6 +43,7 @@ test("nested group has parent_source_group_id", async () => {
         "source_group_id": "source_group_2",
         "subcircuit_id": "subcircuit_source_group_2",
         "type": "source_group",
+        "was_automatically_named": true,
       },
     ]
   `)


### PR DESCRIPTION
## Summary
- bump circuit-json to the latest release
- flag source groups that rely on automatically generated names when inserting them
- refresh affected inline snapshots to include the new metadata

## Testing
- bun test tests/components/primitive-components
- bun test tests/groups
- bun test tests/components/normal-components
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e582959e1c832e8ec01266defd2f83