### PR TITLE
Implement static asset resolver pattern for asset loading on tscircuit.com (cad model urls not supported, just kicad_mod)

### DIFF
--- a/lib/RootCircuit.ts
+++ b/lib/RootCircuit.ts
@@ -290,3 +290,5 @@ export const Project = RootCircuit
  * incorporated into a larger RootCircuit
  */
 export const Circuit = RootCircuit
+
+export { resolveStaticFileImport } from "./utils/resolveStaticFileImport"

--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
@@ -10,8 +10,8 @@ import {
   external_footprint_load_error,
 } from "circuit-json"
 import { getFileExtension } from "./utils/getFileExtension"
-import { constructAssetUrl } from "lib/utils/constructAssetUrl"
 import { isStaticAssetPath } from "./utils/isStaticAssetPath"
+import { resolveStaticFileImport } from "lib/utils/resolveStaticFileImport"
 
 interface FootprintLibraryResult {
   footprintCircuitJson: any[]
@@ -39,11 +39,10 @@ export function NormalComponent_doInitialPcbFootprintStringRender(
   ) {
     if (component._hasStartedFootprintUrlLoad) return
     component._hasStartedFootprintUrlLoad = true
-    const projectBaseUrl = component.root?.platform?.projectBaseUrl
-    const footprintUrl = isHttpUrl(footprint)
-      ? footprint
-      : constructAssetUrl(footprint, projectBaseUrl)
     queueAsyncEffect("load-footprint-from-platform-file-parser", async () => {
+      const footprintUrl = isHttpUrl(footprint)
+        ? footprint
+        : await resolveStaticFileImport(footprint, component.root?.platform)
       try {
         const result = await footprintParser.loadFromUrl(footprintUrl)
         const fpComponents = createComponentsFromCircuitJson(

--- a/lib/utils/resolveStaticFileImport.ts
+++ b/lib/utils/resolveStaticFileImport.ts
@@ -1,0 +1,29 @@
+import type { PlatformConfig } from "@tscircuit/props"
+import Debug from "debug"
+import { constructAssetUrl } from "./constructAssetUrl"
+
+const resolveStaticFileImportDebug = Debug(
+  "tscircuit:core:resolveStaticFileImport",
+)
+
+export async function resolveStaticFileImport(
+  path: string,
+  platform?: PlatformConfig,
+): Promise<string> {
+  if (!path) return path
+
+  const resolver = platform?.resolveProjectStaticFileImportUrl
+  if (resolver && path.startsWith("/")) {
+    try {
+      const resolved = await resolver(path)
+      if (resolved) return resolved
+    } catch (error) {
+      resolveStaticFileImportDebug(
+        "failed to resolve static file via platform resolver",
+        error,
+      )
+    }
+  }
+
+  return constructAssetUrl(path, platform?.projectBaseUrl)
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@tscircuit/matchpack": "^0.0.16",
     "@tscircuit/math-utils": "^0.0.29",
     "@tscircuit/miniflex": "^0.0.4",
-    "@tscircuit/props": "0.0.378",
+    "@tscircuit/props": "0.0.381",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/schematic-trace-solver": "^0.0.41",

--- a/tests/footprint/footprint-resolver-url.test.tsx
+++ b/tests/footprint/footprint-resolver-url.test.tsx
@@ -1,0 +1,44 @@
+import { expect, it } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import kicadModJson from "tests/fixtures/assets/R_0402_1005Metric.json" with {
+  type: "json",
+}
+
+it("prefers platform resolver for static footprint imports", async () => {
+  const resolvedUrl = "https://cdn.example.com/footprint.kicad_mod"
+  let resolverCalls = 0
+  let loadCalls = 0
+
+  const { circuit } = getTestFixture({
+    platform: {
+      projectBaseUrl: "http://localhost:3020/api/files/static",
+      resolveProjectStaticFileImportUrl: async (path: string) => {
+        resolverCalls += 1
+        expect(path).toBe("/api/files/static/footprint.kicad_mod")
+        return resolvedUrl
+      },
+      footprintFileParserMap: {
+        kicad_mod: {
+          loadFromUrl: async (url: string) => {
+            loadCalls += 1
+            expect(url).toBe(resolvedUrl)
+            return {
+              footprintCircuitJson: kicadModJson,
+            }
+          },
+        },
+      },
+    },
+  })
+
+  circuit.add(
+    <board>
+      <chip footprint="/api/files/static/footprint.kicad_mod" name="U2" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(resolverCalls).toBe(1)
+  expect(loadCalls).toBe(1)
+})


### PR DESCRIPTION
## Summary
- move the async static asset resolver into a dedicated utility module and re-export it from RootCircuit
- update footprint URL loading to import the shared resolver utility while leaving CadModel cache-busting logic unchanged
- keep the async resolver test coverage while ensuring CadModel still uses its existing constructAssetUrl flow

## Testing
- bunx tsc --noEmit
- bun test tests/footprint

------
https://chatgpt.com/codex/tasks/task_b_68fc141b1604832e9a44ce01b525781d