### PR TITLE
Refactor: Simplify VoltageSource imports and update intrinsic JSX types

### DIFF
--- a/lib/components/normal-components/VoltageSource.ts
+++ b/lib/components/normal-components/VoltageSource.ts
@@ -1,34 +1,11 @@
-import { frequency, rotation, voltage } from "circuit-json"
-import {
-  commonComponentProps,
-  type CommonComponentProps,
-} from "@tscircuit/props"
-import { z } from "zod"
+import { voltageSourceProps } from "@tscircuit/props"
 import { NormalComponent } from "../base-components/NormalComponent/NormalComponent"
-import { FTYPE, type BaseSymbolName, type Ftype } from "lib/utils/constants"
+import { type BaseSymbolName, type Ftype } from "lib/utils/constants"
 import type { SimulationAcVoltageSource } from "circuit-json"
-import { Port } from "../primitive-components/Port"
+
 import type { RenderPhase } from "lib/components/base-components/Renderable"
 
 export type WaveShape = "sinewave" | "square" | "triangle" | "sawtooth"
-
-export interface VoltageSourceProps extends CommonComponentProps {
-  voltage?: number | string
-  frequency?: number | string
-  peakToPeakVoltage?: number | string
-  waveShape?: WaveShape
-  phase?: number | string
-  dutyCycle?: number
-}
-
-export const voltageSourceProps = commonComponentProps.extend({
-  voltage: voltage.optional(),
-  frequency: frequency.optional(),
-  peakToPeakVoltage: voltage.optional(),
-  waveShape: z.enum(["sinewave", "square", "triangle", "sawtooth"]).optional(),
-  phase: rotation.optional(),
-  dutyCycle: z.number().optional(),
-})
 
 export class VoltageSource extends NormalComponent<
   typeof voltageSourceProps,

--- a/lib/fiber/intrinsic-jsx.ts
+++ b/lib/fiber/intrinsic-jsx.ts
@@ -1,5 +1,4 @@
 import type * as Props from "@tscircuit/props"
-import type { VoltageSourceProps } from "lib/components/normal-components/VoltageSource"
 import type { DetailedHTMLProps, SVGProps } from "react"
 
 export interface TscircuitElements {
@@ -75,7 +74,7 @@ export interface TscircuitElements {
   switch: Props.SwitchProps
   mosfet: Props.MosfetProps
   testpoint: Props.TestpointProps
-  voltagesource: VoltageSourceProps
+  voltagesource: Props.VoltageSourceProps
   voltageprobe: Props.VoltageProbeProps
   copperpour: Props.CopperPourProps
   analogsimulation: Props.AnalogSimulationProps


### PR DESCRIPTION
This pull request refactors the way `VoltageSource` component props are imported and used, aligning them with the shared props package and removing local duplication. The main goal is to ensure consistency and maintainability by relying on the centralized `@tscircuit/props` definitions.

Props refactoring and unification:

* Replaced local definitions of `VoltageSourceProps` and `voltageSourceProps` in `VoltageSource.ts` with imports from `@tscircuit/props`, removing redundant code and ensuring consistency across the codebase.
* Updated the `TscircuitElements` interface in `intrinsic-jsx.ts` to use `Props.VoltageSourceProps` instead of the locally defined `VoltageSourceProps`, further unifying prop types. [[1]](diffhunk://#diff-a597f8be64af7c92a5829674f84bfa3cc2c04a095aecfd44e83a122a953c2086L2) [[2]](diffhunk://#diff-a597f8be64af7c92a5829674f84bfa3cc2c04a095aecfd44e83a122a953c2086L78-R77)