### PR TITLE
fix(layout): honor shouldBeOnEdgeOfBoard by snapping to nearest edge

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -20,6 +20,7 @@ import {
   type SchematicComponent,
   type SchematicPort,
   distance,
+  length,
 } from "circuit-json"
 import Debug from "debug"
 import type { GraphicsObject } from "graphics-debug"
@@ -1448,6 +1449,14 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       }
     }
 
+    // Snap children flagged with `shouldBeOnEdgeOfBoard` to the
+    // nearest edge of this group's bounds BEFORE the layout mode
+    // dispatch. Runs regardless of which layout mode applies (or
+    // even if it's "none"), because the prop's whole purpose is to
+    // override the packer's auto-placement for parts that must
+    // touch a board edge (connectors, through-holes).
+    this._doInitialPcbEdgeSnap()
+
     const pcbLayoutMode = this._getPcbLayoutMode()
 
     if (pcbLayoutMode === "grid") {
@@ -1456,6 +1465,96 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       this._doInitialPcbLayoutPack()
     } else if (pcbLayoutMode === "flex") {
       this._doInitialPcbLayoutFlex()
+    }
+  }
+
+  /**
+   * Implements `shouldBeOnEdgeOfBoard`. For every direct child whose
+   * `_parsedProps.shouldBeOnEdgeOfBoard` is true, find the nearest
+   * edge of this group's bounds (only runs if `width` and `height`
+   * are specified) and shift the child so its courtyard touches that
+   * edge. Picks edge by which is closest to the child's CURRENT
+   * center — so explicit `pcbX`/`pcbY` acts as a directional hint
+   * while only the perpendicular dimension is snapped.
+   */
+  _doInitialPcbEdgeSnap(): void {
+    if (this.root?.pcbDisabled) return
+    const props = this._parsedProps as any
+    if (props.width === undefined || props.height === undefined) return
+
+    const { db } = this.root!
+    const widthMm = length.parse(props.width)
+    const heightMm = length.parse(props.height)
+    const bounds = {
+      minX: -widthMm / 2,
+      maxX: widthMm / 2,
+      minY: -heightMm / 2,
+      maxY: heightMm / 2,
+    }
+
+    for (const child of this.children) {
+      const childAny = child as any
+      if (!childAny._parsedProps?.shouldBeOnEdgeOfBoard) continue
+      if (!childAny.pcb_component_id) continue
+
+      const pcbComponent = db.pcb_component.get(childAny.pcb_component_id)
+      if (!pcbComponent) continue
+
+      let size = { width: 0, height: 0 }
+      if (typeof childAny.getPcbSize === "function") {
+        try {
+          size = childAny.getPcbSize()
+        } catch {
+          size = {
+            width: pcbComponent.width ?? 0,
+            height: pcbComponent.height ?? 0,
+          }
+        }
+      } else {
+        size = {
+          width: pcbComponent.width ?? 0,
+          height: pcbComponent.height ?? 0,
+        }
+      }
+
+      // Read the user's positional hint from display_offset_x/y (where
+      // explicit pcbX/pcbY get stamped during _initializePcbDisplayOffset)
+      // rather than pcb_component.center, which is still (0,0) at this
+      // phase.
+      const hintX =
+        typeof (pcbComponent as any).display_offset_x === "number"
+          ? ((pcbComponent as any).display_offset_x as number)
+          : pcbComponent.center.x
+      const hintY =
+        typeof (pcbComponent as any).display_offset_y === "number"
+          ? ((pcbComponent as any).display_offset_y as number)
+          : pcbComponent.center.y
+
+      const distLeft = Math.abs(hintX - bounds.minX)
+      const distRight = Math.abs(bounds.maxX - hintX)
+      const distTop = Math.abs(bounds.maxY - hintY)
+      const distBottom = Math.abs(hintY - bounds.minY)
+      const minDist = Math.min(distLeft, distRight, distTop, distBottom)
+
+      const newCenter = { x: hintX, y: hintY }
+      if (minDist === distLeft) {
+        newCenter.x = bounds.minX + size.width / 2
+      } else if (minDist === distRight) {
+        newCenter.x = bounds.maxX - size.width / 2
+      } else if (minDist === distTop) {
+        newCenter.y = bounds.maxY - size.height / 2
+      } else {
+        newCenter.y = bounds.minY + size.height / 2
+      }
+
+      // Update both center (used by getBounds and downstream consumers)
+      // AND display_offset_x/y (used by the packer / applyPackOutput
+      // pipeline) so the snapped position survives subsequent phases.
+      db.pcb_component.update(childAny.pcb_component_id, {
+        center: newCenter,
+        display_offset_x: newCenter.x as any,
+        display_offset_y: newCenter.y as any,
+      })
     }
   }
 

