### PR TITLE
Set up routing phase plans for group autorouting

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -44,6 +44,8 @@ import { Group_doInitialSchematicLayoutMatchPack } from "./Group_doInitialSchema
 import { Group_doInitialSchematicTraceRender } from "./Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender"
 import { Group_doInitialSimulationSpiceEngineRender } from "./Group_doInitialSimulationSpiceEngineRender"
 import { Group_doInitialSourceAddConnectivityMapKey } from "./Group_doInitialSourceAddConnectivityMapKey"
+import type { RoutingPhasePlan } from "./GroupRoutingPhasePlan"
+import { Group_getRoutingPhasePlans } from "./Group_getRoutingPhasePlans"
 import type { ISubcircuit } from "./Subcircuit/ISubcircuit"
 import { addPortIdsToTracesAtJumperPads } from "./add-port-ids-to-traces-at-jumper-pads"
 import { insertAutoplacedJumpers } from "./insert-autoplaced-jumpers"
@@ -389,11 +391,19 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     return false
   }
 
+  _getRoutingPhasePlans(): RoutingPhasePlan[] {
+    return Group_getRoutingPhasePlans(this)
+  }
+
   _hasTracesToRoute(): boolean {
     const debug = Debug("tscircuit:core:_hasTracesToRoute")
-    const traces = this.selectAll("trace") as Trace[]
-    debug(`[${this.getString()}] has ${traces.length} traces to route`)
-    return traces.length > 0
+    const routingPhasePlans = this._getRoutingPhasePlans()
+    let traceCount = 0
+    for (const routingPhasePlan of routingPhasePlans) {
+      traceCount += routingPhasePlan.traces.length
+    }
+    debug(`[${this.getString()}] has ${traceCount} traces to route`)
+    return traceCount > 0
   }
 
   async _runEffectMakeHttpAutoroutingRequest() {

--- a/lib/components/primitive-components/Group/GroupRoutingPhasePlan.ts
+++ b/lib/components/primitive-components/Group/GroupRoutingPhasePlan.ts
@@ -1,0 +1,6 @@
+import type { Trace } from "../Trace/Trace"
+
+export interface RoutingPhasePlan {
+  routingPhaseIndex: number | null
+  traces: Trace[]
+}

--- a/lib/components/primitive-components/Group/Group_getRoutingPhasePlans.ts
+++ b/lib/components/primitive-components/Group/Group_getRoutingPhasePlans.ts
@@ -1,0 +1,18 @@
+import type { Trace } from "../Trace/Trace"
+import type { Group } from "./Group"
+import type { RoutingPhasePlan } from "./GroupRoutingPhasePlan"
+
+export function Group_getRoutingPhasePlans(
+  group: Group<any>,
+): RoutingPhasePlan[] {
+  const traces = group.selectAll("trace") as Trace[]
+
+  if (traces.length === 0) return []
+
+  return [
+    {
+      routingPhaseIndex: null,
+      traces,
+    },
+  ]
+}

--- a/lib/components/primitive-components/Group/Subcircuit/ISubcircuit.ts
+++ b/lib/components/primitive-components/Group/Subcircuit/ISubcircuit.ts
@@ -3,9 +3,11 @@ import type { NormalComponent } from "lib/components/base-components/NormalCompo
 import type { AutorouterConfig, subcircuitGroupProps } from "@tscircuit/props"
 import { z } from "zod"
 import type { AnyCircuitElement } from "circuit-json"
+import type { RoutingPhasePlan } from "../GroupRoutingPhasePlan"
 
 export interface ISubcircuit extends PrimitiveComponent {
   _shouldUseTraceByTraceRouting(): boolean
+  _getRoutingPhasePlans(): RoutingPhasePlan[]
   _parsedProps: z.infer<typeof subcircuitGroupProps>
   _getAutorouterConfig(): AutorouterConfig
   _isAutoJumperAutorouter(autorouterConfig?: AutorouterConfig): boolean


### PR DESCRIPTION
Adds a small routing phase plan seam to Group without changing autorouting behavior.

  Group_getRoutingPhasePlans currently returns the existing behavior as one default null phase containing all traces.
  _hasTracesToRoute now uses that plan abstraction, so a follow-up PR can split traces by routingPhaseIndex and route phases  incrementally without doing that refactor in the same diff.