### PR TITLE
Fix axis-aligned rotated rect obstacle expansion

### DIFF
--- a/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
+++ b/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
@@ -10,6 +10,37 @@ import { fillCircleWithRects } from "./fillCircleWithRects"
 import type { Obstacle } from "./types"
 
 const EVERY_LAYER = ["top", "inner1", "inner2", "bottom"]
+const QUARTER_TURN_TOLERANCE_DEGREES = 0.01
+
+const getAxisAlignedRectFromRotatedRect = (
+  rotatedRect: RotatedRect,
+): {
+  center: { x: number; y: number }
+  width: number
+  height: number
+} | null => {
+  const normalizedRotation = ((rotatedRect.rotation % 360) + 360) % 360
+  const axisAlignedAngles = [0, 90, 180, 270] as const
+
+  for (const angle of axisAlignedAngles) {
+    const angularDistance = Math.min(
+      Math.abs(normalizedRotation - angle),
+      360 - Math.abs(normalizedRotation - angle),
+    )
+
+    if (angularDistance > QUARTER_TURN_TOLERANCE_DEGREES) continue
+
+    const isVertical = angle === 90 || angle === 270
+
+    return {
+      center: rotatedRect.center,
+      width: isVertical ? rotatedRect.height : rotatedRect.width,
+      height: isVertical ? rotatedRect.width : rotatedRect.height,
+    }
+  }
+
+  return null
+}
 
 export const getObstaclesFromCircuitJson = (
   soup: AnyCircuitElement[],
@@ -56,8 +87,12 @@ export const getObstaclesFromCircuitJson = (
           height: element.height,
           rotation: element.ccw_rotation,
         }
-        const approximatingRects = generateApproximatingRects(rotatedRect)
-        for (const rect of approximatingRects) {
+        const singleRect = getAxisAlignedRectFromRotatedRect(rotatedRect)
+        const rects = singleRect
+          ? [singleRect]
+          : generateApproximatingRects(rotatedRect)
+
+        for (const rect of rects) {
           obstacles.push({
             type: "rect",
             layers: [element.layer],

--- a/tests/utils/autorouting/simple-route-json-axis-aligned-rotated-rect-obstacles.test.tsx
+++ b/tests/utils/autorouting/simple-route-json-axis-aligned-rotated-rect-obstacles.test.tsx
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test"
+import type { PcbSmtPadRotatedRect } from "circuit-json"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("axis-aligned rotated_rect pads become single simple-route obstacles", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint={
+          <footprint>
+            <smtpad
+              shape="rotated_rect"
+              width="2mm"
+              height="1mm"
+              portHints={["pin1"]}
+              ccwRotation={0}
+              pcbX={-8}
+            />
+            <smtpad
+              shape="rotated_rect"
+              width="2mm"
+              height="1mm"
+              portHints={["pin2"]}
+              ccwRotation={90}
+              pcbX={-4}
+            />
+            <smtpad
+              shape="rotated_rect"
+              width="2mm"
+              height="1mm"
+              portHints={["pin3"]}
+              ccwRotation={180}
+            />
+            <smtpad
+              shape="rotated_rect"
+              width="2mm"
+              height="1mm"
+              portHints={["pin4"]}
+              ccwRotation={270}
+              pcbX={4}
+            />
+            <smtpad
+              shape="rotated_rect"
+              width="2mm"
+              height="1mm"
+              portHints={["pin5"]}
+              ccwRotation={45}
+              pcbX={8}
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const rotatedPads = circuit
+    .getCircuitJson()
+    .filter(
+      (element): element is PcbSmtPadRotatedRect =>
+        element.type === "pcb_smtpad" && element.shape === "rotated_rect",
+    )
+
+  expect(rotatedPads).toHaveLength(5)
+
+  const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
+    db: circuit.db,
+  })
+
+  for (const pad of rotatedPads) {
+    const matchingObstacles = simpleRouteJson.obstacles.filter((obstacle) =>
+      obstacle.connectedTo.includes(pad.pcb_smtpad_id),
+    )
+
+    if (pad.ccw_rotation === 45) {
+      expect(matchingObstacles.length).toBeGreaterThan(1)
+      continue
+    }
+
+    expect(matchingObstacles).toHaveLength(1)
+
+    const [obstacle] = matchingObstacles
+    const isVertical = pad.ccw_rotation === 90 || pad.ccw_rotation === 270
+
+    expect(obstacle.center.x).toBeCloseTo(pad.x, 6)
+    expect(obstacle.center.y).toBeCloseTo(pad.y, 6)
+    expect(obstacle.width).toBeCloseTo(isVertical ? pad.height : pad.width, 6)
+    expect(obstacle.height).toBeCloseTo(isVertical ? pad.width : pad.height, 6)
+  }
+})


### PR DESCRIPTION
## Summary
- collapse `rotated_rect` SMT pads at quarter-turn rotations into a single simple-route obstacle
- keep the existing multi-rect approximation for non-axis-aligned rotations
- add a regression test covering `0/90/180/270` rotations and a diagonal `45°` case

## Testing
- `bun test tests/utils/autorouting/simple-route-json-axis-aligned-rotated-rect-obstacles.test.tsx`
- `bun test tests/repros/repro7-rotated-rect-obstacle.test.tsx`
- `bunx tsc --noEmit`