### PR TITLE
Fix Keepout Layer Handling & Include Keepouts as Autorouter Obstacles

### DIFF
--- a/lib/components/primitive-components/Keepout.ts
+++ b/lib/components/primitive-components/Keepout.ts
@@ -27,11 +27,18 @@ export class Keepout extends PrimitiveComponent<typeof pcbKeepoutProps> {
     )
     const isRotated90 =
       Math.abs(decomposedMat.rotation.angle * (180 / Math.PI) - 90) % 180 < 0.01
+    let layers = props.layers
+    if (!layers && props.layer) {
+      layers = [props.layer]
+    }
+    if (!layers) {
+      layers = ["top"]
+    }
 
     let pcb_keepout: PCBKeepout | null = null
     if (props.shape === "circle") {
       pcb_keepout = db.pcb_keepout.insert({
-        layers: ["top"],
+        layers,
         shape: "circle",
         // @ts-ignore: no idea why this is triggering
         radius: props.radius,
@@ -44,7 +51,7 @@ export class Keepout extends PrimitiveComponent<typeof pcbKeepoutProps> {
       })
     } else if (props.shape === "rect") {
       pcb_keepout = db.pcb_keepout.insert({
-        layers: ["top"],
+        layers,
         shape: "rect",
         ...(isRotated90
           ? { width: props.height, height: props.width }

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -91,6 +91,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
       ...db.pcb_plated_hole.list(),
       ...db.pcb_hole.list(),
       ...db.pcb_via.list(),
+      ...db.pcb_keepout.list(),
       ...db.pcb_cutout.list(),
       // getObstaclesFromSoup is old and doesn't support diagonal traces
       // ...db.pcb_trace.list(),

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.8",
-    "@tscircuit/props": "^0.0.513",
+    "@tscircuit/props": "^0.0.517",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/schematic-trace-solver": "^0.0.51",
     "@tscircuit/solver-utils": "^0.0.3",

--- a/tests/components/primitive-components/keepout.test.tsx
+++ b/tests/components/primitive-components/keepout.test.tsx
@@ -15,3 +15,45 @@ test("Keepout component rendering", () => {
 
   expect(circuit.getCircuitJson()).toMatchPcbSnapshot(import.meta.path)
 })
+
+test("Keepout supports layer and layers props", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm">
+      <keepout
+        shape="rect"
+        layer="bottom"
+        width="5mm"
+        height="3mm"
+        pcbX="-10mm"
+        pcbY="0mm"
+      />
+      <keepout
+        shape="circle"
+        layers={["top", "bottom"]}
+        radius="2mm"
+        pcbX="0mm"
+        pcbY="0mm"
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const keepouts = circuit
+    .getCircuitJson()
+    .filter((elm) => elm.type === "pcb_keepout")
+
+  expect(keepouts).toHaveLength(2)
+  expect(keepouts[0]).toMatchObject({
+    type: "pcb_keepout",
+    shape: "rect",
+    layers: ["bottom"],
+  })
+  expect(keepouts[1]).toMatchObject({
+    type: "pcb_keepout",
+    shape: "circle",
+    layers: ["top", "bottom"],
+  })
+})


### PR DESCRIPTION

This PR resolves a limitation where `Keepout` components were always assigned to the `"top"` layer, ignoring user-provided `layer` or `layers` props. It introduces proper fallback logic to support both single (`layer`) and multiple (`layers`) layer inputs, defaulting to `"top"` only when neither is provided.

Additionally, PCB keepouts are now included in the autorouter obstacle set, ensuring routing avoids defined keepout regions.

**Key Changes:**

* Add support for `layer` and `layers` props in `Keepout`, with correct priority and defaults.
* Replace hardcoded `"top"` layer assignment with dynamic layer resolution.
* Include `pcb_keepout` entities in autorouting obstacle generation.
* Add tests verifying correct layer handling for both single and multiple layer configurations.
* Bump `@tscircuit/props` dependency version.

**Impact:**
Improves correctness of multilayer PCB designs and ensures autorouting respects keepout constraints.
