### PR TITLE
Honor `noConnect` on chips: mark source ports do_not_connect and suppress missing-trace warnings

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialSourceDesignRuleChecks.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialSourceDesignRuleChecks.ts
@@ -31,6 +31,8 @@ export const NormalComponent_doInitialSourceDesignRuleChecks = (
   for (const port of ports) {
     if (!port.source_port_id) continue
     if (!shouldCheckPortForMissingTrace(component, port)) continue
+    const sourcePort = db.source_port.get(port.source_port_id)
+    if (sourcePort?.do_not_connect) continue
     if (connected.has(port.source_port_id)) continue
     db.source_pin_missing_trace_warning.insert({
       message: `Port ${port.getNameAndAliases()[0]} on ${component.props.name} is missing a trace`,

--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -296,18 +296,28 @@ export class Port extends PrimitiveComponent<typeof portProps> {
   }
 
   private _getMatchingPinAttributes(): PinAttributeMap[] {
-    const pinAttributes = (this.parent as any)?._parsedProps?.pinAttributes as
+    const parentProps = (this.parent as any)?._parsedProps
+    const pinAttributes = parentProps?.pinAttributes as
       | Record<string, PinAttributeMap>
       | undefined
-
-    if (!pinAttributes) return []
+    const noConnect = parentProps?.noConnect as string[] | undefined
 
     const matches: PinAttributeMap[] = []
     for (const alias of this.getNameAndAliases()) {
-      const attributes = pinAttributes[alias]
-      if (attributes) {
-        matches.push(attributes)
+      if (pinAttributes) {
+        const attributes = pinAttributes[alias]
+        if (attributes) {
+          matches.push(attributes)
+        }
       }
+
+      if (noConnect?.includes(alias)) {
+        matches.push({ doNotConnect: true })
+      }
+    }
+
+    if (matches.length === 0) {
+      return []
     }
 
     return matches

--- a/lib/fiber/intrinsic-jsx.ts
+++ b/lib/fiber/intrinsic-jsx.ts
@@ -18,7 +18,6 @@ export interface TscircuitElements {
   solderjumper: Props.SolderJumperProps
   bug: Props.ChipProps
   potentiometer: Props.PotentiometerProps
-  // TODO use ChipProps once it gets merged in @tscircuit/props
   chip: Props.ChipProps
   pinout: Props.PinoutProps
   powersource: Props.PowerSourceProps

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.8",
-    "@tscircuit/props": "^0.0.504",
+    "@tscircuit/props": "^0.0.506",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/schematic-trace-solver": "^v0.0.45",
     "@tscircuit/solver-utils": "^0.0.3",

--- a/tests/components/normal-components/chip-no-connect-prop.test.tsx
+++ b/tests/components/normal-components/chip-no-connect-prop.test.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("chip noConnect marks source ports do_not_connect and suppresses missing trace warnings", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin2: "GND", pin3: "NC" }}
+        pinAttributes={{
+          VCC: { requiresPower: true },
+          GND: { requiresGround: true },
+        }}
+        noConnect={["NC"]}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const sourcePorts = circuit.db.source_port.list()
+  const ncPort = sourcePorts.find((port) => port.name === "NC")
+
+  expect(ncPort?.do_not_connect).toBe(true)
+
+  const missingTraceWarnings =
+    circuit.db.source_pin_missing_trace_warning.list()
+  expect(
+    missingTraceWarnings.find(
+      (warning) => warning.source_port_id === ncPort?.source_port_id,
+    ),
+  ).toBeUndefined()
+  expect(missingTraceWarnings.length).toBe(2)
+})

--- a/tests/repros/repro87-trace-overlap.test.tsx
+++ b/tests/repros/repro87-trace-overlap.test.tsx
@@ -4,32 +4,32 @@ import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
 const pinLabels1 = {
-  1: ["GND1", "A1"],
-  2: ["GND2", "B12"],
-  3: ["VBUS1", "A4"],
-  4: ["VBUS2", "B9"],
-  5: ["SBU2", "B8"],
-  6: ["CC1", "A5"],
-  7: ["DM2", "B7"],
-  8: ["DP1", "A6"],
-  9: ["DM1", "A7"],
-  10: ["DP2", "B6"],
-  11: ["SBU1", "A8"],
-  12: ["CC2", "B5"],
-  13: ["VBUS1", "A9"],
-  14: ["VBUS2", "B4"],
-  15: ["GND1", "A12"],
-  16: ["GND2", "B1"],
+  pin1: ["GND1", "A1"],
+  pin2: ["GND2", "B12"],
+  pin3: ["VBUS1", "A4"],
+  pin4: ["VBUS2", "B9"],
+  pin5: ["SBU2", "B8"],
+  pin6: ["CC1", "A5"],
+  pin7: ["DM2", "B7"],
+  pin8: ["DP1", "A6"],
+  pin9: ["DM1", "A7"],
+  pin10: ["DP2", "B6"],
+  pin11: ["SBU1", "A8"],
+  pin12: ["CC2", "B5"],
+  pin13: ["VBUS1", "A9"],
+  pin14: ["VBUS2", "B4"],
+  pin15: ["GND1", "A12"],
+  pin16: ["GND2", "B1"],
 } as const
 
-interface Props extends ChipProps<typeof pinLabels1> {
+interface SmdUsbCProps extends ChipProps<typeof pinLabels1> {
   name: string
 }
 
 /**
  * USB Type C connector (C165948)
  */
-export const SmdUsbC = (props: Props) => {
+export const SmdUsbC = (props: SmdUsbCProps) => {
   return (
     <chip
       {...props}
@@ -308,11 +308,11 @@ const pinLabels2 = {
 } as const
 const pinNames2 = Object.values(pinLabels2)
 
-interface Props extends CommonLayoutProps {
+interface RedLedProps extends CommonLayoutProps {
   name: string
 }
 
-export const RedLed = (props: Props) => {
+export const RedLed = (props: RedLedProps) => {
   return (
     <led
       {...props}
@@ -452,11 +452,11 @@ const pinLabels = {
 } as const
 const pinNames = Object.values(pinLabels)
 
-interface Props extends CommonLayoutProps {
+interface Ne555Props extends CommonLayoutProps {
   name: string
 }
 
-export const NE555P = (props: Props) => {
+export const NE555P = (props: Ne555Props) => {
   return (
     <chip
       {...props}


### PR DESCRIPTION
### Motivation

- Allow a component-level `noConnect` list (e.g. on `chip`) to mark source ports as intentionally unconnected and prevent spurious missing-trace warnings.

### Description

- Skip creating a missing-trace warning if `db.source_port.get(...).do_not_connect` is true in `NormalComponent_doInitialSourceDesignRuleChecks.ts`.
- Extend `Port._getMatchingPinAttributes` to read the parent `_parsedProps.noConnect` array and produce a `{ doNotConnect: true }` match for aliases listed there, and return an empty array when no matches are found.
- Bump `@tscircuit/props` devDependency to `^0.0.506` and apply small test/typing cleanups in `intrinsic-jsx.ts` and component test fixtures.
- Add `tests/components/normal-components/chip-no-connect-prop.test.tsx` to verify `noConnect` behavior and adjust `tests/repros/repro87-trace-overlap.test.tsx` for updated typings.

### Testing

- Ran the unit test suite with `bun test` including `tests/components/normal-components/chip-no-connect-prop.test.tsx` and `tests/repros/repro87-trace-overlap.test.tsx`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e19e20fbe8832eaac27f2512896a44)