--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
@@ -133,6 +133,19 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
     }
   }
 
+  // shouldBeOnEdgeOfBoard children are pre-snapped + marked static
+  // by `_doInitialPcbEdgeSnap` (runs in `doInitialPcbLayout` before
+  // mode dispatch). Pick them up here so the packer leaves them put.
+  for (const child of group.children) {
+    const childAny = child as any
+    if (
+      childAny._parsedProps?.shouldBeOnEdgeOfBoard &&
+      childAny.pcb_component_id
+    ) {
+      staticPcbComponentIds.add(childAny.pcb_component_id)
+    }
+  }
+
   const packInput: PackInput = {
     ...convertPackOutputToPackInput(
       convertCircuitJsonToPackOutput(filteredCircuitJson, {

--- a/tests/components/pcb/should-be-on-edge-of-board.test.tsx
+++ b/tests/components/pcb/should-be-on-edge-of-board.test.tsx
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Regression: `shouldBeOnEdgeOfBoard` is declared on `pcbLayoutProps`
+// and shows up in TypeScript completion, but the auto-placer never
+// read it — setting it on a chip / connector / through-hole was a
+// no-op. This is the same shape of "documented prop the runtime
+// ignores" bug as #2242 (`pcbPositionMode`, fixed in #2247) and
+// #2270 (`<platedhole connectsTo>`).
+//
+// Snap semantics: pick whichever board edge is closest to the
+// component's current `display_offset_x/y` (which reflects any
+// explicit `pcbX`/`pcbY`), and shift only the perpendicular dimension
+// so the courtyard touches that edge. The component's center is set
+// directly so subsequent layout phases leave it put.
+
+const probeChip = (name: string, extra: Record<string, unknown> = {}) => (
+  <chip
+    name={name}
+    shouldBeOnEdgeOfBoard
+    pinLabels={{ pin1: ["A"] }}
+    footprint={
+      <footprint>
+        <smtpad shape="rect" width="2mm" height="2mm" pcbX="0mm" pcbY="0mm" portHints={["pin1"]} />
+      </footprint>
+    }
+    {...extra}
+  />
+)
+
+test("snaps a component to the nearest edge (right edge wins on a wide board)", async () => {
+  // 40 x 20 board with hint at (+10, 0). Distances: distLeft=30,
+  // distRight=10, distTop=10, distBottom=10. Right ties with top
+  // and bottom but the implementation orders left/right before
+  // top/bottom, so right wins (deterministic tiebreaker).
+  // Body width = 2 mm; right edge at +20 mm; expected center.x = +19.
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="40mm" height="20mm">{probeChip("J_RIGHT", { pcbX: 10, pcbY: 0 })}</board>,
+  )
+  circuit.render()
+  const placed = circuit.db.pcb_component.list()[0]
+  expect(placed!.center.x).toBeCloseTo(19, 1)
+  // Y unchanged (top/bottom were tied, right won).
+  expect(placed!.center.y).toBeCloseTo(0, 1)
+})
+
+test("hint near left edge snaps left, Y preserved", async () => {
+  // 40 x 20 board, hint at (-15, 4). Distances: distLeft=5,
+  // distRight=35, distTop=6, distBottom=14. Left wins.
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="40mm" height="20mm">{probeChip("J_LEFT", { pcbX: -15, pcbY: 4 })}</board>,
+  )
+  circuit.render()
+  const placed = circuit.db.pcb_component.list()[0]
+  expect(placed!.center.x).toBeCloseTo(-19, 1) // -20 + 1 (half body)
+  expect(placed!.center.y).toBeCloseTo(4, 1) // unchanged
+})
+
+test("hint near top edge snaps top, X preserved", async () => {
+  // 40 x 20 board, hint at (0, 8). Distances: distLeft=20,
+  // distRight=20, distTop=2, distBottom=18. Top wins.
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="40mm" height="20mm">{probeChip("J_TOP", { pcbX: 0, pcbY: 8 })}</board>,
+  )
+  circuit.render()
+  const placed = circuit.db.pcb_component.list()[0]
+  expect(placed!.center.x).toBeCloseTo(0, 1) // unchanged
+  expect(placed!.center.y).toBeCloseTo(9, 1) // 10 - 1 (half body)
+})
+
+test("hint near bottom edge snaps bottom", async () => {
+  // 40 x 20 board, hint at (0, -8). Distances: distLeft=20,
+  // distRight=20, distTop=18, distBottom=2. Bottom wins.
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="40mm" height="20mm">{probeChip("J_BOTTOM", { pcbX: 0, pcbY: -8 })}</board>,
+  )
+  circuit.render()
+  const placed = circuit.db.pcb_component.list()[0]
+  expect(placed!.center.x).toBeCloseTo(0, 1)
+  expect(placed!.center.y).toBeCloseTo(-9, 1) // -10 + 1 (half body)
+})
+
+test("siblings without shouldBeOnEdgeOfBoard are NOT snapped", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="40mm" height="20mm">
+      {probeChip("J_EDGE", { pcbX: 0, pcbY: 8 })}
+      <resistor name="R1" resistance="10k" footprint="0402" pcbX={5} pcbY={0} />
+    </board>,
+  )
+  circuit.render()
+
+  const r1 = circuit.db.pcb_component
+    .list()
+    .find(
+      (c) =>
+        circuit.db.source_component.get(c.source_component_id)?.name === "R1",
+    )
+  expect(r1).toBeDefined()
+  // R1 explicitly placed at (5, 0). Edge snap should leave it alone
+  // because the prop wasn't set on R1.
+  expect(r1!.center.x).toBeCloseTo(5, 1)
+  expect(r1!.center.y).toBeCloseTo(0, 1)
+})

