### PR TITLE
Support calc expressions for pcb coordinates

### DIFF
--- a/lib/RootCircuit.ts
+++ b/lib/RootCircuit.ts
@@ -1,5 +1,6 @@
-import type { AnyCircuitElement, LayerRef } from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import type { PrimitiveComponent } from "./components/base-components/PrimitiveComponent"
+import type { BoardI } from "./components/normal-components/BoardI"
 import type { CircuitJsonUtilObjects } from "@tscircuit/circuit-json-util"
 import { su } from "@tscircuit/circuit-json-util"
 import { isValidElement, type ReactElement } from "react"
@@ -90,13 +91,7 @@ export class RootCircuit {
   /**
    * Get the main board for this Circuit.
    */
-  _getBoard():
-    | (PrimitiveComponent & {
-        boardThickness: number
-        _connectedSchematicPortPairs: Set<string>
-        allLayers: LayerRef[]
-      })
-    | undefined {
+  _getBoard(): (PrimitiveComponent & BoardI) | undefined {
     const directBoard = this.children.find((c) => c.componentName === "Board")
     if (directBoard) {
       return directBoard as any

--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -24,6 +24,8 @@ import { Renderable } from "lib/components/base-components/Renderable"
 import type { IGroup } from "lib/components/primitive-components/Group/IGroup"
 import type { Ftype } from "lib/utils/constants"
 import { selectOne, selectAll, type Options } from "css-select"
+import type { BoardI } from "lib/components/normal-components/BoardI"
+import { evaluateCalcString } from "lib/utils/evaluateCalcString"
 import {
   cssSelectPrimitiveComponentAdapter,
   cssSelectPrimitiveComponentAdapterOnlySubcircuits,
@@ -190,16 +192,74 @@ export abstract class PrimitiveComponent<
     return pcbRotation ?? null
   }
 
+  getResolvedPcbPositionProp(): { pcbX: number; pcbY: number } {
+    return {
+      pcbX: this._resolvePcbCoordinate((this._parsedProps as any).pcbX, "pcbX"),
+      pcbY: this._resolvePcbCoordinate((this._parsedProps as any).pcbY, "pcbY"),
+    }
+  }
+
+  protected _resolvePcbCoordinate(
+    rawValue: unknown,
+    axis: "pcbX" | "pcbY",
+    options: { allowBoardVariables?: boolean } = {},
+  ): number {
+    if (rawValue == null) return 0
+    if (typeof rawValue === "number") return rawValue
+    if (typeof rawValue !== "string") {
+      throw new Error(
+        `Invalid ${axis} value for ${this.componentName}: ${String(rawValue)}`,
+      )
+    }
+
+    const allowBoardVariables =
+      options.allowBoardVariables ?? (this as any)._isNormalComponent === true
+    const includesBoardVariable = rawValue.includes("board.")
+    const knownVariables: Record<string, number> = {}
+
+    if (allowBoardVariables) {
+      const board = this._getBoard()
+      const boardVariables = board?._getBoardCalcVariables() ?? {}
+
+      if (includesBoardVariable && !board) {
+        throw new Error(
+          `Cannot resolve ${axis} for ${this.componentName}: no board found for board.* variables`,
+        )
+      }
+
+      if (
+        includesBoardVariable &&
+        board &&
+        Object.keys(boardVariables).length === 0
+      ) {
+        throw new Error(
+          "Cannot do calculations based on board size when the board is auto-sized",
+        )
+      }
+
+      Object.assign(knownVariables, boardVariables)
+    }
+
+    try {
+      return evaluateCalcString(rawValue, { knownVariables })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(
+        `Invalid ${axis} value for ${this.componentName}: ${message}`,
+      )
+    }
+  }
+
   /**
    * Computes a transformation matrix from the props of this component for PCB
    * components
    */
   computePcbPropsTransform(): Matrix {
-    const { _parsedProps: props } = this
     const rotation = this._getPcbRotationBeforeLayout() ?? 0
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
 
     const matrix = compose(
-      translate(props.pcbX ?? 0, props.pcbY ?? 0),
+      translate(pcbX, pcbY),
       rotate((rotation * Math.PI) / 180),
     )
 
@@ -546,6 +606,19 @@ export abstract class PrimitiveComponent<
     return applyToPoint(this.computeSchematicGlobalTransform(), { x: 0, y: 0 })
   }
 
+  _getBoard(): (PrimitiveComponent & BoardI) | undefined {
+    let current: PrimitiveComponent | Renderable | null = this
+    while (current) {
+      const maybePrimitive = current as PrimitiveComponent
+      if ((maybePrimitive as any).componentName === "Board") {
+        return maybePrimitive as PrimitiveComponent & BoardI
+      }
+      current =
+        (current.parent as PrimitiveComponent | Renderable | null) ?? null
+    }
+    return this.root?._getBoard() as (PrimitiveComponent & BoardI) | undefined
+  }
+
   get root(): RootCircuit | null {
     return this.parent?.root ?? null
   }
@@ -824,7 +897,7 @@ export abstract class PrimitiveComponent<
         return this._parsedProps.layers
       }
       if (this.componentName === "PlatedHole") {
-        return this.root?._getBoard()?.allLayers ?? ["top", "bottom"]
+        return [...(this.root?._getBoard()?.allLayers ?? ["top", "bottom"])]
       }
       return []
     }

--- a/lib/components/normal-components/BoardI.ts
+++ b/lib/components/normal-components/BoardI.ts
@@ -1,0 +1,9 @@
+import type { LayerRef } from "circuit-json"
+
+export interface BoardI {
+  componentName: string
+  boardThickness: number
+  _connectedSchematicPortPairs: Set<string>
+  allLayers: ReadonlyArray<LayerRef>
+  _getBoardCalcVariables(): Record<string, number>
+}

--- a/lib/components/normal-components/Chip.ts
+++ b/lib/components/normal-components/Chip.ts
@@ -30,6 +30,7 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
 
     // Then, ensure that any pins referenced in externallyConnectedPins have ports created
     const { _parsedProps: props } = this
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
     if (props.externallyConnectedPins) {
       const requiredPorts = new Set<string>()
 
@@ -84,6 +85,7 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
   doInitialSourceRender(): void {
     const { db } = this.root!
     const { _parsedProps: props } = this
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
 
     const source_component = db.source_component.insert({
       ftype: "simple_chip",
@@ -99,6 +101,7 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
     if (this.root?.pcbDisabled) return
     const { db } = this.root!
     const { _parsedProps: props } = this
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
 
     // Validate that components can only be placed on top or bottom layers
     const componentLayer = props.layer ?? "top"
@@ -116,7 +119,7 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
     }
 
     const pcb_component = db.pcb_component.insert({
-      center: { x: props.pcbX ?? 0, y: props.pcbY ?? 0 },
+      center: { x: pcbX, y: pcbY },
       width: 2, // Default width, adjust as needed
       height: 3, // Default height, adjust as needed
       layer:

--- a/lib/components/normal-components/Jumper.ts
+++ b/lib/components/normal-components/Jumper.ts
@@ -49,6 +49,7 @@ export class Jumper<PinLabels extends string = never> extends NormalComponent<
   doInitialSourceRender(): void {
     const { db } = this.root!
     const { _parsedProps: props } = this
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
 
     const source_component = db.source_component.insert({
       ftype: "simple_chip", // TODO unknown or jumper
@@ -64,9 +65,10 @@ export class Jumper<PinLabels extends string = never> extends NormalComponent<
     if (this.root?.pcbDisabled) return
     const { db } = this.root!
     const { _parsedProps: props } = this
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
 
     const pcb_component = db.pcb_component.insert({
-      center: { x: props.pcbX ?? 0, y: props.pcbY ?? 0 },
+      center: { x: pcbX, y: pcbY },
       width: 2, // Default width, adjust as needed
       height: 3, // Default height, adjust as needed
       layer: props.layer ?? "top",

--- a/lib/components/normal-components/SolderJumper.ts
+++ b/lib/components/normal-components/SolderJumper.ts
@@ -125,6 +125,7 @@ export class SolderJumper<
   doInitialSourceRender(): void {
     const { db } = this.root!
     const { _parsedProps: props } = this
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
 
     const source_component = db.source_component.insert({
       ftype: "simple_chip", // TODO unknown or jumper
@@ -140,9 +141,10 @@ export class SolderJumper<
     if (this.root?.pcbDisabled) return
     const { db } = this.root!
     const { _parsedProps: props } = this
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
 
     const pcb_component = db.pcb_component.insert({
-      center: { x: props.pcbX ?? 0, y: props.pcbY ?? 0 },
+      center: { x: pcbX, y: pcbY },
       width: 2, // Default width, adjust as needed
       height: 3, // Default height, adjust as needed
       layer: props.layer ?? "top",

--- a/lib/components/primitive-components/BreakoutPoint.ts
+++ b/lib/components/primitive-components/BreakoutPoint.ts
@@ -53,7 +53,7 @@ export class BreakoutPoint extends PrimitiveComponent<
     if (this.root?.pcbDisabled) return
     const { db } = this.root!
     this._matchConnection()
-    const { pcbX = 0, pcbY = 0 } = this._parsedProps
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
     const group = this.parent?.getGroup()
     const subcircuit = this.getSubcircuit()
     if (!group || !group.pcb_group_id) return
@@ -76,7 +76,7 @@ export class BreakoutPoint extends PrimitiveComponent<
   }
 
   _getPcbCircuitJsonBounds() {
-    const { pcbX = 0, pcbY = 0 } = this._parsedProps
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
     return {
       center: { x: pcbX, y: pcbY },
       bounds: { left: pcbX, top: pcbY, right: pcbX, bottom: pcbY },

--- a/lib/components/primitive-components/CadModel.ts
+++ b/lib/components/primitive-components/CadModel.ts
@@ -54,9 +54,11 @@ export class CadModel extends PrimitiveComponent<typeof cadmodelProps> {
       rotationOffset.z = Number(parsed.z)
     }
 
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
+
     const positionOffset = point3.parse({
-      x: props.pcbX ?? 0,
-      y: props.pcbY ?? 0,
+      x: pcbX,
+      y: pcbY,
       z: props.pcbZ ?? 0,
       ...(typeof props.positionOffset === "object" ? props.positionOffset : {}),
     })

--- a/lib/components/primitive-components/ErrorPlaceholder.ts
+++ b/lib/components/primitive-components/ErrorPlaceholder.ts
@@ -4,6 +4,19 @@ import { z } from "zod"
 class ErrorPlaceholderComponent extends PrimitiveComponent {
   constructor(props: any, error: any) {
     super(props)
+    const resolveCoordinate = (value: unknown, axis: "pcbX" | "pcbY") => {
+      if (typeof value === "number") return value
+      if (typeof value === "string") {
+        try {
+          return this._resolvePcbCoordinate(value, axis, {
+            allowBoardVariables: false,
+          })
+        } catch (err) {
+          return 0
+        }
+      }
+      return 0
+    }
     this._parsedProps = {
       ...props,
       error,
@@ -11,8 +24,8 @@ class ErrorPlaceholderComponent extends PrimitiveComponent {
       component_name: props.name,
       error_type: "source_failed_to_create_component_error",
       message: error instanceof Error ? error.message : String(error),
-      pcbX: props.pcbX,
-      pcbY: props.pcbY,
+      pcbX: resolveCoordinate(props.pcbX, "pcbX"),
+      pcbY: resolveCoordinate(props.pcbY, "pcbY"),
       schX: props.schX,
       schY: props.schY,
     }

--- a/lib/components/primitive-components/FabricationNoteRect.ts
+++ b/lib/components/primitive-components/FabricationNoteRect.ts
@@ -18,6 +18,7 @@ export class FabricationNoteRect extends PrimitiveComponent<
     if (this.root?.pcbDisabled) return
     const { db } = this.root!
     const { _parsedProps: props } = this
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
     const { maybeFlipLayer } = this._getPcbPrimitiveFlippedHelpers()
 
     const layer = maybeFlipLayer(props.layer ?? "top") as "top" | "bottom"
@@ -43,8 +44,8 @@ export class FabricationNoteRect extends PrimitiveComponent<
       color: props.color,
 
       center: {
-        x: props.pcbX ?? 0,
-        y: props.pcbY ?? 0,
+        x: pcbX,
+        y: pcbY,
       },
       width: props.width,
       height: props.height,

--- a/lib/components/primitive-components/FabricationNoteText.ts
+++ b/lib/components/primitive-components/FabricationNoteText.ts
@@ -15,13 +15,14 @@ export class FabricationNoteText extends PrimitiveComponent<
     if (this.root?.pcbDisabled) return
     const { db } = this.root!
     const { _parsedProps: props } = this
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
     const container = this.getPrimitiveContainer()!
     const subcircuit = this.getSubcircuit()
     db.pcb_fabrication_note_text.insert({
       anchor_alignment: props.anchorAlignment,
       anchor_position: {
-        x: props.pcbX ?? 0,
-        y: props.pcbY ?? 0,
+        x: pcbX,
+        y: pcbY,
       },
       font: props.font ?? "tscircuit2024",
       font_size: props.fontSize ?? 1,

--- a/lib/components/primitive-components/SilkscreenCircle.ts
+++ b/lib/components/primitive-components/SilkscreenCircle.ts
@@ -18,6 +18,7 @@ export class SilkscreenCircle extends PrimitiveComponent<
     if (this.root?.pcbDisabled) return
     const { db } = this.root!
     const { _parsedProps: props } = this
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
     const { maybeFlipLayer } = this._getPcbPrimitiveFlippedHelpers()
     const layer = maybeFlipLayer(props.layer ?? "top") as "top" | "bottom"
 
@@ -37,8 +38,8 @@ export class SilkscreenCircle extends PrimitiveComponent<
       pcb_component_id,
       layer,
       center: {
-        x: props.pcbX ?? 0,
-        y: props.pcbY ?? 0,
+        x: pcbX,
+        y: pcbY,
       },
       radius: props.radius,
       subcircuit_id: subcircuit?.subcircuit_id ?? undefined,

--- a/lib/components/primitive-components/SilkscreenRect.ts
+++ b/lib/components/primitive-components/SilkscreenRect.ts
@@ -28,6 +28,7 @@ export class SilkscreenRect extends PrimitiveComponent<
     }
 
     const subcircuit = this.getSubcircuit()
+    const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
 
     const pcb_component_id =
       this.parent?.pcb_component_id ??
@@ -36,8 +37,8 @@ export class SilkscreenRect extends PrimitiveComponent<
       pcb_component_id,
       layer,
       center: {
-        x: props.pcbX ?? 0,
-        y: props.pcbY ?? 0,
+        x: pcbX,
+        y: pcbY,
       },
       width: props.width,
       height: props.height,

--- a/lib/utils/evaluateCalcString.ts
+++ b/lib/utils/evaluateCalcString.ts
@@ -1,0 +1,273 @@
+export interface EvaluateCalcOptions {
+  knownVariables: Record<string, number>
+  /**
+   * Optional unit multipliers relative to "mm".
+   * Example: { mm: 1, cm: 10, in: 25.4 }
+   */
+  units?: Record<string, number>
+}
+
+type NumberToken = {
+  type: "number"
+  value: number
+}
+
+type StringToken = {
+  type: "identifier" | "operator" | "paren"
+  value: string
+}
+
+type Token = NumberToken | StringToken
+
+const defaultUnits: Record<string, number> = {
+  mm: 1,
+  // You can add more if you need them:
+  // cm: 10,
+  // in: 25.4,
+  // mil: 0.0254,
+}
+
+export function evaluateCalcString(
+  input: string,
+  options: EvaluateCalcOptions,
+): number {
+  const { knownVariables, units: userUnits } = options
+  const units = { ...defaultUnits, ...(userUnits ?? {}) }
+
+  const expr = extractExpression(input)
+  const tokens = tokenize(expr, units)
+  const result = parseExpression(tokens, knownVariables)
+
+  return result
+}
+
+/**
+ * Strip the outer calc(...) if present and return the inner expression.
+ */
+function extractExpression(raw: string): string {
+  const trimmed = raw.trim()
+
+  if (!trimmed.toLowerCase().startsWith("calc")) {
+    // Not a calc() wrapper, treat as a plain expression
+    return trimmed
+  }
+
+  const match = trimmed.match(/^calc\s*\((.*)\)$/is)
+  if (!match) {
+    throw new Error(`Invalid calc() expression: "${raw}"`)
+  }
+  return match[1].trim()
+}
+
+/**
+ * Tokenizer: turns "board.minx + 1mm" into tokens.
+ */
+function tokenize(expr: string, units: Record<string, number>): Token[] {
+  const tokens: Token[] = []
+  let i = 0
+
+  const isDigit = (ch: string) => ch >= "0" && ch <= "9"
+  const isIdentStart = (ch: string) =>
+    (ch >= "A" && ch <= "Z") || (ch >= "a" && ch <= "z") || ch === "_"
+  const isIdentChar = (ch: string) =>
+    isIdentStart(ch) || isDigit(ch) || ch === "."
+
+  while (i < expr.length) {
+    const ch = expr[i]
+
+    // Whitespace -> skip
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      i++
+      continue
+    }
+
+    // Number (possibly with unit like "mm")
+    if (
+      isDigit(ch) ||
+      (ch === "." && i + 1 < expr.length && isDigit(expr[i + 1]))
+    ) {
+      const start = i
+      i++ // consume first char
+
+      // digits and decimal points
+      while (i < expr.length) {
+        const c = expr[i]
+        if (isDigit(c) || c === ".") {
+          i++
+        } else {
+          break
+        }
+      }
+
+      const numberText = expr.slice(start, i)
+      let num = Number(numberText)
+      if (Number.isNaN(num)) {
+        throw new Error(`Invalid number: "${numberText}"`)
+      }
+
+      // Optional unit directly after number (e.g. "1mm")
+      const unitStart = i
+      while (i < expr.length && /[A-Za-z]/.test(expr[i])) {
+        i++
+      }
+      if (i > unitStart) {
+        const unitText = expr.slice(unitStart, i)
+        const factor = units[unitText]
+        if (factor == null) {
+          throw new Error(`Unknown unit: "${unitText}"`)
+        }
+        num *= factor
+      }
+
+      tokens.push({ type: "number", value: num })
+      continue
+    }
+
+    // Identifier: board.minx, foo, x1, etc.
+    if (isIdentStart(ch)) {
+      const start = i
+      i++
+      while (i < expr.length && isIdentChar(expr[i])) {
+        i++
+      }
+      const ident = expr.slice(start, i)
+      tokens.push({ type: "identifier", value: ident })
+      continue
+    }
+
+    // Parentheses
+    if (ch === "(" || ch === ")") {
+      tokens.push({ type: "paren", value: ch })
+      i++
+      continue
+    }
+
+    // Operators
+    if (ch === "+" || ch === "-" || ch === "*" || ch === "/") {
+      tokens.push({ type: "operator", value: ch })
+      i++
+      continue
+    }
+
+    throw new Error(`Unexpected character "${ch}" in expression "${expr}"`)
+  }
+
+  return tokens
+}
+
+/**
+ * Recursive‑descent parser / evaluator
+ * Grammar:
+ *   expression := term (("+" | "-") term)*
+ *   term       := factor (("*" | "/") factor)*
+ *   factor     := ("+" | "-") factor | primary
+ *   primary    := NUMBER | IDENTIFIER | "(" expression ")"
+ */
+function parseExpression(
+  tokens: Token[],
+  vars: Record<string, number>,
+): number {
+  let index = 0
+
+  const peek = (): Token | undefined => tokens[index]
+  const consume = (): Token => tokens[index++]
+
+  const parsePrimary = (): number => {
+    const token = peek()
+    if (!token) {
+      throw new Error("Unexpected end of expression")
+    }
+
+    if (token.type === "number") {
+      consume()
+      return token.value
+    }
+
+    if (token.type === "identifier") {
+      consume()
+      const value = vars[token.value]
+      if (value == null) {
+        throw new Error(`Unknown variable: "${token.value}"`)
+      }
+      return value
+    }
+
+    if (token.type === "paren" && token.value === "(") {
+      consume() // "("
+      const value = parseExpr()
+      const next = peek()
+      if (!next || next.type !== "paren" || next.value !== ")") {
+        throw new Error('Expected ")"')
+      }
+      consume() // ")"
+      return value
+    }
+
+    throw new Error(`Unexpected token "${(token as any).value}"`)
+  }
+
+  const parseFactor = (): number => {
+    const token = peek()
+    if (
+      token &&
+      token.type === "operator" &&
+      (token.value === "+" || token.value === "-")
+    ) {
+      // Unary +/−
+      consume()
+      const value = parseFactor()
+      return token.value === "+" ? value : -value
+    }
+    return parsePrimary()
+  }
+
+  const parseTerm = (): number => {
+    let value = parseFactor()
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const token = peek()
+      if (!token || token.type !== "operator") break
+      if (token.value !== "*" && token.value !== "/") break
+
+      consume()
+      const rhs = parseFactor()
+      if (token.value === "*") {
+        value *= rhs
+      } else {
+        value /= rhs
+      }
+    }
+    return value
+  }
+
+  const parseExpr = (): number => {
+    let value = parseTerm()
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const token = peek()
+      if (!token || token.type !== "operator") break
+      if (token.value !== "+" && token.value !== "-") break
+
+      consume()
+      const rhs = parseTerm()
+      if (token.value === "+") {
+        value += rhs
+      } else {
+        value -= rhs
+      }
+    }
+    return value
+  }
+
+  const result = parseExpr()
+
+  if (index < tokens.length) {
+    const leftover = tokens
+      .slice(index)
+      .map((t) => ("value" in t ? (t as any).value : "?"))
+      .join(" ")
+    throw new Error(`Unexpected tokens at end of expression: ${leftover}`)
+  }
+
+  return result
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@tscircuit/math-utils": "^0.0.29",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.4",
-    "@tscircuit/props": "^0.0.419",
+    "@tscircuit/props": "^0.0.421",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/schematic-trace-solver": "^v0.0.45",

--- a/tests/components/pcb/calc-pcb-position.test.tsx
+++ b/tests/components/pcb/calc-pcb-position.test.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/**
+ * These tests ensure pcbX/pcbY support calc(...) expressions with board variables.
+ */
+test("pcb coordinates can use calc expressions with board bounds", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="10mm">
+      <resistor
+        name="R1"
+        footprint="0402"
+        resistance="1k"
+        pcbX="calc(board.minx + 1mm)"
+        pcbY="calc(board.maxy - 1mm)"
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  // Inspect generated PCB components
+  const pcbComponents = circuit.db.pcb_component.list()
+  expect(pcbComponents.length).toBeGreaterThan(0)
+  const errors = circuit.db.source_failed_to_create_component_error.list()
+  expect(errors.length).toBe(0)
+
+  const resistor = pcbComponents[0]
+  expect(resistor?.center.x).toBeCloseTo(-9)
+  expect(resistor?.center.y).toBeCloseTo(4)
+})
+
+test("calc expressions using board bounds fail for auto-sized boards", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board>
+      <resistor
+        name="R1"
+        footprint="0402"
+        resistance="1k"
+        pcbX="calc(board.minx + 1mm)"
+      />
+    </board>,
+  )
+
+  try {
+    circuit.render()
+    throw new Error("render should have thrown")
+  } catch (error) {
+    expect((error as Error).message).toContain(
+      "Cannot do calculations based on board size when the board is auto-sized",
+    )
+  }
+})


### PR DESCRIPTION
## Summary
- add calc string evaluation and PCB position resolution with board bounds context
- provide board traversal and calc variable support while guarding auto-sized boards
- update primitives to use resolved PCB positions and cover calc usage with new tests

## Testing
- bun test tests/components/pcb/calc-pcb-position.test.tsx
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692bb780444c832e804a41c0a6555917)