### PR TITLE
Add solver started event and export solver map

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -525,6 +525,13 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         capacityDepth: this.props.autorouter?.capacityDepth,
         targetMinCapacity: this.props.autorouter?.targetMinCapacity,
         useAssignableViaSolver: isLaserPrefabPreset || isSingleLayerBoard,
+        onSolverStarted: ({ solverName, solverParams }) =>
+          this.root?.emit("solver:started", {
+            type: "solver:started",
+            solverName,
+            solverParams,
+            componentName: this.getString(),
+          }),
       })
     }
 

--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
@@ -1,6 +1,6 @@
 import type { Group } from "../Group"
 import {
-  pack,
+  PackSolver2,
   convertCircuitJsonToPackOutput,
   convertPackOutputToPackInput,
   getGraphicsFromPackOutput,
@@ -167,7 +167,20 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
 
   let packOutput: PackOutput
   try {
-    packOutput = pack(packInput)
+    const solver = new PackSolver2(packInput)
+    group.root?.emit("solver:started", {
+      type: "solver:started",
+      solverName: solver.constructor.name,
+      solverParams: solver.getConstructorParams(),
+      componentName: group.getString(),
+    })
+
+    solver.solve()
+
+    packOutput = {
+      ...packInput,
+      components: solver.packedComponents,
+    }
   } catch (error) {
     group.root?.emit("packing:error", {
       subcircuit_id: group.subcircuit_id,

--- a/lib/events/index.ts
+++ b/lib/events/index.ts
@@ -16,6 +16,7 @@ export type RootCircuitEventName =
   | "packing:start"
   | "packing:end"
   | "packing:error"
+  | "solver:started"
   | "renderComplete"
   | "debug:logOutput"
 
@@ -65,6 +66,13 @@ export interface PackingErrorEvent {
   subcircuit_id: string | null
   componentDisplayName: string
   error?: { message: string }
+}
+
+export interface SolverStartedEvent {
+  type: "solver:started"
+  solverName: string
+  solverParams: unknown
+  componentName: string
 }
 
 export interface DebugLogOutputEvent {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -17,6 +17,7 @@ export * from "./utils/autorouting/GenericLocalAutorouter"
 export * from "./utils/edit-events/apply-pcb-edit-events-to-manual-edits-file"
 export * from "./utils/edit-events/apply-schematic-edit-events-to-manual-edits-file"
 export * from "./utils/edit-events/apply-edit-events-to-circuit-json"
+export * from "./solvers"
 
 // Allows easier introspection of render process
 export * from "./components/base-components/Renderable"

--- a/lib/solvers.ts
+++ b/lib/solvers.ts
@@ -1,0 +1,13 @@
+import { PackSolver2 } from "calculate-packing"
+import {
+  AutoroutingPipelineSolver,
+  AssignableViaAutoroutingPipelineSolver,
+} from "@tscircuit/capacity-autorouter"
+
+export const SOLVERS = {
+  PackSolver2,
+  AutoroutingPipelineSolver,
+  AssignableViaAutoroutingPipelineSolver,
+}
+
+export type SolverName = keyof typeof SOLVERS

--- a/lib/utils/autorouting/CapacityMeshAutorouter.ts
+++ b/lib/utils/autorouting/CapacityMeshAutorouter.ts
@@ -18,6 +18,10 @@ export interface CapacityMeshAutoRouterOptions {
   targetMinCapacity?: number
   stepDelay?: number
   useAssignableViaSolver?: boolean
+  onSolverStarted?: (details: {
+    solverName: string
+    solverParams: unknown
+  }) => void
 }
 
 export class CapacityMeshAutorouter implements GenericLocalAutorouter {
@@ -49,6 +53,7 @@ export class CapacityMeshAutorouter implements GenericLocalAutorouter {
       targetMinCapacity,
       stepDelay = 0,
       useAssignableViaSolver = false,
+      onSolverStarted,
     } = options
 
     // Initialize the solver with input and optional configuration
@@ -65,6 +70,18 @@ export class CapacityMeshAutorouter implements GenericLocalAutorouter {
       capacityDepth,
       targetMinCapacity,
       cacheProvider: null,
+    })
+
+    onSolverStarted?.({
+      solverName: SolverClass.name,
+      solverParams: {
+        input,
+        options: {
+          capacityDepth,
+          targetMinCapacity,
+          cacheProvider: null,
+        },
+      },
     })
 
     this.stepDelay = stepDelay

--- a/tests/examples/example36-packing-events.test.tsx
+++ b/tests/examples/example36-packing-events.test.tsx
@@ -56,3 +56,29 @@ test("packing:start does NOT fire when components have pcbX/pcbY", async () => {
   // Packing should NOT run when components have explicit positions
   expect(packingStarted).toBe(false)
 })
+
+test("solver:started fires with packing solver details", async () => {
+  const { circuit } = getTestFixture()
+  let solverStartedEvent: any
+
+  circuit.on("solver:started", (event) => {
+    solverStartedEvent = event
+  })
+
+  circuit.add(
+    <board routingDisabled>
+      <resistor name="R1" footprint={"0402"} resistance={"100"} />
+      <capacitor name="C1" footprint={"0402"} capacitance={"100nF"} />
+    </board>,
+  )
+
+  circuit.render()
+
+  expect(solverStartedEvent?.solverName).toBe("PackSolver2")
+  expect(solverStartedEvent?.componentName.replace(/#\d+/, "#")).toBe(
+    "<board# />",
+  )
+  expect(solverStartedEvent?.solverParams).toMatchObject({
+    minGap: expect.any(Number),
+  })
+})

--- a/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter1.test.ts
+++ b/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter1.test.ts
@@ -55,3 +55,22 @@ test("CapacityMeshAutorouter should solve a simple routing problem", () => {
   expect(firstPoint.y).toBeCloseTo(0, 0)
   expect(lastPoint.y).toBeCloseTo(0, 0)
 })
+
+test("CapacityMeshAutorouter invokes onSolverStarted callback", () => {
+  const simpleRouteJson = createTestSimpleRouteJson()
+  let solverDetails: any
+
+  new CapacityMeshAutorouter(simpleRouteJson, {
+    onSolverStarted: (details) => {
+      solverDetails = details
+    },
+  })
+
+  expect(solverDetails?.solverName).toBeDefined()
+  expect(solverDetails?.solverParams).toMatchObject({
+    input: simpleRouteJson,
+    options: expect.objectContaining({
+      cacheProvider: null,
+    }),
+  })
+})


### PR DESCRIPTION
## Summary
- emit a new `solver:started` event with solver names, params, and component context for packing and autorouting
- expose a `SOLVERS` export that maps solver constructor names to their classes
- add tests covering packing solver events and autorouter solver start callbacks

## Testing
- bun test tests/examples/example36-packing-events.test.tsx
- bun test tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter1.test.ts
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c890d9f30832ebf8dfa1925ab65cb)