### PR TITLE
fix(schematic): respect schTraceAutoLabelEnabled={false} to suppress port-net auto-labels

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
@@ -19,6 +19,17 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
   if (!group.isSubcircuit) return
   if (group.root?.schematicDisabled) return
 
+  // `schTraceAutoLabelEnabled` is a tri-state:
+  //   - undefined (default): existing behaviour
+  //   - true : opt INTO net labels for complex traces (handled
+  //            in Trace_doInitialSchematicTraceRender)
+  //   - false: opt OUT of auto-generated net labels for ports
+  //            connected to a net via no explicit trace. Useful
+  //            when you'd rather see drawn wires (or accept
+  //            visually disconnected ports) over auto labels.
+  const autoLabelExplicitlyDisabled =
+    group._parsedProps.schTraceAutoLabelEnabled === false
+
   // Prepare the solver input and context
   const {
     inputProblem,
@@ -42,14 +53,16 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
     inputProblem.netConnections.length > 0
 
   if (!hasRouteableSchematicConnections) {
-    insertNetLabelsForPortsMissingTrace({
-      group,
-      allSourceAndSchematicPortIdsInScope,
-      schPortIdToSourcePortId,
-      sckToSourceNet,
-      pinIdToSchematicPortId,
-      schematicPortIdsWithPreExistingNetLabels,
-    })
+    if (!autoLabelExplicitlyDisabled) {
+      insertNetLabelsForPortsMissingTrace({
+        group,
+        allSourceAndSchematicPortIdsInScope,
+        schPortIdToSourcePortId,
+        sckToSourceNet,
+        pinIdToSchematicPortId,
+        schematicPortIdsWithPreExistingNetLabels,
+      })
+    }
     return
   }
 
@@ -93,14 +106,16 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
     schematicPortIdsWithRoutedTraces,
   })
 
-  insertNetLabelsForPortsMissingTrace({
-    group,
-    allSourceAndSchematicPortIdsInScope,
-    schPortIdToSourcePortId,
-    sckToSourceNet,
-    pinIdToSchematicPortId,
-    schematicPortIdsWithPreExistingNetLabels,
-  })
+  if (!autoLabelExplicitlyDisabled) {
+    insertNetLabelsForPortsMissingTrace({
+      group,
+      allSourceAndSchematicPortIdsInScope,
+      schPortIdToSourcePortId,
+      sckToSourceNet,
+      pinIdToSchematicPortId,
+      schematicPortIdsWithPreExistingNetLabels,
+    })
+  }
 
   // Insert labels for traces that explicitly asked for schDisplayLabel
   // insertNetLabelsForTracesExcludedFromRouting({

--- a/tests/components/sch/sch-trace-autolabel-disabled.test.tsx
+++ b/tests/components/sch/sch-trace-autolabel-disabled.test.tsx
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Regression: setting `schTraceAutoLabelEnabled={false}` on a board or
+// group must reduce the number of auto-generated `schematic_net_label`
+// elements created for ports that are connected to a named net via no
+// explicit trace. Previously the prop typechecked but had no observable
+// effect when set to false (only the true case was wired up, for
+// complex multi-junction trace labelling).
+
+test("schTraceAutoLabelEnabled={false} suppresses auto-net-labels at unconnected named-net ports", async () => {
+  const { circuit } = getTestFixture()
+
+  // A chip whose VCC/GND pins are connected to named nets but not to
+  // any other component would normally get a net label drawn at each
+  // pin (the canonical "label, not wire" rendering). With the prop
+  // explicitly disabled, those auto labels should not be created.
+  circuit.add(
+    <board width="20mm" height="20mm" schTraceAutoLabelEnabled={false}>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin2: "GND" }}
+        connections={{ VCC: "net.V3_3", GND: "net.GND" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const labels = circuit.db.schematic_net_label.list()
+  expect(labels.length).toBe(0)
+})
+
+test("schTraceAutoLabelEnabled unset (default) preserves the historical auto-labelling behaviour", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin2: "GND" }}
+        connections={{ VCC: "net.V3_3", GND: "net.GND" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  // Without the opt-out, the placer emits auto labels for the named
+  // net connections (existing behaviour).
+  const labels = circuit.db.schematic_net_label.list()
+  expect(labels.length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Summary

Closes #2243.

`schTraceAutoLabelEnabled` is declared as a tri-state prop in the type definitions, but only the `true` case was wired up at runtime — for opting INTO net labels at complex multi-junction traces (in `Trace_doInitialSchematicTraceRender.ts`). Setting the prop to `false` had no observable effect, because the only consumer treats falsy (undefined or false) as "not opted in".

The user-facing pain: named-net connections (every chip pin tied to `net.V3_3` / `net.GND` / etc.) automatically get a `schematic_net_label` drawn at every endpoint — the canonical "label, not wire" rendering. Users wanted a way to opt out and got none.

## Fix

Wire `schTraceAutoLabelEnabled === false` (explicit, not undefined) into `Group_doInitialSchematicTraceRender` so that `insertNetLabelsForPortsMissingTrace` is skipped when the user explicitly opts out. Both call sites (early-return when no routable connections, and post-routing) honour the opt-out.

### Tri-state semantics

| value | behaviour |
|---|---|
| `undefined` (default) | existing behaviour, auto labels emitted |
| `true` | opt INTO labels for complex traces (existing, in `Trace_doInitialSchematicTraceRender`) |
| `false` | opt OUT of port-net auto-labels (NEW) |

## Test plan

- [x] New `tests/components/sch/sch-trace-autolabel-disabled.test.tsx`:
   - `false` → `0` `schematic_net_label` records for a chip on `net.V3_3` / `net.GND`
   - unset (default) → `≥1` `schematic_net_label` (existing behaviour preserved)
- [x] `bun test tests/components/sch`: 2/2 pass
- [x] Full-suite delta vs `main`: same flaky-test profile (1 fail in `tests/repros/repro81-panel-unnamed-pcb-group.test.tsx` which flakes under full-suite load on `main` too — passes in isolation; not caused by this change)

## What this PR does NOT solve

- The `true` case behaviour is unchanged from current semantics (only opts into complex-trace labels).
- This PR only suppresses labels at port-missing-trace junctions (the most common user pain). Other auto-label sources (e.g. labels emitted by the trace solver inside `applyNetLabelPlacements`) are not affected. Reasonable next step is to extend the opt-out to those paths too, but it'd touch more code and is left as follow-up.

## Why this scope

The most surprising part of the original report was *the prop has zero observable effect when set to false*. After this PR, setting `false` produces an immediately-visible difference (no more port-net auto-labels). Users who want "named nets render as wires, not labels" still need other mechanisms (port-to-port connections via array `connections`), but at least they have one knob that makes a visible difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
