### PR TITLE
Ensure single-layer boards use assignable via solver

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -486,6 +486,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     debug(`[${this.getString()}] starting local autorouting`)
     const autorouterConfig = this._getAutorouterConfig()
     const isLaserPrefabPreset = this._isLaserPrefabAutorouter(autorouterConfig)
+    const isSingleLayerBoard = this._getSubcircuitLayerCount() === 1
 
     const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
       db,
@@ -523,7 +524,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         // Optional configuration parameters
         capacityDepth: this.props.autorouter?.capacityDepth,
         targetMinCapacity: this.props.autorouter?.targetMinCapacity,
-        useAssignableViaSolver: isLaserPrefabPreset,
+        useAssignableViaSolver: isLaserPrefabPreset || isSingleLayerBoard,
       })
     }
 

--- a/tests/components/normal-components/interconnect-single-layer-bridge.test.tsx
+++ b/tests/components/normal-components/interconnect-single-layer-bridge.test.tsx
@@ -5,7 +5,7 @@ test("interconnect acts as bridge across cutout on single-layer board", async ()
   const { circuit } = getTestFixture()
 
   circuit.add(
-    <board width="20mm" height="8mm" layers={1} autorouter="laser_prefab">
+    <board width="20mm" height="8mm" layers={1}>
       <silkscreentext
         text="Trace should use the interconnect to cross the cutout"
         pcbX={-10}


### PR DESCRIPTION
## Summary
- ensure single-layer boards use the assignable via autorouting solver, matching laser_prefab behavior
- remove the explicit laser_prefab preset from the single-layer interconnect bridge test

## Testing
- bun test tests/components/normal-components/interconnect-single-layer-bridge.test.tsx
- bunx tsc --noEmit
- bun run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693a14516f1c832e8fec74960bbad03e)