### PR TITLE
Propagate async effect detection to children

### DIFF
--- a/lib/RootCircuit.ts
+++ b/lib/RootCircuit.ts
@@ -168,12 +168,7 @@ export class RootCircuit {
   }
 
   private _hasIncompleteAsyncEffects(): boolean {
-    return this.children.some((child) => {
-      if (child._hasIncompleteAsyncEffects()) return true
-      return child.children.some((grandchild) =>
-        grandchild._hasIncompleteAsyncEffects(),
-      )
-    })
+    return this.children.some((child) => child._hasIncompleteAsyncEffects())
   }
 
   getCircuitJson(): AnyCircuitElement[] {

--- a/lib/components/base-components/Renderable.ts
+++ b/lib/components/base-components/Renderable.ts
@@ -232,7 +232,13 @@ export abstract class Renderable implements IRenderable {
   }
 
   _hasIncompleteAsyncEffects(): boolean {
-    return this._asyncEffects.some((effect) => !effect.complete)
+    if (this._asyncEffects.some((effect) => !effect.complete)) return true
+
+    return this.children.some((child) =>
+      typeof (child as Renderable)._hasIncompleteAsyncEffects === "function"
+        ? (child as Renderable)._hasIncompleteAsyncEffects()
+        : false,
+    )
   }
 
   _hasIncompleteAsyncEffectsInSubtreeForPhase(phase: RenderPhase): boolean {

--- a/tests/footprint/footprint-kicad-url-in-group.test.tsx
+++ b/tests/footprint/footprint-kicad-url-in-group.test.tsx
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import kicadModJson from "tests/fixtures/assets/R_0402_1005Metric.json" with {
+  type: "json",
+}
+
+test("chip with kicad url footprint renders inside group", async () => {
+  let loadCalled = false
+  const { circuit } = getTestFixture({
+    platform: {
+      footprintFileParserMap: {
+        kicad_mod: {
+          loadFromUrl: async (url: string) => {
+            expect(url).toBe("https://cdn.example.com/footprint.kicad_mod")
+            loadCalled = true
+            return { footprintCircuitJson: kicadModJson }
+          },
+        },
+      },
+    },
+  })
+
+  circuit.add(
+    <board>
+      <group>
+        <chip
+          name="U1"
+          footprint="https://cdn.example.com/footprint.kicad_mod"
+        />
+      </group>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(loadCalled).toBeTrue()
+  const pcbPads = circuit
+    .getCircuitJson()
+    .filter((element) => element.type === "pcb_smtpad")
+  expect(pcbPads.length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Summary
- check renderable children for incomplete async effects so traversal is shared across component types
- remove the redundant Group override now that the base class handles children

## Testing
- bun test tests/footprint/footprint-kicad-url-in-group.test.tsx
- bunx tsc --noEmit
- bun run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692fbfe67f74832eaa9816557d9e8b49)