### PR TITLE
Derive 3D camera preset positions from circuit geometry

### DIFF
--- a/tests/components/primitive-components/smtpad-bottom-rotation.test.tsx
+++ b/tests/components/primitive-components/smtpad-bottom-rotation.test.tsx
@@ -52,17 +52,13 @@ test("smt pads on the bottom layer preserve their rotation", async () => {
   expect(topPad).toBeDefined()
   expect(bottomPad).toBeDefined()
   expect(circuit).toMatchPcbSnapshot(import.meta.path)
-  expect(circuit).toMatchSimple3dSnapshot(
-    import.meta.path,
-
-    {
-      poppygl: {
-        width: 1280,
-        height: 1280,
-        ambient: 1,
-        gamma: 2.2,
-        camPos: [-20, -30, -30],
-      },
+  expect(circuit).toMatch3dSnapshot(import.meta.path, {
+    cameraPreset: "bottom_angled",
+    poppygl: {
+      width: 1280,
+      height: 1280,
+      ambient: 1,
+      gamma: 2.2,
     },
-  )
+  })
 })

--- a/tests/fixtures/extend-expect-3d-matcher.test.ts
+++ b/tests/fixtures/extend-expect-3d-matcher.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test"
+import { createElement } from "react"
+import { getTestFixture } from "./get-test-fixture"
+import { resolvePoppyglOptions } from "./extend-expect-3d-matcher"
+
+describe("resolvePoppyglOptions", () => {
+  it("merges poppygl options with top-level camera overrides", async () => {
+    const result = await resolvePoppyglOptions([], {
+      poppygl: {
+        width: 512,
+        height: 256,
+        camPos: [1, 2, 3],
+      },
+      camPos: [4, 5, 6],
+      cameraPreset: "bottom_angled",
+    })
+
+    expect(result).toEqual({
+      width: 512,
+      height: 256,
+      ambient: 0.2,
+      gamma: 2.2,
+      camPos: [4, 5, 6],
+      cameraPreset: "bottom_angled",
+    })
+  })
+
+  it("applies defaults when no options are provided", async () => {
+    await expect(resolvePoppyglOptions([])).resolves.toEqual({
+      width: 1024,
+      height: 1024,
+      ambient: 0.2,
+      gamma: 2.2,
+    })
+  })
+
+  it("derives a camera position from the bottom_angled preset", async () => {
+    const { circuit } = getTestFixture()
+
+    circuit.add(
+      createElement(
+        "board",
+        { width: "10mm", height: "10mm" },
+        createElement("resistor", {
+          name: "R1",
+          resistance: "1k",
+          footprint: "0402",
+          pcbX: 0,
+          pcbY: 0,
+        }),
+      ),
+    )
+
+    await circuit.renderUntilSettled()
+
+    const soup = circuit.getCircuitJson()
+    const result = await resolvePoppyglOptions(soup, {
+      cameraPreset: "bottom_angled",
+    })
+
+    expect(result.camPos).toBeDefined()
+    const [x, y, z] = result.camPos!
+    expect(y).toBeLessThan(0)
+
+    const { circuit: largerCircuit } = getTestFixture()
+    largerCircuit.add(
+      createElement(
+        "board",
+        { width: "40mm", height: "25mm" },
+        createElement("resistor", {
+          name: "R1",
+          resistance: "1k",
+          footprint: "0402",
+          pcbX: 5,
+          pcbY: -3,
+        }),
+      ),
+    )
+    await largerCircuit.renderUntilSettled()
+    const largerResult = await resolvePoppyglOptions(
+      largerCircuit.getCircuitJson(),
+      {
+        cameraPreset: "bottom_angled",
+      },
+    )
+
+    const baseRadius = Math.hypot(x, z)
+    const largerRadius = Math.hypot(
+      largerResult.camPos![0],
+      largerResult.camPos![2],
+    )
+    expect(largerRadius).toBeGreaterThan(baseRadius)
+  })
+})


### PR DESCRIPTION
## Summary
- derive poppygl camera overrides from circuit geometry so presets like `bottom_angled` resolve to deterministic camPos values
- disable GLTF board textures by default for the snapshot helper to avoid DOM-only fallbacks when resvg is absent
- cover the new camera resolver in unit tests and switch the SMT pad bottom rotation snapshot to use the preset API

## Testing
- bun test tests/fixtures/extend-expect-3d-matcher.test.ts
- bun test tests/components/primitive-components/smtpad-bottom-rotation.test.tsx
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68f51f8ec118832ebb408b662b9e97a8