### PR TITLE
Skip missing trace warnings for Interconnect components

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialSourceDesignRuleChecks.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialSourceDesignRuleChecks.ts
@@ -46,6 +46,9 @@ export const shouldCheckPortForMissingTrace = (
   component: NormalComponent,
   port: Port,
 ): boolean => {
+  if (component.config.componentName === "Interconnect") {
+    return false
+  }
   if (component.config.componentName === "Chip") {
     const pinAttributes = (component.props as any).pinAttributes
     if (!pinAttributes) return false


### PR DESCRIPTION
### Motivation
- Interconnect components that represent off-board or 0-ohm jumper connections were producing false positive `source_pin_missing_trace_warning` DRCs.
- The change prevents interconnect ports from being checked for missing traces since their connectivity can be expressed via internal connections or off-board routing.

### Description
- Short-circuit `shouldCheckPortForMissingTrace` to return `false` when `component.config.componentName === "Interconnect"`.
- The update is in `lib/components/base-components/NormalComponent/NormalComponent_doInitialSourceDesignRuleChecks.ts` and avoids inserting missing-trace warnings for interconnects.
- All other components retain the existing missing-trace checking logic.

### Testing
- Ran `bun test tests/features/interconnect-no-false-positive-drc.test.tsx` and it passed.
- Ran `bunx tsc --noEmit` and TypeScript typechecking succeeded.
- Ran `bun run format` to format the code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69520d777324832e8d8a006bf397d1ee)