### PR TITLE
Normalize auto_cloud autorouter preset

### DIFF
--- a/lib/utils/autorouting/getPresetAutoroutingConfig.ts
+++ b/lib/utils/autorouting/getPresetAutoroutingConfig.ts
@@ -29,7 +29,10 @@ export function getPresetAutoroutingConfig(
   const providedConfig =
     typeof autorouterConfig === "object" ? autorouterConfig : {}
 
-  switch (preset) {
+  const normalizedPreset =
+    typeof preset === "string" ? preset.replace(/_/g, "-") : preset
+
+  switch (normalizedPreset) {
     case "auto-local":
       return {
         local: true,

--- a/tests/utils/autorouting/getPresetAutoroutingConfig.test.ts
+++ b/tests/utils/autorouting/getPresetAutoroutingConfig.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import type { AutorouterConfig } from "@tscircuit/props"
+import { getPresetAutoroutingConfig } from "lib/utils/autorouting/getPresetAutoroutingConfig"
+
+describe("getPresetAutoroutingConfig", () => {
+  test("treats auto_cloud preset string the same as auto-cloud", () => {
+    const expected = getPresetAutoroutingConfig(
+      "auto-cloud" as unknown as AutorouterConfig,
+    )
+    const alias = getPresetAutoroutingConfig(
+      "auto_cloud" as unknown as AutorouterConfig,
+    )
+
+    expect(alias).toEqual(expected)
+  })
+
+  test("treats auto_cloud preset object the same as auto-cloud", () => {
+    const expected = getPresetAutoroutingConfig({
+      preset: "auto-cloud",
+      serverUrl: "https://example.com",
+    } as AutorouterConfig)
+
+    const alias = getPresetAutoroutingConfig({
+      preset: "auto_cloud",
+      serverUrl: "https://example.com",
+    } as AutorouterConfig)
+
+    expect(alias).toEqual(expected)
+  })
+})


### PR DESCRIPTION
## Summary
- normalize autorouter preset names so underscore variants map to the same configuration as their hyphenated counterparts
- add unit tests covering the auto_cloud preset alias behavior

## Testing
- bun test tests/utils/autorouting/getPresetAutoroutingConfig.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68fc22aa3bd4832ebfb8e616f26d3a99