### PR TITLE
Support double-row pinheader footprint

### DIFF
--- a/lib/components/normal-components/PinHeader.ts
+++ b/lib/components/normal-components/PinHeader.ts
@@ -32,6 +32,7 @@ export class PinHeader extends NormalComponent<typeof pinHeaderProps> {
     const platedDiameter = this._parsedProps.platedDiameter
     const pitch = this._parsedProps.pitch
     const showSilkscreenPinLabels = this._parsedProps.showSilkscreenPinLabels
+    const rows = this._parsedProps.doubleRow ? 2 : 1
 
     if (pinCount > 0) {
       let footprintString: string
@@ -54,6 +55,10 @@ export class PinHeader extends NormalComponent<typeof pinHeaderProps> {
       // Default behavior (undefined/false) hides pin labels
       if (showSilkscreenPinLabels !== true) {
         footprintString += "_nopinlabels"
+      }
+
+      if (rows > 1) {
+        footprintString += `_rows${rows}`
       }
 
       return footprintString

--- a/tests/components/normal-components/pin-header-double-row.test.tsx
+++ b/tests/components/normal-components/pin-header-double-row.test.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("pinheader doubleRow generates a two-row footprint", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <pinheader
+        name="J1"
+        pinCount={6}
+        doubleRow
+        pitch="2.54mm"
+        pcbX={0}
+        pcbY={0}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const platedHoles = circuit.db.pcb_plated_hole.list()
+  const roundedYLevels = new Set(
+    platedHoles.map((hole) => Number(hole.y.toFixed(5))),
+  )
+
+  expect(platedHoles).toHaveLength(6)
+  expect(roundedYLevels.size).toBe(2)
+
+  const countsByRow = Array.from(roundedYLevels).map(
+    (yLevel) =>
+      platedHoles.filter((hole) => Number(hole.y.toFixed(5)) === yLevel).length,
+  )
+
+  expect(countsByRow).toEqual([3, 3])
+})


### PR DESCRIPTION
## Summary
- include the doubleRow prop when inferring pinheader footprints so two-row headers request dual-row pad layouts
- add a regression test ensuring double-row pinheaders place pins across two PCB rows

## Testing
- bun test tests/components/normal-components/pin-header-double-row.test.tsx
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692b5ad8a340832ea41578622b01e00e)