### PR TITLE
Disable parts engine when BOM is disabled

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -1517,6 +1517,7 @@ export class NormalComponent<
 
   doInitialPartsEngineRender(): void {
     if (this.props.doNotPlace) return
+    if (this.getInheritedProperty("bomDisabled")) return
     const partsEngine = this.getInheritedProperty("partsEngine")
     if (!partsEngine) return
     const { db } = this.root!
@@ -1566,6 +1567,7 @@ export class NormalComponent<
 
   updatePartsEngineRender(): void {
     if (this.props.doNotPlace) return
+    if (this.getInheritedProperty("bomDisabled")) return
     const { db } = this.root!
 
     const source_component = db.source_component.get(this.source_component_id!)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@tscircuit/math-utils": "^0.0.29",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.8",
-    "@tscircuit/props": "^0.0.432",
+    "@tscircuit/props": "^0.0.435",
     "@tscircuit/schematic-autolayout": "^0.0.6",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/schematic-trace-solver": "^v0.0.45",


### PR DESCRIPTION
### Motivation

- The `bomDisabled` flag in group props should disable BOM/parts-engine behavior to avoid supplier lookups when BOM is intentionally turned off.
- Parts engine supplier lookups may perform network/cache operations that should be skipped when BOM is disabled.
- The `@tscircuit/props` package was updated to expose the `bomDisabled` property in the inherited props chain.
- Preventing unnecessary parts lookups reduces noise and potential errors when BOM is disabled.

### Description

- Bumped `@tscircuit/props` dependency to `^0.0.435` in `package.json` to pick up `bomDisabled` typings.
- Added an inherited-property check `if (this.getInheritedProperty("bomDisabled")) return` to `doInitialPartsEngineRender` to skip initial supplier lookups when BOM is disabled.
- Added the same inherited-property check to `updatePartsEngineRender` to avoid updating supplier data when BOM is disabled.
- No other behavior changes; existing `doNotPlace` guarding remains in place.

### Testing

- Ran typecheck with `bunx tsc --noEmit`, which completed successfully.
- Ran formatter with `bun run format`, which completed successfully.
- Executed `bun update --latest @tscircuit/props` to update the dependency, which completed successfully.
- No unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694886d0c1f4832eae0fccbbe9d8310d)