### PR TITLE
Pass autorouter effort level to local solver

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -44,6 +44,10 @@ import { Group_doInitialSimulationSpiceEngineRender } from "./Group_doInitialSim
 import { Group_doInitialPcbComponentAnchorAlignment } from "./Group_doInitialPcbComponentAnchorAlignment"
 import { computeCenterFromAnchorPosition } from "./utils/computeCenterFromAnchorPosition"
 
+const getAutorouterEffort = (
+  level?: SubcircuitGroupProps["autorouterEffortLevel"],
+) => (level ? parseFloat(level.replace("x", "")) : undefined)
+
 export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
   extends NormalComponent<Props>
   implements ISubcircuit
@@ -495,6 +499,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     const autorouterConfig = this._getAutorouterConfig()
     const isLaserPrefabPreset = this._isLaserPrefabAutorouter(autorouterConfig)
     const isSingleLayerBoard = this._getSubcircuitLayerCount() === 1
+    const effort = getAutorouterEffort(props.autorouterEffortLevel)
 
     const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
       db,
@@ -534,6 +539,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         capacityDepth: this.props.autorouter?.capacityDepth,
         targetMinCapacity: this.props.autorouter?.targetMinCapacity,
         useAssignableSolver: isLaserPrefabPreset || isSingleLayerBoard,
+        effort,
         onSolverStarted: ({ solverName, solverParams }) =>
           this.root?.emit("solver:started", {
             type: "solver:started",

--- a/lib/utils/autorouting/CapacityMeshAutorouter.ts
+++ b/lib/utils/autorouting/CapacityMeshAutorouter.ts
@@ -18,6 +18,7 @@ export interface AutorouterOptions {
   targetMinCapacity?: number
   stepDelay?: number
   useAssignableSolver?: boolean
+  effort?: number
   onSolverStarted?: (details: {
     solverName: string
     solverParams: unknown
@@ -48,6 +49,7 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
       targetMinCapacity,
       stepDelay = 0,
       useAssignableSolver = false,
+      effort,
       onSolverStarted,
     } = options
 
@@ -58,21 +60,20 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
       : "AutoroutingPipelineSolver"
     const SolverClass = SOLVERS[solverName]
 
-    this.solver = new SolverClass(input as any, {
+    const solverOptions = {
       capacityDepth,
       targetMinCapacity,
       cacheProvider: null,
-    })
+      effort,
+    } as any
+
+    this.solver = new SolverClass(input as any, solverOptions)
 
     onSolverStarted?.({
       solverName,
       solverParams: {
         input,
-        options: {
-          capacityDepth,
-          targetMinCapacity,
-          cacheProvider: null,
-        },
+        options: solverOptions,
       },
     })
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "@resvg/resvg-js": "^2.6.2",
-    "@tscircuit/capacity-autorouter": "^0.0.210",
+    "@tscircuit/capacity-autorouter": "^0.0.211",
     "@tscircuit/checks": "^0.0.87",
     "@tscircuit/circuit-json-util": "^0.0.73",
     "@tscircuit/common": "^0.0.20",

--- a/tests/features/autorouter-effort-level.test.tsx
+++ b/tests/features/autorouter-effort-level.test.tsx
@@ -1,0 +1,51 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "../fixtures/get-test-fixture"
+
+test("autorouterEffortLevel passes effort into local autorouter", async () => {
+  const { circuit } = getTestFixture()
+  let solverStartedEvent: any
+
+  circuit.on("solver:started", (event) => {
+    if (
+      event.solverName === "AutoroutingPipelineSolver" ||
+      event.solverName === "AssignableAutoroutingPipeline2"
+    ) {
+      solverStartedEvent = event
+    }
+  })
+
+  circuit.add(
+    <board
+      width="20mm"
+      height="20mm"
+      autorouterEffortLevel="2x"
+      autorouter={{
+        local: true,
+        groupMode: "subcircuit",
+      }}
+    >
+      <resistor
+        name="R1"
+        pcbX={-5}
+        pcbY={0}
+        resistance={10000}
+        footprint="0402"
+      />
+      <resistor
+        name="R2_obstacle"
+        resistance="1k"
+        pcbX={0}
+        pcbY={0}
+        footprint="0402"
+      />
+      <led name="LED1" pcbX={5} pcbY={0} footprint="0603" />
+
+      <trace from=".R1 > .pin2" to=".LED1 > .anode" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(solverStartedEvent).toBeDefined()
+  expect(solverStartedEvent?.solverParams?.options?.effort).toBe(2)
+})


### PR DESCRIPTION
### Motivation
- Allow `autorouterEffortLevel` strings on subcircuits/boards to control the numeric solver effort used by the local autorouter. 
- Ensure the numeric `effort` is forwarded into the solver instantiation and included in emitted `solver:started` params. 

### Description
- Parse `autorouterEffortLevel` with `parseFloat(level.replace("x", ""))` in `Group` to produce a numeric `effort` value. 
- Add an optional `effort?: number` field to `AutorouterOptions` and pass the value through to the `TscircuitAutorouter` constructor. 
- Build a `solverOptions` object cast as `any` and pass it to the underlying solver to avoid strict solver option typing conflicts while still emitting the options via `onSolverStarted`. 
- Update the dev dependency `@tscircuit/capacity-autorouter` to `^0.0.211` and add `tests/features/autorouter-effort-level.test.tsx` to validate forwarding of `effort`. 

### Testing
- Ran `bun test tests/features/autorouter-effort-level.test.tsx` and the test passed (1 pass, 0 fail). 
- Ran `bunx tsc --noEmit` for typechecking and it completed without errors. 
- Ran `bun run format` to apply formatting changes and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6952f65dd454832e88e55f3123bd68ab)