### PR TITLE
Update footprint intrinsic type and props dependency

### DIFF
--- a/lib/fiber/intrinsic-jsx.ts
+++ b/lib/fiber/intrinsic-jsx.ts
@@ -46,7 +46,7 @@ export interface TscircuitElements {
   custom: any
   component: Props.ComponentProps
   crystal: Props.CrystalProps
-  footprint: any
+  footprint: Props.FootprintProps & { name?: string }
   silkscreentext: Props.SilkscreenTextProps
   cutout: Props.CutoutProps
   silkscreenpath: Props.SilkscreenPathProps

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@tscircuit/math-utils": "^0.0.29",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.4",
-    "@tscircuit/props": "^0.0.418",
+    "@tscircuit/props": "^0.0.419",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/schematic-trace-solver": "^v0.0.45",


### PR DESCRIPTION
## Summary
- update @tscircuit/props to the latest release
- type the intrinsic JSX footprint element using FootprintProps while retaining optional name support

## Testing
- bunx tsc --noEmit
- bun run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929ddd1dd58832e9834a08dda8a120e)