### PR TITLE
fix: broken rendering logs in runframe for Group_doInitialSchematicLayoutMatchpack

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
@@ -237,7 +237,7 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
 
   const packOutput = pack(packInput)
 
-  if (debug.enabled) {
+  if (debug.enabled && global.debugGraphics) {
     const graphics = getGraphicsFromPackOutput(packOutput)
     graphics.title = `packOutput-${group.name}`
     global.debugGraphics?.push(graphics)

--- a/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutMatchAdapt.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicLayoutMatchAdapt.ts
@@ -20,7 +20,7 @@ export function Group_doInitialSchematicLayoutMatchAdapt<
   const bpcGraphBeforeGeneratedNetLabels =
     convertCircuitJsonToBpc(subtreeCircuitJson)
 
-  if (debug.enabled) {
+  if (debug.enabled && global.debugGraphics) {
     global.debugGraphics?.push(
       getGraphicsForBpcGraph(bpcGraphBeforeGeneratedNetLabels, {
         title: `floatingBpcGraph-${group.name}`,
@@ -78,7 +78,7 @@ export function Group_doInitialSchematicLayoutMatchAdapt<
     },
   )
 
-  if (debug.enabled) {
+  if (debug.enabled && global.debugGraphics) {
     global.debugGraphics?.push(
       getGraphicsForBpcGraph(laidOutBpcGraph, {
         title: `laidOutBpcGraph-${group.name}`,


### PR DESCRIPTION
Add a check before accessing `global`

<img width="1972" height="1434" alt="image" src="https://github.com/user-attachments/assets/2f5dac46-a73f-4ce3-90ee-db8e825b3fb0" />
