### PR TITLE
Default dimension text to measured distance

### DIFF
--- a/lib/components/primitive-components/FabricationNoteDimension.ts
+++ b/lib/components/primitive-components/FabricationNoteDimension.ts
@@ -57,6 +57,8 @@ export class FabricationNoteDimension extends PrimitiveComponent<
       this.parent?.pcb_component_id ??
       this.getPrimitiveContainer()?.pcb_component_id!
 
+    const text = props.text ?? this._formatDistanceText({ from, to })
+
     const fabrication_note_dimension = db.pcb_fabrication_note_dimension.insert(
       {
         pcb_component_id,
@@ -65,7 +67,7 @@ export class FabricationNoteDimension extends PrimitiveComponent<
         layer,
         from,
         to,
-        text: props.text,
+        text,
         offset: props.offset,
         font: props.font ?? "tscircuit2024",
         font_size: props.fontSize ?? 1,
@@ -87,5 +89,24 @@ export class FabricationNoteDimension extends PrimitiveComponent<
       width: Math.abs(to.x - from.x),
       height: Math.abs(to.y - from.y),
     }
+  }
+
+  private _formatDistanceText({
+    from,
+    to,
+  }: {
+    from: Point
+    to: Point
+  }): string {
+    const dx = to.x - from.x
+    const dy = to.y - from.y
+    const distance = Math.sqrt(dx * dx + dy * dy)
+
+    const roundedDistance = Math.round(distance)
+    const isWholeNumber = Math.abs(distance - roundedDistance) < 1e-9
+
+    const valueText = isWholeNumber ? `${roundedDistance}` : distance.toFixed(2)
+
+    return `${valueText}mm`
   }
 }

--- a/lib/components/primitive-components/PcbNoteDimension.ts
+++ b/lib/components/primitive-components/PcbNoteDimension.ts
@@ -48,13 +48,15 @@ export class PcbNoteDimension extends PrimitiveComponent<
       this.getPrimitiveContainer()?.pcb_component_id ??
       undefined
 
+    const text = props.text ?? this._formatDistanceText({ from, to })
+
     const pcb_note_dimension = db.pcb_note_dimension.insert({
       pcb_component_id,
       subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
       pcb_group_id: group?.pcb_group_id ?? undefined,
       from,
       to,
-      text: props.text,
+      text,
       font: props.font ?? "tscircuit2024",
       font_size: props.fontSize ?? 1,
       color: props.color,
@@ -73,5 +75,24 @@ export class PcbNoteDimension extends PrimitiveComponent<
       width: Math.abs(to.x - from.x),
       height: Math.abs(to.y - from.y),
     }
+  }
+
+  private _formatDistanceText({
+    from,
+    to,
+  }: {
+    from: Point
+    to: Point
+  }): string {
+    const dx = to.x - from.x
+    const dy = to.y - from.y
+    const distance = Math.sqrt(dx * dx + dy * dy)
+
+    const roundedDistance = Math.round(distance)
+    const isWholeNumber = Math.abs(distance - roundedDistance) < 1e-9
+
+    const valueText = isWholeNumber ? `${roundedDistance}` : distance.toFixed(2)
+
+    return `${valueText}mm`
   }
 }

--- a/tests/components/normal-components/fabrication-notes.test.tsx
+++ b/tests/components/normal-components/fabrication-notes.test.tsx
@@ -57,3 +57,30 @@ test("fabrication note path, text and rect are created", async () => {
 
   await expect(circuit).toMatchPcbSnapshot(import.meta.path)
 })
+
+test("fabricationnotedimension defaults text to measured distance", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <fabricationnotedimension
+        from={{ x: 0, y: 0 }}
+        to={{ x: 3, y: 4 }}
+        offset={1}
+      />
+      <fabricationnotedimension
+        from={{ x: 0, y: 0 }}
+        to={{ x: 0, y: 1.234 }}
+        offset={1}
+        layer="bottom"
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const dimensions = circuit.db.pcb_fabrication_note_dimension.list()
+  expect(dimensions).toHaveLength(2)
+  expect(dimensions[0].text).toBe("5mm")
+  expect(dimensions[1].text).toBe("1.23mm")
+})

--- a/tests/components/primitive-components/pcb-note-dimension-board.test.tsx
+++ b/tests/components/primitive-components/pcb-note-dimension-board.test.tsx
@@ -34,3 +34,21 @@ test("pcbnotedimension renders between explicit points", async () => {
   expect(dimensions[0].pcb_component_id).toBeUndefined()
   await expect(circuit).toMatchPcbSnapshot(import.meta.path)
 })
+
+test("pcbnotedimension defaults text to measured distance", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <pcbnotedimension from={{ x: 1, y: 1 }} to={{ x: 6, y: 1 }} />
+      <pcbnotedimension from={{ x: 0, y: 0 }} to={{ x: 1.234, y: 0 }} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const dimensions = circuit.db.pcb_note_dimension.list()
+  expect(dimensions).toHaveLength(2)
+  expect(dimensions[0].text).toBe("5mm")
+  expect(dimensions[1].text).toBe("1.23mm")
+})


### PR DESCRIPTION
## Summary
- default PCB and fabrication note dimension text to the measured distance when no text is provided
- format the generated text with whole numbers left as-is and other values rounded to two decimal places
- add unit tests covering the new defaulting behavior for both dimension components

## Testing
- bunx tsc --noEmit
- bun test tests/components/primitive-components/pcb-note-dimension-board.test.tsx
- bun test tests/components/normal-components/fabrication-notes.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68f81f8c37bc832eab2fce91aaa668a0