### PR TITLE
Reuse shared file extension utility for cad models

### DIFF
--- a/lib/components/base-components/NormalComponent/utils/getFileExtension.ts
+++ b/lib/components/base-components/NormalComponent/utils/getFileExtension.ts
@@ -1,5 +1,13 @@
 export const getFileExtension = (filename: string | null) => {
   if (!filename) return null
-  const cleanFilename = filename.split("?")[0]
-  return cleanFilename.split(".").pop()
+
+  const withoutQuery = filename.split("?")[0]
+  const sanitized = withoutQuery.split("#")[0]
+  const lastSegment = sanitized.split("/").pop() ?? sanitized
+
+  if (!lastSegment.includes(".")) return null
+
+  const extension = lastSegment.split(".").pop()
+
+  return extension?.toLowerCase() ?? null
 }

--- a/lib/components/primitive-components/CadModel.ts
+++ b/lib/components/primitive-components/CadModel.ts
@@ -4,6 +4,7 @@ import type { CadModelProps } from "@tscircuit/props"
 import { z } from "zod"
 import type { CadComponent } from "circuit-json"
 import { decomposeTSR } from "transformation-matrix"
+import { getFileExtension } from "../base-components/NormalComponent/utils/getFileExtension"
 
 const rotation = z.union([z.number(), z.string()])
 const rotation3 = z.object({ x: rotation, y: rotation, z: rotation })
@@ -56,7 +57,7 @@ export class CadModel extends PrimitiveComponent<typeof cadmodelProps> {
 
     const layer = parent.props.layer === "bottom" ? "bottom" : "top"
 
-    const ext = new URL(props.modelUrl).pathname.split(".").pop()?.toLowerCase()
+    const ext = getFileExtension(props.modelUrl)
     const urlProps: Partial<CadComponent> = {}
     if (ext === "stl")
       urlProps.model_stl_url = this._addCachebustToModelUrl(props.modelUrl)

--- a/tests/components/normal-components/chip-cad-model-glb-absolute-path.test.tsx
+++ b/tests/components/normal-components/chip-cad-model-glb-absolute-path.test.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+import "lib/register-catalogue"
+
+test("chip cadModel glbUrl accepts absolute path", () => {
+  const { project } = getTestFixture()
+
+  project.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pcbX={0}
+        pcbY={0}
+        cadModel={{
+          glbUrl: "/mymodels/model.glb",
+        }}
+      />
+    </board>,
+  )
+
+  project.render()
+
+  const cadComponent = project.db.cad_component.list()[0]
+  expect(cadComponent.model_glb_url).toBe("/mymodels/model.glb")
+})

--- a/tests/components/primitive-components/cadmodel-absolute-path.test.tsx
+++ b/tests/components/primitive-components/cadmodel-absolute-path.test.tsx
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+import "lib/register-catalogue"
+
+test("cadmodel primitive accepts absolute modelUrl", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor
+        name="R1"
+        resistance={1000}
+        footprint="0402"
+        cadModel={<cadmodel modelUrl="/mymodels/model.glb" pcbX={1} />}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const cadComponents = circuit.db.cad_component.list()
+  expect(cadComponents).toHaveLength(1)
+  expect(cadComponents[0].model_glb_url).toBe("/mymodels/model.glb")
+})


### PR DESCRIPTION
## Summary
- reuse the shared `getFileExtension` helper in the cad model primitive so absolute paths are handled consistently
- extend the helper to strip query/hash fragments, handle path segments, and normalize the returned extension

## Testing
- bun test tests/components/primitive-components/cadmodel-absolute-path.test.tsx
- bun test tests/components/normal-components/chip-cad-model-glb-absolute-path.test.tsx
- bun test tests/components/normal-components/chip-cad-model-gltf.test.tsx
- bun test tests/footprint
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68e9554b0078832e8e943aab43ddd94d