### PR TITLE
Respect board thickness for cadmodel offsets

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -12,6 +12,7 @@ import type {
   CadModelWrl,
 } from "@tscircuit/props"
 import {
+  distance,
   pcb_manual_edit_conflict_warning,
   point3,
   rotation,
@@ -938,7 +939,7 @@ export class NormalComponent<
     }
 
     // Add React-based cadModel subtree (CadAssembly or CadModel) if provided
-    const cmElm = this.props.cadModel as any
+    const cmElm = this.props.cadModel
     if (isValidElement(cmElm)) {
       // Mark that CAD will be handled by child elements to avoid parent inserting a CAD model
       this._isCadModelChild = true
@@ -1293,6 +1294,17 @@ export class NormalComponent<
         : {}),
     })
 
+    const zOffsetFromSurface =
+      cadModel &&
+      typeof cadModel === "object" &&
+      "zOffsetFromSurface" in cadModel
+        ? cadModel.zOffsetFromSurface !== undefined
+          ? distance.parse(
+              (cadModel as { zOffsetFromSurface?: unknown }).zOffsetFromSurface,
+            )
+          : 0
+        : 0
+
     const computedLayer = this.props.layer === "bottom" ? "bottom" : "top"
 
     // Get the accumulated rotation from the global transform
@@ -1309,7 +1321,11 @@ export class NormalComponent<
         z:
           (computedLayer === "bottom"
             ? -boardThickness / 2
-            : boardThickness / 2) + positionOffset.z,
+            : boardThickness / 2) +
+          (computedLayer === "bottom"
+            ? -zOffsetFromSurface
+            : zOffsetFromSurface) +
+          positionOffset.z,
       },
       rotation: {
         x: rotationOffset.x,

--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -90,7 +90,7 @@ export class Board extends Group<typeof boardProps> {
 
   get boardThickness() {
     const { _parsedProps: props } = this
-    return 1.4 // TODO use prop
+    return props.thickness ?? 1.4
   }
 
   /**

--- a/lib/components/primitive-components/CadModel.ts
+++ b/lib/components/primitive-components/CadModel.ts
@@ -3,6 +3,7 @@ import { PrimitiveComponent } from "../base-components/PrimitiveComponent"
 import type { CadModelProps } from "@tscircuit/props"
 import { z } from "zod"
 import type { CadComponent } from "circuit-json"
+import { distance } from "circuit-json"
 import { decomposeTSR } from "transformation-matrix"
 import { getFileExtension } from "../base-components/NormalComponent/utils/getFileExtension"
 
@@ -55,6 +56,11 @@ export class CadModel extends PrimitiveComponent<typeof cadmodelProps> {
       ...(typeof props.positionOffset === "object" ? props.positionOffset : {}),
     })
 
+    const zOffsetFromSurface =
+      props.zOffsetFromSurface !== undefined
+        ? distance.parse(props.zOffsetFromSurface)
+        : 0
+
     const layer = parent.props.layer === "bottom" ? "bottom" : "top"
 
     const ext = getFileExtension(props.modelUrl)
@@ -79,6 +85,7 @@ export class CadModel extends PrimitiveComponent<typeof cadmodelProps> {
         y: bounds.center.y + Number(positionOffset.y),
         z:
           (layer === "bottom" ? -boardThickness / 2 : boardThickness / 2) +
+          (layer === "bottom" ? -zOffsetFromSurface : zOffsetFromSurface) +
           Number(positionOffset.z),
       },
       rotation: {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tscircuit/matchpack": "^0.0.16",
     "@tscircuit/math-utils": "^0.0.21",
     "@tscircuit/miniflex": "^0.0.4",
-    "@tscircuit/props": "0.0.361",
+    "@tscircuit/props": "0.0.363",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/schematic-trace-solver": "^0.0.41",

--- a/tests/components/primitive-components/cadmodel-z-offset-from-surface.test.tsx
+++ b/tests/components/primitive-components/cadmodel-z-offset-from-surface.test.tsx
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+import "lib/register-catalogue"
+
+test("cadmodel primitive respects zOffsetFromSurface on top layer", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor
+        name="R1"
+        resistance={1000}
+        footprint="0402"
+        cadModel={
+          <cadmodel
+            modelUrl="https://example.com/model.glb"
+            zOffsetFromSurface="1mm"
+          />
+        }
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const cadComponents = circuit.db.cad_component.list()
+  expect(cadComponents).toHaveLength(1)
+  expect(cadComponents[0].position.z).toBeCloseTo(1.4 / 2 + 1, 5)
+})
+
+test("cadmodel primitive respects zOffsetFromSurface on bottom layer", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor
+        name="R1"
+        resistance={1000}
+        footprint="0402"
+        layer="bottom"
+        cadModel={
+          <cadmodel
+            modelUrl="https://example.com/model.glb"
+            zOffsetFromSurface="1mm"
+          />
+        }
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const cadComponents = circuit.db.cad_component.list()
+  expect(cadComponents).toHaveLength(1)
+  expect(cadComponents[0].position.z).toBeCloseTo(-(1.4 / 2 + 1), 5)
+})
+
+test("cadmodel primitive uses board thickness when zOffsetFromSurface provided", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm" thickness="2.2mm">
+      <resistor
+        name="R1"
+        resistance={1000}
+        footprint="0402"
+        cadModel={
+          <cadmodel
+            modelUrl="https://example.com/model.glb"
+            zOffsetFromSurface="1mm"
+          />
+        }
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const cadComponents = circuit.db.cad_component.list()
+  expect(cadComponents).toHaveLength(1)
+  expect(cadComponents[0].position.z).toBeCloseTo(2.2 / 2 + 1, 5)
+})


### PR DESCRIPTION
## Summary
- read the board component's parsed thickness when calculating boardThickness
- update @tscircuit/props to 0.0.363 so cadmodel props expose zOffsetFromSurface
- add a cadmodel surface offset test that sets an explicit board thickness

## Testing
- bun test tests/components/primitive-components/cadmodel-z-offset-from-surface.test.tsx
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68eeafa1e468832eaceb15ab2b15da99