### PR TITLE
Deduplicate logical ports from composite footprint copper

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -69,6 +69,7 @@ import { NormalComponent_doInitialPcbComponentAnchorAlignment } from "./NormalCo
 import { NormalComponent_doInitialPcbFootprintStringRender } from "./NormalComponent_doInitialPcbFootprintStringRender"
 import { NormalComponent_doInitialSilkscreenOverlapAdjustment } from "./NormalComponent_doInitialSilkscreenOverlapAdjustment"
 import { NormalComponent_doInitialSourceDesignRuleChecks } from "./NormalComponent_doInitialSourceDesignRuleChecks"
+import { getLogicalPortsFromPortHintGroups } from "./utils/getLogicalPortsFromPortHintGroups"
 import { isHttpUrl } from "./utils/isHttpUrl"
 import { isStaticAssetPath } from "./utils/isStaticAssetPath"
 import { parseLibraryFootprintRef } from "./utils/parseLibraryFootprintRef"
@@ -1190,17 +1191,19 @@ export class NormalComponent<
         return []
       }
 
-      const newPorts: Port[] = []
-      for (const elm of fpCircuitJson) {
-        if ("port_hints" in elm && elm.port_hints) {
-          const newPort = getPortFromHints(elm.port_hints, opts)
-          if (!newPort) continue
-          newPort.originDescription = `footprint:string:${footprint}:port_hints[0]:${elm.port_hints[0]}`
-          newPorts.push(newPort)
-        }
-      }
-
-      return newPorts
+      return getLogicalPortsFromPortHintGroups(
+        fpCircuitJson.flatMap((elm) =>
+          "port_hints" in elm && elm.port_hints
+            ? [
+                {
+                  hints: elm.port_hints,
+                  originDescription: `footprint:string:${footprint}:port_hints[0]:${elm.port_hints[0]}`,
+                },
+              ]
+            : [],
+        ),
+        opts,
+      )
     }
     if (
       !isValidElement(footprint) &&
@@ -1209,35 +1212,19 @@ export class NormalComponent<
     ) {
       const fp = footprint as Footprint
 
-      let pinNumber = 1
-      const newPorts: Port[] = []
-      for (const fpChild of fp.children) {
-        if (!fpChild.props.portHints) continue
-
-        // Filter out empty strings from port hints
-        const filteredPortHints = fpChild.props.portHints.filter(
-          (hint: string) => hint && hint.trim() !== "",
-        )
-
-        if (filteredPortHints.length === 0) continue
-
-        let portHintsList = filteredPortHints
-        const hasPinIdentifier = portHintsList.some(
-          (hint: string) =>
-            hint.startsWith("pin") || /^(?:pin)?\d+$/.test(hint),
-        )
-        if (!hasPinIdentifier) {
-          portHintsList = [...portHintsList, `pin${pinNumber}`]
-        }
-        pinNumber++
-        const newPort = getPortFromHints(portHintsList)
-        if (!newPort) continue
-        newPort.originDescription = `footprint:${footprint}`
-        newPorts.push(newPort)
-      }
-
-      // If no ports were found, return an empty array instead of throwing an error
-      return newPorts
+      return getLogicalPortsFromPortHintGroups(
+        fp.children.flatMap((fpChild) =>
+          fpChild.props.portHints
+            ? [
+                {
+                  hints: fpChild.props.portHints,
+                  originDescription: `footprint:${footprint}`,
+                },
+              ]
+            : [],
+        ),
+        opts,
+      )
     }
 
     // Explore children for possible smtpads etc.

--- a/lib/components/base-components/NormalComponent/utils/getLogicalPortsFromPortHintGroups.ts
+++ b/lib/components/base-components/NormalComponent/utils/getLogicalPortsFromPortHintGroups.ts
@@ -6,6 +6,18 @@ type PortHintGroup = {
   originDescription: string
 }
 
