### PR TITLE
Add pcbStyle defaults for via diameters

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -28,6 +28,7 @@ import { getBoundsFromPoints } from "@tscircuit/math-utils"
 import { Group_doInitialSchematicLayoutMatchAdapt } from "./Group_doInitialSchematicLayoutMatchAdapt"
 import { Group_doInitialSchematicLayoutMatchPack } from "./Group_doInitialSchematicLayoutMatchPack"
 import { Group_doInitialSourceAddConnectivityMapKey } from "./Group_doInitialSourceAddConnectivityMapKey"
+import { getViaDiameterDefaults } from "lib/utils/pcbStyle/getViaDiameterDefaults"
 import { Group_doInitialSchematicLayoutGrid } from "./Group_doInitialSchematicLayoutGrid"
 import { Group_doInitialSchematicLayoutFlex } from "./Group_doInitialSchematicLayoutFlex"
 import { Group_doInitialPcbLayoutGrid } from "./Group_doInitialPcbLayoutGrid"
@@ -739,6 +740,9 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     // TODO
 
     // Apply each routed trace to the corresponding circuit trace
+    const pcbStyle = this.getInheritedMergedProperty("pcbStyle")
+    const { holeDiameter, padDiameter } = getViaDiameterDefaults(pcbStyle)
+
     for (const pcb_trace of output_pcb_traces) {
       // vias can be included
       if (pcb_trace.type !== "pcb_trace") continue
@@ -768,8 +772,8 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
               pcb_trace_id: pcb_trace.pcb_trace_id,
               x: point.x,
               y: point.y,
-              hole_diameter: 0.3,
-              outer_diameter: 0.6,
+              hole_diameter: holeDiameter,
+              outer_diameter: padDiameter,
               layers: [
                 point.from_layer as LayerRef,
                 point.to_layer as LayerRef,

--- a/lib/components/primitive-components/Trace/Trace_doInitialPcbTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialPcbTraceRender.ts
@@ -12,6 +12,7 @@ import type { Port } from "../Port"
 import type { TraceHint } from "../TraceHint"
 import { getTraceLength } from "./trace-utils/compute-trace-length"
 import { getObstaclesFromCircuitJson } from "lib/utils/obstacles/getObstaclesFromCircuitJson"
+import { getViaDiameterDefaults } from "lib/utils/pcbStyle/getViaDiameterDefaults"
 
 type PcbRouteObjective =
   | RouteHintPoint
@@ -368,6 +369,8 @@ export function Trace_doInitialPcbTraceRender(trace: Trace) {
   const mergedRoute = mergeRoutes(routes)
 
   const traceLength = getTraceLength(mergedRoute)
+  const pcbStyle = trace.getInheritedMergedProperty("pcbStyle")
+  const { holeDiameter, padDiameter } = getViaDiameterDefaults(pcbStyle)
   const pcb_trace = db.pcb_trace.insert({
     route: mergedRoute,
     source_trace_id: trace.source_trace_id!,
@@ -383,8 +386,8 @@ export function Trace_doInitialPcbTraceRender(trace: Trace) {
         pcb_trace_id: pcb_trace.pcb_trace_id,
         x: point.x,
         y: point.y,
-        hole_diameter: 0.3,
-        outer_diameter: 0.6,
+        hole_diameter: holeDiameter,
+        outer_diameter: padDiameter,
         layers: [point.from_layer as LayerRef, point.to_layer as LayerRef],
         from_layer: point.from_layer as LayerRef,
         to_layer: point.to_layer as LayerRef,

--- a/lib/components/primitive-components/VoltageProbe.ts
+++ b/lib/components/primitive-components/VoltageProbe.ts
@@ -65,16 +65,16 @@ export class VoltageProbe extends PrimitiveComponent<typeof voltageProbeProps> {
 
     this.color = getSimulationColorForId(connectedId)
 
-    let finalName = name
+    let finalName: string | undefined = name
 
     if (!finalName) {
       finalName = targets[0]
         .split(" > ")
-        .map((s) => s.replace(/^\./, ""))
+        .map((s: string) => s.replace(/^\./, ""))
         .join(".")
     }
 
-    this.finalProbeName = finalName
+    this.finalProbeName = finalName ?? null
 
     const { simulation_voltage_probe_id } = db.simulation_voltage_probe.insert({
       name: finalName,

--- a/lib/utils/pcbStyle/getViaDiameterDefaults.ts
+++ b/lib/utils/pcbStyle/getViaDiameterDefaults.ts
@@ -1,0 +1,38 @@
+import type { PcbStyle } from "@tscircuit/props"
+
+const DEFAULT_VIA_HOLE_DIAMETER = 0.3
+const DEFAULT_VIA_PAD_DIAMETER = 0.6
+
+const parseDistance = (
+  value: string | number | undefined,
+  fallback: number,
+) => {
+  if (value === undefined) return fallback
+  if (typeof value === "number") return value
+  const parsed = parseFloat(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export const getViaDiameterDefaults = (pcbStyle?: PcbStyle) => {
+  return {
+    holeDiameter: parseDistance(
+      pcbStyle?.viaHoleDiameter,
+      DEFAULT_VIA_HOLE_DIAMETER,
+    ),
+    padDiameter: parseDistance(
+      pcbStyle?.viaPadDiameter,
+      DEFAULT_VIA_PAD_DIAMETER,
+    ),
+  }
+}
+
+export const getViaDiameterDefaultsWithOverrides = (
+  overrides: { holeDiameter?: number; padDiameter?: number },
+  pcbStyle?: PcbStyle,
+) => {
+  const defaults = getViaDiameterDefaults(pcbStyle)
+  return {
+    holeDiameter: overrides.holeDiameter ?? defaults.holeDiameter,
+    padDiameter: overrides.padDiameter ?? defaults.padDiameter,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@tscircuit/math-utils": "^0.0.29",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.4",
-    "@tscircuit/props": "^0.0.410",
+    "@tscircuit/props": "^0.0.418",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/schematic-trace-solver": "^v0.0.45",

--- a/tests/features/pcb-style-via-diameter.test.tsx
+++ b/tests/features/pcb-style-via-diameter.test.tsx
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/**
+ * Verify that pcbStyle provides default via diameters when unspecified
+ */
+test("pcbStyle sets default via diameters", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board
+      width="20mm"
+      height="20mm"
+      pcbStyle={{ viaPadDiameter: "0.8mm", viaHoleDiameter: "0.35mm" }}
+    >
+      <via pcbX={0} pcbY={0} fromLayer="top" toLayer="bottom" />
+      <via
+        pcbX={2}
+        pcbY={0}
+        fromLayer="top"
+        toLayer="bottom"
+        outerDiameter="0.55mm"
+        holeDiameter="0.25mm"
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const vias = circuit.db.pcb_via.list()
+  const styledVia = vias.find((via) => via.x === 0 && via.y === 0)
+  const explicitVia = vias.find((via) => via.x === 2 && via.y === 0)
+
+  expect(styledVia?.outer_diameter).toBeCloseTo(0.8, 5)
+  expect(styledVia?.hole_diameter).toBeCloseTo(0.35, 5)
+
+  expect(explicitVia?.outer_diameter).toBeCloseTo(0.55, 5)
+  expect(explicitVia?.hole_diameter).toBeCloseTo(0.25, 5)
+})


### PR DESCRIPTION
## Summary
- bump @tscircuit/props to the latest release
- apply pcbStyle via diameter defaults to vias from components and autorouter output
- add a regression test for pcbStyle-driven via sizing and clean up voltage probe typing

## Testing
- bunx tsc --noEmit
- bun test tests/features/pcb-style-via-diameter.test.tsx
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929381f5040832ea1832d01ec87f715)