### PR TITLE
Bump @tscircuit/capacity-autorouter to ^0.0.505

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@biomejs/biome": "^1.8.3",
     "@resvg/resvg-js": "^2.6.2",
     "@tscircuit/alphabet": "0.0.25",
-    "@tscircuit/capacity-autorouter": "^0.0.502",
+    "@tscircuit/capacity-autorouter": "^0.0.505",
     "@tscircuit/checks": "0.0.126",
     "@tscircuit/circuit-json-util": "^0.0.94",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
### Motivation
- Upgrade to the latest published `@tscircuit/capacity-autorouter` to pick up fixes and improvements.

### Description
- Bumped the devDependency in `package.json` from `^0.0.502` to `^0.0.505`.

### Testing
- Verified the package version with `npm view @tscircuit/capacity-autorouter version`, ran `bun install` and `bunx tsc --noEmit`, and executed targeted tests with `bun test` (including `tests/repros/repro50-rp2040-decoupling-capacitors.test.tsx` and capacity-mesh autorouter tests) which passed when run individually; a full `bun test` run hit a timing issue on one test that passed on isolated rerun.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb86c1c67c8327b3898fb75628c8b7)