### PR TITLE
Handle tiny board border radii

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -15,20 +15,32 @@ import type { RenderPhase } from "../base-components/Renderable"
 import { getDescendantSubcircuitIds } from "../../utils/autorouting/getAncestorSubcircuitIds"
 import { getBoundsFromPoints } from "@tscircuit/math-utils"
 
+const MIN_EFFECTIVE_BORDER_RADIUS_MM = 0.01
+
 const getRoundedRectOutline = (
   width: number,
   height: number,
   radius: number,
 ) => {
-  const r = Math.min(radius, width / 2, height / 2)
+  const w2 = width / 2
+  const h2 = height / 2
+  const r = Math.min(radius, w2, h2)
+
+  if (r < MIN_EFFECTIVE_BORDER_RADIUS_MM) {
+    return [
+      { x: -w2, y: -h2 },
+      { x: w2, y: -h2 },
+      { x: w2, y: h2 },
+      { x: -w2, y: h2 },
+    ]
+  }
+
   const maxArcLengthPerSegment = 0.1 // mm
   const segments = Math.max(
     1,
     Math.ceil(((Math.PI / 2) * r) / maxArcLengthPerSegment),
   )
   const step = Math.PI / 2 / segments
-  const w2 = width / 2
-  const h2 = height / 2
 
   const outline: { x: number; y: number }[] = []
 

--- a/tests/components/normal-components/board-border-radius.test.tsx
+++ b/tests/components/normal-components/board-border-radius.test.tsx
@@ -14,3 +14,24 @@ test("board borderRadius generates rounded outline", () => {
 
   expect(circuit).toMatchPcbSnapshot(import.meta.path)
 })
+
+test("borderRadius below threshold falls back to rectangular outline", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width={20} height={10} borderRadius={0.005}>
+      <resistor name="R1" resistance="10k" footprint="0402" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const board = circuit.db.pcb_board.list()[0]
+
+  expect(board.outline).toEqual([
+    { x: -10, y: -5 },
+    { x: 10, y: -5 },
+    { x: 10, y: 5 },
+    { x: -10, y: 5 },
+  ])
+})


### PR DESCRIPTION
## Summary
- avoid generating rounded outlines when the border radius is below 0.01mm by falling back to a rectangle
- add a regression test to verify that tiny radii produce a rectangular outline

## Testing
- bun test tests/components/normal-components/board-border-radius.test.tsx
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68f6d30cb4bc832e98209e452f86b77c