### PR TITLE
Add pcb_panel center data and upgrade circuit-json

### DIFF
--- a/lib/components/normal-components/Panel.ts
+++ b/lib/components/normal-components/Panel.ts
@@ -1,8 +1,11 @@
 import { panelProps } from "@tscircuit/props"
+import { distance } from "circuit-json"
 import type { PrimitiveComponent } from "../base-components/PrimitiveComponent"
 import { Group } from "../primitive-components/Group/Group"
 
 export class Panel extends Group<typeof panelProps> {
+  pcb_panel_id: string | null = null
+
   get config() {
     return {
       componentName: "Panel",
@@ -11,6 +14,10 @@ export class Panel extends Group<typeof panelProps> {
   }
 
   get isGroup() {
+    return true
+  }
+
+  get isSubcircuit() {
     return true
   }
 
@@ -27,5 +34,44 @@ export class Panel extends Group<typeof panelProps> {
     }
 
     super.runRenderCycle()
+  }
+
+  doInitialPcbComponentRender() {
+    super.doInitialPcbComponentRender()
+    if (this.root?.pcbDisabled) return
+
+    const { db } = this.root!
+    const props = this._parsedProps
+
+    const inserted = db.pcb_panel.insert({
+      width: distance.parse(props.width),
+      height: distance.parse(props.height),
+      center: this._getGlobalPcbPositionBeforeLayout(),
+      covered_with_solder_mask: !(props.noSolderMask ?? false),
+    })
+
+    this.pcb_panel_id = inserted.pcb_panel_id
+  }
+
+  updatePcbComponentRender() {
+    if (this.root?.pcbDisabled) return
+    if (!this.pcb_panel_id) return
+
+    const { db } = this.root!
+    const props = this._parsedProps
+
+    db.pcb_panel.update(this.pcb_panel_id, {
+      width: distance.parse(props.width),
+      height: distance.parse(props.height),
+      center: this._getGlobalPcbPositionBeforeLayout(),
+      covered_with_solder_mask: !(props.noSolderMask ?? false),
+    })
+  }
+
+  removePcbComponentRender() {
+    if (!this.pcb_panel_id) return
+
+    this.root?.db.pcb_panel.delete(this.pcb_panel_id)
+    this.pcb_panel_id = null
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "bun-match-svg": "0.0.12",
     "calculate-elbow": "^0.0.12",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.306",
+    "circuit-json": "^0.0.307",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.22",
     "circuit-json-to-gltf": "^0.0.31",

--- a/tests/components/normal-components/panel.test.tsx
+++ b/tests/components/normal-components/panel.test.tsx
@@ -66,3 +66,38 @@ test("panel must contain at least one board", () => {
     circuit.render()
   }).toThrow("<panel> must contain at least one <board>")
 })
+
+test("panel emits pcb_panel with center", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <panel width="100mm" height="50mm" pcbX="10mm" pcbY="20mm">
+      <board width="10mm" height="10mm" routingDisabled />
+    </panel>,
+  )
+
+  circuit.render()
+
+  const pcbPanel = circuit.db.pcb_panel.list()[0]
+  expect(pcbPanel).toMatchObject({
+    width: 100,
+    height: 50,
+    center: { x: 10, y: 20 },
+    covered_with_solder_mask: true,
+  })
+})
+
+test("panel noSolderMask disables solder mask coverage", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <panel width="100mm" height="100mm" noSolderMask>
+      <board width="10mm" height="10mm" routingDisabled />
+    </panel>,
+  )
+
+  circuit.render()
+
+  const pcbPanel = circuit.db.pcb_panel.list()[0]
+  expect(pcbPanel.covered_with_solder_mask).toBe(false)
+})


### PR DESCRIPTION
## Summary
- bump `circuit-json` to v0.0.307
- insert and maintain `pcb_panel` records with width, height, center, and solder mask coverage info
- add panel tests covering the new `pcb_panel` data

## Testing
- bun test tests/components/normal-components/panel.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6914c2102c5083338597833d4bd5251e)