### PR TITLE
Preserve CAD model from fetched connector part Circuit JSON

### DIFF
--- a/lib/components/normal-components/Connector.ts
+++ b/lib/components/normal-components/Connector.ts
@@ -8,6 +8,7 @@ import type { AnyCircuitElement, SourceSimpleConnector } from "circuit-json"
 import { unknown_error_finding_part } from "circuit-json"
 import { createComponentsFromCircuitJson } from "lib/utils/createComponentsFromCircuitJson"
 import { convertCircuitJsonToUsbCStandardCircuitJson } from "lib/utils/connectors/convertCircuitJsonToUsbCStandardCircuitJson"
+import { extractCadModelFromCircuitJson } from "lib/utils/connectors/extractCadModelFromCircuitJson"
 import { symbols } from "schematic-symbols"
 import { Chip } from "./Chip"
 import { insertInnerSymbolInSchematicBox } from "./Connector_insertInnerSymbolInSchematicBox"
@@ -116,6 +117,14 @@ export class Connector<
       },
       standardizedCircuitJson,
     )
+
+    const fetchedCadModel = extractCadModelFromCircuitJson(
+      standardizedCircuitJson,
+    )
+    if (fetchedCadModel) {
+      this._asyncFootprintCadModel = fetchedCadModel
+    }
+
     this.addAll(fpComponents)
     this._markDirty("InitializePortsFromChildren")
   }

--- a/lib/utils/connectors/extractCadModelFromCircuitJson.ts
+++ b/lib/utils/connectors/extractCadModelFromCircuitJson.ts
@@ -1,0 +1,49 @@
+import { cadModelProp, type CadModelProp } from "@tscircuit/props"
+import type { AnyCircuitElement, CadComponent } from "circuit-json"
+
+export const extractCadModelFromCircuitJson = (
+  circuitJson: AnyCircuitElement[],
+): CadModelProp | undefined => {
+  const cadComponent = circuitJson.find(
+    (elm): elm is CadComponent => elm.type === "cad_component",
+  )
+  if (!cadComponent) return undefined
+
+  const cadModelCandidate: Record<string, unknown> = {
+    stlUrl: cadComponent.model_stl_url,
+    objUrl: cadComponent.model_obj_url,
+    gltfUrl: cadComponent.model_gltf_url,
+    glbUrl: cadComponent.model_glb_url,
+    stepUrl: cadComponent.model_step_url,
+    wrlUrl: cadComponent.model_wrl_url,
+    modelOriginPosition: cadComponent.model_origin_position ?? undefined,
+    modelUnitToMmScale: cadComponent.model_unit_to_mm_scale_factor,
+    modelBoardNormalDirection: cadComponent.model_board_normal_direction,
+    size: cadComponent.size ?? undefined,
+    rotationOffset: cadComponent.rotation ?? undefined,
+    positionOffset: cadComponent.position ?? undefined,
+    showAsTranslucentModel: cadComponent.show_as_translucent_model,
+  }
+
+  if (
+    !cadModelCandidate.stlUrl &&
+    !cadModelCandidate.objUrl &&
+    !cadModelCandidate.gltfUrl &&
+    !cadModelCandidate.glbUrl &&
+    !cadModelCandidate.stepUrl &&
+    !cadModelCandidate.wrlUrl &&
+    !cadComponent.model_jscad
+  ) {
+    return undefined
+  }
+
+  if (
+    cadComponent.model_jscad &&
+    typeof cadComponent.model_jscad === "object"
+  ) {
+    cadModelCandidate.jscad = cadComponent.model_jscad
+  }
+
+  const parsedCadModel = cadModelProp.safeParse(cadModelCandidate)
+  return parsedCadModel.success ? parsedCadModel.data : undefined
+}

--- a/tests/components/normal-components/parts-engine-fetch-circuit-json-user-cadmodel-priority.test.tsx
+++ b/tests/components/normal-components/parts-engine-fetch-circuit-json-user-cadmodel-priority.test.tsx
@@ -1,0 +1,62 @@
+import { test, expect } from "bun:test"
+import type { PartsEngine } from "@tscircuit/props"
+import type { AnyCircuitElement } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import usbCC165948CircuitJson from "tests/fixtures/assets/usb-c-C165948.circuit.json"
+
+test("connector usb_c prefers user cadModel over fetched part cad_component", async () => {
+  const { circuit } = getTestFixture()
+
+  const mockPartsEngine: PartsEngine = {
+    findPart: async ({ sourceComponent }: any) => {
+      if (
+        sourceComponent.ftype === "simple_connector" &&
+        sourceComponent.standard === "usb_c"
+      ) {
+        return { jlcpcb: ["C165948"] }
+      }
+      return {}
+    },
+    fetchPartCircuitJson: async ({
+      supplierPartNumber,
+    }: {
+      supplierPartNumber?: string
+      manufacturerPartNumber?: string
+    }) => {
+      if (supplierPartNumber === "C165948") {
+        return usbCC165948CircuitJson as AnyCircuitElement[]
+      }
+      return undefined
+    },
+  }
+
+  circuit.add(
+    <board partsEngine={mockPartsEngine} width="20mm" height="20mm">
+      <connector
+        name="USB1"
+        standard="usb_c"
+        cadModel={{ glbUrl: "https://example.com/user-model.glb" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const sourceComponent = circuit.db.source_component
+    .list()
+    .find((c: any) => c.name === "USB1")
+  expect(sourceComponent).toBeTruthy()
+
+  const cadComponents = circuit.db.cad_component
+    .list()
+    .filter(
+      (cad: any) =>
+        cad.source_component_id === sourceComponent!.source_component_id,
+    )
+
+  expect(cadComponents).toHaveLength(1)
+  expect(cadComponents[0].model_glb_url).toBe(
+    "https://example.com/user-model.glb",
+  )
+  expect(cadComponents[0].model_obj_url).toBeUndefined()
+})

--- a/tests/components/normal-components/parts-engine-fetch-circuit-json.test.tsx
+++ b/tests/components/normal-components/parts-engine-fetch-circuit-json.test.tsx
@@ -76,6 +76,16 @@ test("connector with standard='usb_c' fetches circuit json from parts engine", a
   // Verify footprint pads were added from the fetched circuit JSON
   const pads = circuit.db.pcb_smtpad.list()
   expect(pads.length).toBeGreaterThan(0)
+
+  // Verify CAD model metadata is preserved from fetched part circuit JSON.
+  const cadComponents = circuit.db.cad_component
+    .list()
+    .filter(
+      (cad: any) =>
+        cad.source_component_id === sourceComponent!.source_component_id,
+    )
+  expect(cadComponents).toHaveLength(1)
+  expect(cadComponents[0].model_obj_url).toBeDefined()
   expect(circuit).toMatchPcbSnapshot(import.meta.path)
   expect(circuit).toMatchSchematicSnapshot(import.meta.path)
 })


### PR DESCRIPTION
For connector standard="usb_c", fetchPartCircuitJson could return a cad_component, but it was dropped because the standard connector flow only inflated footprint primitives and ignored CAD. This caused final Circuit JSON to miss connector CAD models.

This PR extracts CAD metadata from fetched part Circuit JSON into CadModelProp and feeds it through _asyncFootprintCadModel, so CAD is generated in the normal CAD render phase. Explicit user cadModel still takes priority over fetched CAD. Also refactors extraction into a shared utility and adds tests for both preservation and user-override behavior