### PR TITLE
Report invalid pinLabels keys as warnings instead of throwing

### DIFF
--- a/lib/utils/filterPinLabels.ts
+++ b/lib/utils/filterPinLabels.ts
@@ -24,6 +24,12 @@ export function filterPinLabels(
   const invalidPinLabelsMessages: string[] = []
 
   for (const [pin, labelOrLabels] of Object.entries(pinLabels)) {
+    if (!isValidPinLabelKey(pin)) {
+      invalidPinLabelsMessages.push(
+        `Invalid pinLabels key "${pin}" - expected a number or "pin\${number}".`,
+      )
+      continue
+    }
     const labels: string[] = Array.isArray(labelOrLabels)
       ? (labelOrLabels as string[]).slice() // Convert readonly to mutable
       : [labelOrLabels as string]
@@ -72,4 +78,8 @@ function isValidPinLabel(pin: string, label: string): boolean {
   } catch (error) {
     return false
   }
+}
+
+function isValidPinLabelKey(pin: string): boolean {
+  return /^\d+$/.test(pin) || /^pin\d+$/.test(pin)
 }

--- a/tests/components/normal-components/chip-invalid-pinlabel-key.test.tsx
+++ b/tests/components/normal-components/chip-invalid-pinlabel-key.test.tsx
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("chip pinLabels invalid key emits circuit json error", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{
+          foo: "VCC",
+        }}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const errors = circuit
+    .getCircuitJson()
+    .filter((el) => el.type === "source_property_ignored_warning")
+
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toBe(
+    'Invalid pinLabels key "foo" - expected a number or "pin${number}".',
+  )
+})


### PR DESCRIPTION
### Motivation

- Prevent component creation from throwing when encountering invalid `pinLabels` keys and instead surface them as warnings in circuit JSON.
- Centralize pin label key validation in the label-filtering logic and provide descriptive messages for invalid keys and labels.
- Allow components to render even if some pin labels are invalid by filtering invalid entries rather than failing fast.

### Description

- Add `isValidPinLabelKey` to `lib/utils/filterPinLabels.ts` and emit `Invalid pinLabels key "..." - expected a number or "pin${number}".` for invalid keys.
- Continue validating individual labels via the `chipProps` schema and collect `invalidPinLabelsMessages` while returning `validPinLabels` from `filterPinLabels`.
- Remove the throw in `lib/components/base-components/NormalComponent/NormalComponent.ts` so invalid key messages surface as `source_property_ignored_warning` warnings instead of creation errors.
- Update `tests/components/normal-components/chip-invalid-pinlabel-key.test.tsx` to assert the warning type and exact message.

### Testing

- Ran `bun test tests/components/normal-components/chip-invalid-pinlabel-key.test.tsx` and it passed.
- Ran `bunx tsc --noEmit` for type-checking and it completed without errors.
- Ran `bun run format` and formatting completed successfully.
- Attempted `bun update --latest some-dep` which failed due to a 404 when fetching the package.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69561fd2cdb4832e97780534285dcefe)