### PR TITLE
Prevent schPinSpacing from shrinking schematic box width

### DIFF
--- a/lib/utils/schematic/getAllDimensionsForSchematicBox.ts
+++ b/lib/utils/schematic/getAllDimensionsForSchematicBox.ts
@@ -1,6 +1,8 @@
 import { getSizeOfSidesFromPortArrangement } from "./getSizeOfSidesFromPortArrangement"
 import { parsePinNumberFromLabelsOrThrow } from "./parsePinNumberFromLabelsOrThrow"
 
+const DEFAULT_PIN_SPACING = 0.2
+
 export type VerticalPortSideConfiguration = {
   direction?: "top-to-bottom" | "bottom-to-top"
   pins: number[]
@@ -346,9 +348,23 @@ export const getAllDimensionsForSchematicBox = (
   // Use lengths to determine schWidth and schHeight
   let schWidth = params.schWidth
   if (schWidth === undefined) {
+    const computedTopWidth =
+      sidePinCounts.topSize > 0 ? sideLengths.top + params.schPinSpacing * 2 : 0
+    const computedBottomWidth =
+      sidePinCounts.bottomSize > 0
+        ? sideLengths.bottom + params.schPinSpacing * 2
+        : 0
+
+    const marginSpacingForWidth =
+      sidePinCounts.topSize > 0 || sidePinCounts.bottomSize > 0
+        ? params.schPinSpacing
+        : DEFAULT_PIN_SPACING
+
     schWidth = Math.max(
-      sideLengths.top + params.schPinSpacing * 2,
-      sideLengths.bottom + params.schPinSpacing * 2,
+      computedTopWidth,
+      computedBottomWidth,
+      marginSpacingForWidth * 2,
+      DEFAULT_PIN_SPACING * 2,
     )
 
     const labelWidth = params.pinLabels
@@ -369,6 +385,7 @@ export const getAllDimensionsForSchematicBox = (
     schHeight = Math.max(
       sideLengths.left + params.schPinSpacing * 2,
       sideLengths.right + params.schPinSpacing * 2,
+      DEFAULT_PIN_SPACING * 2,
     )
   }
 

--- a/tests/components/normal-components/chip-schpinspacing-width.test.tsx
+++ b/tests/components/normal-components/chip-schpinspacing-width.test.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const getChipSchematicWidth = (schPinSpacing?: number) => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip
+        name="U1"
+        schX={5}
+        schY={5}
+        schPortArrangement={{ leftSize: 4, rightSize: 4 }}
+        {...(schPinSpacing !== undefined ? { schPinSpacing } : {})}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const chip = circuit.selectOne("chip")
+  if (!chip) throw new Error("chip not found")
+
+  const schematicComponent = circuit.db.schematic_component.get(
+    chip.schematic_component_id!,
+  )
+
+  return schematicComponent?.size.width
+}
+
+test("chip schematic box width should not change when schPinSpacing is set", () => {
+  const defaultWidth = getChipSchematicWidth()
+  const customSpacingWidth = getChipSchematicWidth(0.75)
+
+  expect(defaultWidth).toBeGreaterThan(0)
+  expect(customSpacingWidth).toBeCloseTo(defaultWidth!)
+})


### PR DESCRIPTION
## Summary
- add a regression test that records the schematic box width for a chip with and without `schPinSpacing`
- adjust schematic box sizing logic to keep a baseline width when no top/bottom pins are present so `schPinSpacing` no longer shrinks the box

## Testing
- bun test tests/components/normal-components/chip-schpinspacing-width.test.tsx
- bun test tests/utils/schematic/getAllDimensionsForSchematicBox.test.ts
- bunx tsc --noEmit

## Proof of failure before fix
- bun test tests/components/normal-components/chip-schpinspacing-width.test.tsx *(failed with `Expected: 0.4`, `Received: 1.5` prior to the fix)*

------
https://chatgpt.com/codex/tasks/task_e_68feab788a188330bbf40e58a44e1c7b