### PR TITLE
Add PCB position metadata

### DIFF
--- a/tests/components/normal-components/pcb-component-relative-positioning1.test.tsx
+++ b/tests/components/normal-components/pcb-component-relative-positioning1.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test.skip("pcb components include relative positioning metadata 1", async () => {
+test("pcb components include relative positioning metadata 1", async () => {
   const { circuit } = getTestFixture()
 
   circuit.add(

--- a/tests/components/normal-components/pcb-component-relative-positioning2.test.tsx
+++ b/tests/components/normal-components/pcb-component-relative-positioning2.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test.skip("pcb components include relative positioning metadata 2", async () => {
+test("pcb components include relative positioning metadata 2", async () => {
   const { circuit } = getTestFixture()
 
   circuit.add(


### PR DESCRIPTION
## Summary
- add PCB position metadata during layout to capture packed and relative placements
- enable relative positioning tests for PCB components

## Testing
- bunx tsc --noEmit
- bun test tests/components/normal-components/pcb-component-relative-positioning1.test.tsx
- bun test tests/components/normal-components/pcb-component-relative-positioning2.test.tsx
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693a638d19ac832e98d9abcecba6aa1f)