### PR TITLE
repro: unnamed chips receive sequential unnamed_chip fallback names

### DIFF
--- a/tests/repros/repro61-unnamed-chips.test.tsx
+++ b/tests/repros/repro61-unnamed-chips.test.tsx
@@ -27,7 +27,7 @@ test("unnamed chips receive sequential unnamed_chip fallback names", async () =>
           pin2: ["A2"],
         }}
       />
-      <trace from=".unnamed_chip1 > .pin1" to="unnamed_chip2 > .pin1" />
+      <trace from=".unnamed_chip1 > .pin1" to=".unnamed_chip2 > .pin1" />
     </board>,
   )
 


### PR DESCRIPTION
repro for #1467 