### PR TITLE
Validate component layer placement and emit error for invalid layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bun-match-svg": "0.0.12",
     "calculate-elbow": "^0.0.12",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.278",
+    "circuit-json": "^0.0.283",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.22",
     "circuit-json-to-gltf": "^0.0.7",

--- a/tests/components/normal-components/component-invalid-layer.test.tsx
+++ b/tests/components/normal-components/component-invalid-layer.test.tsx
@@ -1,0 +1,108 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("component on invalid layer should throw error", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="10k" layer="inner1" pcbX={0} pcbY={0} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const errors = circuit.db.pcb_component_invalid_layer_error.list()
+
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toContain(
+    "Component cannot be placed on layer 'inner1'",
+  )
+  expect(errors[0].layer).toBe("inner1")
+  expect(errors[0].source_component_id).toBeDefined()
+})
+
+test("chip on invalid layer should throw error", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        layer="inner2"
+        pcbX={0}
+        pcbY={0}
+        footprint={
+          <footprint>
+            <smtpad
+              shape="rect"
+              pcbX={0}
+              pcbY={0}
+              width="1mm"
+              height="1mm"
+              portHints={["1"]}
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const errors = circuit.db.pcb_component_invalid_layer_error.list()
+
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toContain(
+    "Component cannot be placed on layer 'inner2'",
+  )
+  expect(errors[0].layer).toBe("inner2")
+})
+
+test("component on top layer should not throw error", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="10k" layer="top" pcbX={0} pcbY={0} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const errors = circuit.db.pcb_component_invalid_layer_error.list()
+
+  expect(errors).toHaveLength(0)
+})
+
+test("component on bottom layer should not throw error", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="10k" layer="bottom" pcbX={0} pcbY={0} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const errors = circuit.db.pcb_component_invalid_layer_error.list()
+
+  expect(errors).toHaveLength(0)
+})
+
+test("component with default layer (top) should not throw error", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="10k" pcbX={0} pcbY={0} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const errors = circuit.db.pcb_component_invalid_layer_error.list()
+
+  expect(errors).toHaveLength(0)
+})


### PR DESCRIPTION
## PR Description

Components can now only be placed on 'top' or 'bottom' layers. Attempting to place a component on inner layers (inner1, inner2, etc.) will emit a pcb_component_invalid_layer_error while still creating the component with 'top' as a fallback to prevent cascading errors.

- Added layer validation in `NormalComponent.doInitialPcbComponentRender()` that emits `pcb_component_invalid_layer_error` when invalid layer is detected

- Added layer validation in `Chip.doInitialPcbComponentRender()` with same validation logic as `NormalComponent` since Chip overrides this method
- Created `component-invalid-layer.test.tsx` for both resistors & chips which tests valid layers (top, bottom) and default behavior
- Updated `circuit-json` dependency, bumped from ^0.0.278 to ^0.0.283 to support the new error type

fixes #1523 
/claim #1523 