### PR TITLE
fix: prevent duplicate net labels when multiple ports share same net

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/insertNetLabelsForPortsMissingTrace.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/insertNetLabelsForPortsMissingTrace.ts
@@ -20,6 +20,11 @@ export const insertNetLabelsForPortsMissingTrace = ({
 }) => {
   const { db } = group.root!
 
+  // Track which nets already have a label placed to avoid duplicates
+  // When multiple ports share the same net (e.g., C1.pin1 and C2.pin1 both connected to GND),
+  // we only want to place one label, not one per port
+  const netsWithLabels = new Set<string>()
+
   // Create net labels for ports connected only to a net (no trace connected)
   for (const schOrSrcPortId of Array.from(
     allSourceAndSchematicPortIdsInScope,
@@ -37,6 +42,10 @@ export const insertNetLabelsForPortsMissingTrace = ({
     if (!sourceNet) {
       continue
     }
+
+    // Check if this net already has a label placed
+    const netId = sourceNet.source_net_id || sourceNet.name || key
+    if (netsWithLabels.has(netId)) continue
 
     // Avoid duplicate labels at this port anchor position
     // Use a larger tolerance to account for placement discrepancy between
@@ -73,5 +82,8 @@ export const insertNetLabelsForPortsMissingTrace = ({
         ? { source_net_id: sourceNet.source_net_id }
         : {}),
     })
+
+    // Mark this net as having a label placed
+    netsWithLabels.add(netId)
   }
 }

--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/insertNetLabelsForTracesExcludedFromRouting.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/insertNetLabelsForTracesExcludedFromRouting.ts
@@ -18,6 +18,10 @@ export function insertNetLabelsForTracesExcludedFromRouting(args: {
   } = args
   const { db } = group.root!
 
+  // Track which nets already have a label placed to avoid duplicates
+  // When multiple traces share the same net, we only want to place one label
+  const netsWithLabels = new Set<string>()
+
   for (const trace of displayLabelTraces as any[]) {
     const label = trace._parsedProps?.schDisplayLabel
     if (!label) continue
@@ -35,6 +39,9 @@ export function insertNetLabelsForTracesExcludedFromRouting(args: {
           anchor_side: side as any,
           text: label,
         })
+
+        // Check if this net already has a label placed
+        if (netsWithLabels.has(label)) continue
 
         // // Deduplicate: if a label with the same text is already at this anchor position, skip
         const alreadyExists = db.schematic_net_label.list().some((nl) => {
@@ -57,6 +64,9 @@ export function insertNetLabelsForTracesExcludedFromRouting(args: {
             ? { source_trace_id: trace.source_trace_id }
             : {}),
         })
+
+        // Mark this net as having a label placed
+        netsWithLabels.add(label)
       }
     } catch {}
   }


### PR DESCRIPTION
Fixes repro61 test case where duplicate net labels were shown when multiple components share the same net (GND/VCC).

## Problem
When two capacitors C1 and C2 both connect to GND and VCC nets, the schematic renderer placed a net label at each connection point, resulting in duplicate labels (2x GND, 2x VCC).

## Solution
Add a `netsWithLabels` Set to track which nets already have a label placed. When processing ports or traces, skip placing a label if that net already has one.

## Changes
- `insertNetLabelsForPortsMissingTrace.ts`: Add netsWithLabels tracking
- `insertNetLabelsForTracesExcludedFromRouting.ts`: Add netsWithLabels tracking

## Test
Repro61 test case now shows only 2 labels (1x GND, 1x VCC) instead of 4.