### PR TITLE
Handle via metadata when rehydrating vias from circuit JSON

### DIFF
--- a/lib/utils/createComponentsFromCircuitJson.ts
+++ b/lib/utils/createComponentsFromCircuitJson.ts
@@ -8,6 +8,7 @@ import { Keepout } from "lib/components/primitive-components/Keepout"
 import { Hole } from "lib/components/primitive-components/Hole"
 import { SilkscreenText } from "lib/components/primitive-components/SilkscreenText"
 import { Cutout } from "lib/components/primitive-components/Cutout"
+import { Via } from "lib/components/primitive-components/Via"
 import { createPinrowSilkscreenText } from "./createPinrowSilkscreenText"
 import type { PinLabelsProp } from "@tscircuit/props"
 
@@ -264,6 +265,37 @@ export const createComponentsFromCircuitJson = (
           }),
         )
       }
+    } else if (elm.type === "pcb_via") {
+      const layers = elm.layers ?? []
+      const fromLayer =
+        elm.from_layer ?? (layers.length > 0 ? layers[0] : "top")
+      const toLayer =
+        elm.to_layer ??
+        (layers.length > 0 ? layers[layers.length - 1] : fromLayer)
+
+      const viaElm = elm as any
+      const viaProps: ConstructorParameters<typeof Via>[0] = {
+        pcbX: viaElm.x,
+        pcbY: viaElm.y,
+        holeDiameter: viaElm.hole_diameter,
+        outerDiameter: viaElm.outer_diameter,
+        fromLayer,
+        toLayer,
+      }
+
+      if (viaElm.name) {
+        viaProps.name = viaElm.name
+      }
+
+      if (viaElm.connects_to !== undefined) {
+        viaProps.connectsTo = viaElm.connects_to
+      }
+
+      if (viaElm.net_is_assignable !== undefined) {
+        viaProps.netIsAssignable = viaElm.net_is_assignable
+      }
+
+      components.push(new Via(viaProps))
     } else if (elm.type === "pcb_trace") {
       components.push(
         new PcbTrace({

--- a/tests/utils/createComponentsFromCircuitJson/pcb-via-elements.test.tsx
+++ b/tests/utils/createComponentsFromCircuitJson/pcb-via-elements.test.tsx
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import { createComponentsFromCircuitJson } from "lib/utils/createComponentsFromCircuitJson"
+
+import type { Via } from "lib/components"
+
+const baseConfig = {
+  componentName: "TestComponent",
+  componentRotation: "0",
+  footprinterString: "<footprint></footprint>",
+}
+
+test("createComponentsFromCircuitJson handles pcb_via elements", () => {
+  const components = createComponentsFromCircuitJson(baseConfig, [
+    {
+      type: "pcb_via",
+      name: "via1",
+      x: 1,
+      y: 2,
+      hole_diameter: 0.3,
+      outer_diameter: 0.7,
+      layers: ["top", "inner1", "bottom"],
+      net_is_assignable: true,
+      connects_to: ["net.VCC", "net.GND"],
+    } as any,
+  ])
+
+  expect(components.length).toBe(1)
+  const via = components[0] as Via
+
+  expect(via.props.name).toBe("via1")
+  expect(via.componentName).toBe("Via")
+  expect(via.props.holeDiameter).toBe(0.3)
+  expect(via.props.outerDiameter).toBe(0.7)
+  expect(via.props.fromLayer).toBe("top")
+  expect(via.props.toLayer).toBe("bottom")
+  expect(via.props.netIsAssignable).toBe(true)
+  expect(via.props.connectsTo).toEqual(["net.VCC", "net.GND"])
+})
+
+test("createComponentsFromCircuitJson handles pcb_via elements with string connects_to", () => {
+  const components = createComponentsFromCircuitJson(baseConfig, [
+    {
+      type: "pcb_via",
+      x: -1,
+      y: -2,
+      hole_diameter: 0.25,
+      outer_diameter: 0.55,
+      from_layer: "inner1",
+      to_layer: "inner2",
+      connects_to: "net.3v3",
+    } as any,
+  ])
+
+  expect(components.length).toBe(1)
+  const via = components[0] as Via
+
+  expect(via.props.connectsTo).toBe("net.3v3")
+  expect(via.props.fromLayer).toBe("inner1")
+  expect(via.props.toLayer).toBe("inner2")
+})


### PR DESCRIPTION
## Summary
- preserve via name, connectsTo, and net assignable flags when turning `pcb_via` circuit JSON into Via primitives
- add regression coverage for `connects_to` array and string variants from footprint data

## Testing
- bun test tests/utils/createComponentsFromCircuitJson/pcb-via-elements.test.tsx
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69157500bdd8832ebd55a2991441a266)