+/**
+ * Converts footprint primitive port hints into logical component ports.
+ *
+ * Footprints can have multiple copper primitives for one logical pin, for
+ * example an SMT pad and a plated hole that both use `portHints={["pin1"]}`.
+ * This helper dedupes those primitives by parsed pin number and merges any
+ * extra aliases into the first Port for that pin.
+ *
+ * Example:
+ * - inputs: `["pin1"]`, `["pin1", "BAT_POS"]`, `["pin2"]`
+ * - output ports: `pin1` with aliases including `BAT_POS`, and `pin2`
+ */
 export function getLogicalPortsFromPortHintGroups(
   portHintGroups: PortHintGroup[],
   opts?: { additionalAliases?: Record<string, string[]> },

--- a/lib/components/base-components/NormalComponent/utils/getLogicalPortsFromPortHintGroups.ts
+++ b/lib/components/base-components/NormalComponent/utils/getLogicalPortsFromPortHintGroups.ts
@@ -1,0 +1,55 @@
+import { Port } from "lib/components/primitive-components/Port"
+import { getPortFromHints } from "lib/utils/getPortFromHints"
+
+type PortHintGroup = {
+  hints: string[]
+  originDescription: string
+}
+
+export function getLogicalPortsFromPortHintGroups(
+  portHintGroups: PortHintGroup[],
+  opts?: { additionalAliases?: Record<string, string[]> },
+): Port[] {
+  let implicitPinNumber = 1
+  const portsByPinNumber = new Map<number, Port>()
+
+  for (const portHintGroup of portHintGroups) {
+    const filteredPortHints = portHintGroup.hints.filter(
+      (hint) => hint && hint.trim() !== "",
+    )
+
+    if (filteredPortHints.length === 0) continue
+
+    let portHintsList = filteredPortHints
+    const hasPinIdentifier = portHintsList.some(
+      (hint) => hint.startsWith("pin") || /^(?:pin)?\d+$/.test(hint),
+    )
+
+    if (!hasPinIdentifier) {
+      portHintsList = [...portHintsList, `pin${implicitPinNumber}`]
+    }
+    implicitPinNumber++
+
+    const newPort = getPortFromHints(portHintsList, opts)
+    if (!newPort) continue
+
+    newPort.originDescription = portHintGroup.originDescription
+
+    const pinNumber = newPort._parsedProps.pinNumber
+    if (pinNumber === undefined) continue
+
+    const existingPort = portsByPinNumber.get(pinNumber)
+    if (!existingPort) {
+      portsByPinNumber.set(pinNumber, newPort)
+      continue
+    }
+
+    const mergedAliases = newPort
+      .getNameAndAliases()
+      .filter((alias) => !existingPort.getNameAndAliases().includes(alias))
+
+    existingPort.externallyAddedAliases.push(...mergedAliases)
+  }
+
+  return Array.from(portsByPinNumber.values())
+}

--- a/tests/repros/repro108-footprint-composite-pin.test.tsx
+++ b/tests/repros/repro108-footprint-composite-pin.test.tsx
@@ -1,0 +1,194 @@
+import { expect, test } from "bun:test"
+import type { ChipProps } from "@tscircuit/props"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const pinLabels = {
+  pin1: ["BAT_POS"],
+  pin2: ["BAT_NEG"],
+} as const
+
+const pinAttributes = {
+  pin1: { mustBeConnected: true },
+  BAT_POS: { mustBeConnected: true },
+  pin2: { mustBeConnected: true },
+  BAT_NEG: { mustBeConnected: true },
+} as any
+
+function BatteryClipUsingViaConnectsTo(props: ChipProps<typeof pinLabels>) {
+  return (
+    <chip
+      pinLabels={pinLabels}
+      pinAttributes={pinAttributes}
+      footprint={
+        <footprint>
+          <smtpad
+            portHints={["pin1"]}
+            pcbX="-8.5mm"
+            pcbY="0mm"
+            width="5mm"
+            height="3.5mm"
+            shape="rect"
+          />
+          <smtpad
+            portHints={["pin2"]}
+            pcbX="8.5mm"
+            pcbY="0mm"
+            width="5mm"
+            height="5.5mm"
+            shape="rect"
+          />
+          <via
+            pcbX="-8mm"
+            pcbY="0mm"
+            outerDiameter="1.85mm"
+            holeDiameter="0.925mm"
+            fromLayer="top"
+            toLayer="bottom"
+            connectsTo="pin1"
+          />
+          <via
+            pcbX="8mm"
+            pcbY="0mm"
+            outerDiameter="1.85mm"
+            holeDiameter="0.925mm"
+            fromLayer="top"
+            toLayer="bottom"
+            connectsTo="pin2"
+          />
+        </footprint>
+      }
+      {...props}
+    />
+  )
+}
+
+function BatteryClipUsingPlatedHolePortHints(
+  props: ChipProps<typeof pinLabels>,
+) {
+  return (
+    <chip
+      pinLabels={pinLabels}
+      pinAttributes={pinAttributes}
+      footprint={
+        <footprint>
+          <smtpad
+            portHints={["pin1"]}
+            pcbX="-8.5mm"
+            pcbY="0mm"
+            width="5mm"
+            height="3.5mm"
+            shape="rect"
+          />
+          <smtpad
+            portHints={["pin2"]}
+            pcbX="8.5mm"
+            pcbY="0mm"
+            width="5mm"
+            height="5.5mm"
+            shape="rect"
+          />
+          <platedhole
+            portHints={["pin1"]}
+            pcbX="-8mm"
+            pcbY="0mm"
+            outerDiameter="1.85mm"
+            holeDiameter="0.925mm"
+            shape="circle"
+          />
+          <platedhole
+            portHints={["pin2"]}
+            pcbX="8mm"
+            pcbY="0mm"
+            outerDiameter="1.85mm"
+            holeDiameter="0.925mm"
+            shape="circle"
+          />
+        </footprint>
+      }
+      {...props}
+    />
+  )
+}
+
+const summarizeDirectPorts = (component: any) =>
+  component.children
+    .filter((child: any) => child.componentName === "Port")
+    .map((port: any) => ({
+      name: port.props.name,
+      aliases: port.getNameAndAliases(),
+      source_port_id: port.source_port_id,
+      pcb_port_id: port.pcb_port_id,
+      matched: port.matchedComponents.map((c: any) => c.getString()),
+    }))
+
+test("repro108: footprint composite pin mapping", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="130mm" height="40mm" layers={2}>
+      <BatteryClipUsingViaConnectsTo name="J_VIA" pcbX={-35} pcbY={0} />
+      <BatteryClipUsingPlatedHolePortHints name="J_PH" pcbX={35} pcbY={0} />
+
+      <resistor
+        name="R_VIA_POS"
+        resistance="10k"
+        footprint="0603"
+        pcbX={-10}
+        pcbY={-7}
+        pcbRotation={90}
+      />
+      <resistor
+        name="R_VIA_NEG"
+        resistance="10k"
+        footprint="0603"
+        pcbX={-10}
+        pcbY={7}
+        pcbRotation={90}
+      />
+
+      <resistor
+        name="R_PH_POS"
+        resistance="10k"
+        footprint="0603"
+        pcbX={60}
+        pcbY={-7}
+        pcbRotation={90}
+      />
+      <resistor
+        name="R_PH_NEG"
+        resistance="10k"
+        footprint="0603"
+        pcbX={60}
+        pcbY={7}
+        pcbRotation={90}
+      />
+
+      <trace from="J_VIA.BAT_POS" to="R_VIA_POS.pin1" />
+      <trace from="J_VIA.BAT_NEG" to="R_VIA_NEG.pin1" />
+      <trace from="R_VIA_POS.pin2" to="net.VIA_LOAD" />
+      <trace from="R_VIA_NEG.pin2" to="net.VIA_LOAD" />
+
+      <trace from="J_PH.BAT_POS" to="R_PH_POS.pin1" />
+      <trace from="J_PH.BAT_NEG" to="R_PH_NEG.pin1" />
+      <trace from="R_PH_POS.pin2" to="net.PH_LOAD" />
+      <trace from="R_PH_NEG.pin2" to="net.PH_LOAD" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  const jVia = circuit.selectOne(".J_VIA") as any
+  const jPh = circuit.selectOne(".J_PH") as any
+
+  const jViaDirectPorts = summarizeDirectPorts(jVia)
+  const jPhDirectPorts = summarizeDirectPorts(jPh)
+
+  const ambiguousRefs = circuit.db.source_ambiguous_port_reference.list()
+  const notConnected = circuit
+    .getCircuitJson()
+    .filter((elm) => elm.type === "source_trace_not_connected_error")
+
+  expect(jViaDirectPorts).toHaveLength(2)
+  expect(jPhDirectPorts).toHaveLength(2)
+  expect(ambiguousRefs).toHaveLength(0)
+  expect(notConnected).toHaveLength(0)
+})

