### PR TITLE
feat: add mil, thou, cm, and in unit support to evaluateCalcString

### DIFF
--- a/lib/utils/evaluateCalcString.ts
+++ b/lib/utils/evaluateCalcString.ts
@@ -21,10 +21,10 @@ type Token = NumberToken | StringToken
 
 const defaultUnits: Record<string, number> = {
   mm: 1,
-  // You can add more if you need them:
-  // cm: 10,
-  // in: 25.4,
-  // mil: 0.0254,
+  cm: 10,
+  in: 25.4,
+  mil: 0.0254,
+  thou: 0.0254,
 }
 
 export function evaluateCalcString(

--- a/tests/features/mil-thou-unit-support.test.tsx
+++ b/tests/features/mil-thou-unit-support.test.tsx
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test"
+import { evaluateCalcString } from "lib/utils/evaluateCalcString"
+
+test("mil and thou units are supported in evaluateCalcString", () => {
+  // 100mil = 100 * 0.0254mm = 2.54mm
+  expect(evaluateCalcString("100mil", { knownVariables: {} })).toBeCloseTo(
+    2.54,
+    5,
+  )
+
+  // 1000thou = 1000 * 0.0254mm = 25.4mm
+  expect(evaluateCalcString("1000thou", { knownVariables: {} })).toBeCloseTo(
+    25.4,
+    5,
+  )
+
+  // cm: 1cm = 10mm
+  expect(evaluateCalcString("1cm", { knownVariables: {} })).toBeCloseTo(10, 5)
+
+  // in: 1in = 25.4mm
+  expect(evaluateCalcString("1in", { knownVariables: {} })).toBeCloseTo(25.4, 5)
+
+  // Expression with mil: 50mil + 50mil = 2.54mm
+  expect(
+    evaluateCalcString("50mil + 50mil", { knownVariables: {} }),
+  ).toBeCloseTo(2.54, 5)
+})


### PR DESCRIPTION
Closes tscircuit/tscircuit#3084\n\nAdds mil (thou), cm, and in unit support to evaluateCalcString for KiCad grid alignment. Expressions like width="100mil" or pcbX="50thou" now work correctly.