--- a/tests/components/pcb/should-be-on-edge-of-board.test.tsx
+++ b/tests/components/pcb/should-be-on-edge-of-board.test.tsx
@@ -21,7 +21,14 @@ const probeChip = (name: string, extra: Record<string, unknown> = {}) => (
     pinLabels={{ pin1: ["A"] }}
     footprint={
       <footprint>
-        <smtpad shape="rect" width="2mm" height="2mm" pcbX="0mm" pcbY="0mm" portHints={["pin1"]} />
+        <smtpad
+          shape="rect"
+          width="2mm"
+          height="2mm"
+          pcbX="0mm"
+          pcbY="0mm"
+          portHints={["pin1"]}
+        />
       </footprint>
     }
     {...extra}
@@ -36,7 +43,9 @@ test("snaps a component to the nearest edge (right edge wins on a wide board)", 
   // Body width = 2 mm; right edge at +20 mm; expected center.x = +19.
   const { circuit } = getTestFixture()
   circuit.add(
-    <board width="40mm" height="20mm">{probeChip("J_RIGHT", { pcbX: 10, pcbY: 0 })}</board>,
+    <board width="40mm" height="20mm">
+      {probeChip("J_RIGHT", { pcbX: 10, pcbY: 0 })}
+    </board>,
   )
   circuit.render()
   const placed = circuit.db.pcb_component.list()[0]
@@ -50,7 +59,9 @@ test("hint near left edge snaps left, Y preserved", async () => {
   // distRight=35, distTop=6, distBottom=14. Left wins.
   const { circuit } = getTestFixture()
   circuit.add(
-    <board width="40mm" height="20mm">{probeChip("J_LEFT", { pcbX: -15, pcbY: 4 })}</board>,
+    <board width="40mm" height="20mm">
+      {probeChip("J_LEFT", { pcbX: -15, pcbY: 4 })}
+    </board>,
   )
   circuit.render()
   const placed = circuit.db.pcb_component.list()[0]
@@ -63,7 +74,9 @@ test("hint near top edge snaps top, X preserved", async () => {
   // distRight=20, distTop=2, distBottom=18. Top wins.
   const { circuit } = getTestFixture()
   circuit.add(
-    <board width="40mm" height="20mm">{probeChip("J_TOP", { pcbX: 0, pcbY: 8 })}</board>,
+    <board width="40mm" height="20mm">
+      {probeChip("J_TOP", { pcbX: 0, pcbY: 8 })}
+    </board>,
   )
   circuit.render()
   const placed = circuit.db.pcb_component.list()[0]
@@ -76,7 +89,9 @@ test("hint near bottom edge snaps bottom", async () => {
   // distRight=20, distTop=18, distBottom=2. Bottom wins.
   const { circuit } = getTestFixture()
   circuit.add(
-    <board width="40mm" height="20mm">{probeChip("J_BOTTOM", { pcbX: 0, pcbY: -8 })}</board>,
+    <board width="40mm" height="20mm">
+      {probeChip("J_BOTTOM", { pcbX: 0, pcbY: -8 })}
+    </board>,
   )
   circuit.render()
   const placed = circuit.db.pcb_component.list()[0]


### PR DESCRIPTION
## Summary

Closes #2271.

`shouldBeOnEdgeOfBoard` is declared on `pcbLayoutProps` (so every
component that extends those layout props — chips, resistors,
plated holes, etc.) and shows in TypeScript completion, but **the
auto-placer never reads it**. Setting it on a connector / through-
hole was a no-op.

This is the same shape of "documented prop the runtime ignores"
bug as #2242 (`pcbPositionMode`, fixed in #2247) and #2270
(`<platedhole connectsTo>`).

## Repro

```tsx
<board width="40mm" height="20mm">
  <chip
    name="J_USB"
    shouldBeOnEdgeOfBoard
    pcbX={10} pcbY={0}
    footprint={...usb-c receptacle...}
  />
</board>
```

| | Before | After |
|---|---|---|
| `J_USB.center` | (10, 0) — exactly the user's hint, ignoring the flag | (19, 0) — snapped flush against the right edge (board half-width 20 minus body half-width 1) |

## Fix

The fix runs as a new method `Group._doInitialPcbEdgeSnap`, called
from `doInitialPcbLayout` **before** the layout-mode dispatch
(`pack` / `grid` / `flex` / `none`). Crucially this means it works
even when the group's layout mode collapses to `"none"` because all
direct children carry explicit `pcbX/pcbY` — which is the common
case for connectors that already have a positional hint.

For each direct child whose `_parsedProps.shouldBeOnEdgeOfBoard` is
true:

1. Read the user's positional hint from `display_offset_x/y` (where
   explicit `pcbX/pcbY` get stamped during the earlier
   `_initializePcbDisplayOffset` phase).
2. Compute distances to all four edges of the group's bounds (only
   runs when `width` and `height` are specified — without bounds
   there are no edges to snap to).
3. Pick the nearest edge. Tie-breaker: left/right precede top/bottom
   in the impl's if-else order, so a corner-equidistant hint snaps
   to the horizontal edge.
4. Shift only the perpendicular dimension so the courtyard touches
   the chosen edge (using `getPcbSize()` for the half-extent).
5. Update both `center` and `display_offset_x/y` on the
   `pcb_component` record.

In `Group_doInitialPcbLayoutPack`, snapped components are added to
`staticPcbComponentIds` so the packer leaves them put when it does
run for groups with mixed positioned / unpositioned children.

Total diff: ~90 added lines in `Group.ts` (new method + import +
one-line call) and ~10 in `Group_doInitialPcbLayoutPack.ts` (mark
snapped components static), plus a new test file.

## Tests

`tests/components/pcb/should-be-on-edge-of-board.test.tsx` covers
five cases:

- hint near right edge → snaps right, Y preserved
- hint near left edge → snaps left, Y preserved
- hint near top edge → snaps top, X preserved
- hint near bottom edge → snaps bottom, X preserved
- sibling without the prop is **not** snapped (regression guard
  against the new code interfering with normal placement)

The wider `tests/components/primitive-components/` suite (150
tests) and `tests/components/pcb/` (23 tests including this PR's
new ones) all pass.

## Test plan

- [x] New regression tests pass locally
- [x] PCB / primitive-component suites green
- [ ] CI green
- [ ] Reviewer can verify against an existing board with a
      connector flagged `shouldBeOnEdgeOfBoard`: the connector
      snaps to the nearest edge consuming any `pcbX/pcbY` as a
      directional hint.

## Future extensions (out of scope)

- Per-edge selector: `shouldBeOnEdgeOfBoard: "left" | "right" |
  "top" | "bottom" | true` for explicit edge choice (currently
  always picks the nearest of all four).
- Multiple components flagged for the same edge — for now they
  stack on top of each other if they share the same hint Y/X.
  A small lateral packer pass per edge would distribute them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