--- a/tests/repros/repro109-non-overlapping-composite-pin-ambiguous.test.tsx
+++ b/tests/repros/repro109-non-overlapping-composite-pin-ambiguous.test.tsx
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("repro109: repeated portHints on non-overlapping pads are ambiguous", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="10mm">
+      <chip
+        name="U1"
+        pinLabels={{
+          pin1: "SIG",
+        }}
+        footprint={
+          <footprint>
+            <smtpad
+              portHints={["pin1"]}
+              pcbX="-3mm"
+              pcbY="0mm"
+              width="1mm"
+              height="1mm"
+              shape="rect"
+            />
+            <smtpad
+              portHints={["pin1"]}
+              pcbX="3mm"
+              pcbY="0mm"
+              width="1mm"
+              height="1mm"
+              shape="rect"
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const sourcePorts = circuit.db.source_port.list({
+    source_component_id: circuit.db.source_component.getWhere({ name: "U1" })
+      ?.source_component_id,
+  })
+  const ambiguousRefs = circuit.db.source_ambiguous_port_reference.list()
+  const pcbPorts = circuit.db.pcb_port.list()
+
+  expect(sourcePorts).toHaveLength(1)
+  expect(
+    ambiguousRefs.map((error) => ({
+      error_type: error.error_type,
+      message: error.message.replaceAll(/#\d+/g, "#<id>"),
+    })),
+  ).toMatchInlineSnapshot(`
+    [
+      {
+        "error_type": "source_ambiguous_port_reference",
+        "message": "U1.SIG is ambiguous: U1.SIG references multiple non-overlapping pads: <smtpad#<id>(.pin1) />, <smtpad#<id>(.pin1) /> (consider using alternate aliases: pin1, 1)",
+      },
+    ]
+  `)
+  expect(pcbPorts).toHaveLength(0)
+})


### PR DESCRIPTION
 Fixes composite footprints where multiple copper primitives share the same logical pin,
  such as an SMT pad plus plated hole with the same portHints.

  Previously, footprint port discovery returned one port per copper primitive, so repeated
  pin1/pin2 hints could inflate the inferred pin count and create extra logical pins like
  pin3 and pin4.

  This adds a shared helper to normalize footprint portHints, merge aliases, and dedupe
  ports by logical pin number for both string and JSX footprints.