### PR TITLE
Fix SimpleRouteJson layer count for single-layer boards

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -122,6 +122,9 @@ export class Board
    */
   get allLayers() {
     const layerCount = this._parsedProps.layers ?? 2
+    if (layerCount === 1) {
+      return ["top"] as const
+    }
     if (layerCount === 4) {
       return ["top", "bottom", "inner1", "inner2"] as const
     }

--- a/tests/utils/autorouting/simple-route-json-layer-count.test.tsx
+++ b/tests/utils/autorouting/simple-route-json-layer-count.test.tsx
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+
+test("simple route json respects single-layer board layerCount", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm" layers={1}>
+      <testpoint
+        name="TP1"
+        footprintVariant="pad"
+        pcbX={-2}
+        pcbY={0}
+        layer="top"
+      />
+      <testpoint
+        name="TP2"
+        footprintVariant="pad"
+        pcbX={2}
+        pcbY={0}
+        layer="top"
+      />
+      <trace from="TP1.pin1" to="TP2.pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
+    db: circuit.db,
+  })
+
+  expect(simpleRouteJson.layerCount).toBe(1)
+})


### PR DESCRIPTION
### Motivation
- Ensure that when a board is created with `layers={1}` the autorouter input (`SimpleRouteJson.layerCount`) reflects a single-layer board.
- Previously the board layer list always returned at least `['top','bottom']` which caused `layerCount` to be incorrect for single-layer boards.

### Description
- Add a special case in `Board.get allLayers()` to return `['top']` when `this._parsedProps.layers === 1` in `lib/components/normal-components/Board.ts`.
- Add a new test `tests/utils/autorouting/simple-route-json-layer-count.test.tsx` that builds a single-layer board and asserts `simpleRouteJson.layerCount === 1` via `getSimpleRouteJsonFromCircuitJson`.
- This change causes the persisted `num_layers`/`allLayers.length` used when generating `SimpleRouteJson` to be correct for single-layer boards.

### Testing
- Ran `bun test tests/utils/autorouting/simple-route-json-layer-count.test.tsx` and the test passed.
- Ran `bunx tsc --noEmit` for type checking and it succeeded.
- Ran `bun run format` to apply formatting which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6948561a376c832ebf92ff6b3ad981e7)