### PR TITLE
fix kicad_mod footprint loading for chips inside groups

### DIFF
--- a/lib/RootCircuit.ts
+++ b/lib/RootCircuit.ts
@@ -168,7 +168,14 @@ export class RootCircuit {
   }
 
   private _hasIncompleteAsyncEffects(): boolean {
-    return this.children.some((child) => child._hasIncompleteAsyncEffects())
+    const checkComponent = (component: PrimitiveComponent): boolean => {
+      if (component._hasIncompleteAsyncEffects?.()) return true
+      if (component.children) {
+        return component.children.some((child) => checkComponent(child))
+      }
+      return false
+    }
+    return this.children.some((child) => checkComponent(child))
   }
 
   getCircuitJson(): AnyCircuitElement[] {

--- a/tests/footprint/footprint-in-group.test.tsx
+++ b/tests/footprint/footprint-in-group.test.tsx
@@ -1,0 +1,44 @@
+import { expect, it } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import kicadModJson from "tests/fixtures/assets/R_0402_1005Metric.json" with {
+  type: "json",
+}
+
+it("chip with footprint inside group should load footprint", async () => {
+  const resolvedUrl = "https://cdn.example.com/footprint.kicad_mod"
+  let loadCalls = 0
+
+  const { circuit } = getTestFixture({
+    platform: {
+      projectBaseUrl: "http://localhost:3020/api/files/static",
+      resolveProjectStaticFileImportUrl: async (path: string) => {
+        return resolvedUrl
+      },
+      footprintFileParserMap: {
+        kicad_mod: {
+          loadFromUrl: async (url: string) => {
+            loadCalls += 1
+            return {
+              footprintCircuitJson: kicadModJson,
+            }
+          },
+        },
+      },
+    },
+  })
+
+  circuit.add(
+    <board>
+      <group name="MCU">
+        <chip footprint="/api/files/static/footprint.kicad_mod" name="U2" />
+      </group>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(loadCalls).toBe(1)
+
+  const smtpads = circuit.selectAll("smtpad")
+  expect(smtpads.length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
/fixes #1704 

problem: RootCircuit._hasIncompleteAsyncEffects() only checked 2 levels deep (children and grandchildren)
solution: Made _hasIncompleteAsyncEffects() recursively check all descendants at any depth.