### PR TITLE
Include component context in net name validation errors

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -738,7 +738,7 @@ export abstract class PrimitiveComponent<
     if (this._cachedSelectAllQueries.has(selectorRaw)) {
       return this._cachedSelectAllQueries.get(selectorRaw) as T[]
     }
-    const selector = preprocessSelector(selectorRaw)
+    const selector = preprocessSelector(selectorRaw, this)
     const result = selectAll(
       selector,
       this,
@@ -773,7 +773,7 @@ export abstract class PrimitiveComponent<
     if (this._cachedSelectOneQueries.has(selectorRaw)) {
       return this._cachedSelectOneQueries.get(selectorRaw) as T | null
     }
-    const selector = preprocessSelector(selectorRaw)
+    const selector = preprocessSelector(selectorRaw, this)
     if (options?.port) {
       options.type = "port"
     }

--- a/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
+++ b/lib/components/base-components/PrimitiveComponent/preprocessSelector.ts
@@ -1,13 +1,28 @@
-export const preprocessSelector = (selector: string) => {
+import type { PrimitiveComponent } from "./PrimitiveComponent"
+
+const buildPlusMinusNetErrorMessage = (
+  selector: string,
+  component?: PrimitiveComponent,
+) => {
+  const netName = selector.split("net.")[1]?.split(/[ >]/)[0] ?? selector
+  const componentName = component?.componentName ?? "Unknown component"
+  return (
+    `Net names cannot contain "+" or "-" (component "${componentName}" received "${netName}" via "${selector}"). ` +
+    `Try using underscores instead, e.g. VCC_P`
+  )
+}
+
+export const preprocessSelector = (
+  selector: string,
+  component?: PrimitiveComponent,
+) => {
   if (/net\.[^\s>]*\./.test(selector)) {
     throw new Error(
       'Net names cannot contain a period, try using "sel.net..." to autocomplete with conventional net names, e.g. V3_3',
     )
   }
   if (/net\.[^\s>]*[+-]/.test(selector)) {
-    throw new Error(
-      'Net names cannot contain "+" or "-", try using underscores instead, e.g. VCC_P',
-    )
+    throw new Error(buildPlusMinusNetErrorMessage(selector, component))
   }
   if (/net\.[0-9]/.test(selector)) {
     const match = selector.match(/net\.([^ >]+)/)

--- a/lib/components/primitive-components/Net.ts
+++ b/lib/components/primitive-components/Net.ts
@@ -7,12 +7,12 @@ import type { AnyCircuitElement, SourceTrace } from "circuit-json"
 import { autoroute } from "@tscircuit/infgrid-ijump-astar"
 
 export const netProps = z.object({
-  name: z
-    .string()
-    .refine(
-      (val) => !/[+-]/.test(val),
-      'Net names cannot contain "+" or "-", try using underscores instead, e.g. VCC_P',
-    ),
+  name: z.string().refine(
+    (val) => !/[+-]/.test(val),
+    (val) => ({
+      message: `Net names cannot contain "+" or "-" (component "Net" received "${val}"). Try using underscores instead, e.g. VCC_P`,
+    }),
+  ),
 })
 
 export class Net extends PrimitiveComponent<typeof netProps> {

--- a/lib/utils/components/createNetsFromProps.ts
+++ b/lib/utils/components/createNetsFromProps.ts
@@ -13,9 +13,11 @@ export const createNetsFromProps = (
         )
       }
       if (/net\.[^\s>]*[+-]/.test(prop)) {
-        throw new Error(
-          'Net names cannot contain "+" or "-", try using underscores instead, e.g. VCC_P',
-        )
+        const netName = prop.split("net.")[1]
+        const message =
+          `Net names cannot contain "+" or "-" (component "${component.componentName}" received "${netName}" via "${prop}"). ` +
+          `Try using underscores instead, e.g. VCC_P`
+        throw new Error(message)
       }
       if (/net\.[0-9]/.test(prop)) {
         const netName = prop.split("net.")[1]

--- a/tests/sel/net-name-minus.test.ts
+++ b/tests/sel/net-name-minus.test.ts
@@ -1,8 +1,10 @@
 import { preprocessSelector } from "lib/components/base-components/PrimitiveComponent/preprocessSelector"
 import { test, expect } from "bun:test"
 
+const mockComponent = { componentName: "MockComponent" } as any
+
 test("preprocessSelector - minus sign in net name throws", () => {
-  expect(() => preprocessSelector("net.VCC-")).toThrow(
-    'Net names cannot contain "+" or "-", try using underscores instead, e.g. VCC_P',
+  expect(() => preprocessSelector("net.VCC-", mockComponent)).toThrow(
+    'Net names cannot contain "+" or "-" (component "MockComponent" received "VCC-" via "net.VCC-"). Try using underscores instead, e.g. VCC_P',
   )
 })

--- a/tests/sel/net-name-plus.test.ts
+++ b/tests/sel/net-name-plus.test.ts
@@ -1,8 +1,10 @@
 import { preprocessSelector } from "lib/components/base-components/PrimitiveComponent/preprocessSelector"
 import { test, expect } from "bun:test"
 
+const mockComponent = { componentName: "MockComponent" } as any
+
 test("preprocessSelector - plus sign in net name throws", () => {
-  expect(() => preprocessSelector("net.VCC+")).toThrow(
-    'Net names cannot contain "+" or "-", try using underscores instead, e.g. VCC_P',
+  expect(() => preprocessSelector("net.VCC+", mockComponent)).toThrow(
+    'Net names cannot contain "+" or "-" (component "MockComponent" received "VCC+" via "net.VCC+"). Try using underscores instead, e.g. VCC_P',
   )
 })


### PR DESCRIPTION
## Summary
- include the component name and provided net identifier in the "+"/"-" net validation error
- pass component context into selector preprocessing and add targeted tests
- update the Net zod schema error message to mention the offending value

## Testing
- bun test tests/sel/net-name-plus.test.ts
- bun test tests/sel/net-name-minus.test.ts
- bunx tsc --noEmit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915771a90cc832e87cd74d7588489a8)