### PR TITLE
fix(layout): respect manualEdits placements during auto-pack

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
@@ -112,6 +112,24 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
     }
   }
 
+  // Also mark any descendant component that has a manualEdits placement
+  // as static — otherwise the packer would happily reposition it on top
+  // of the user's pinned location, silently undoing the manual edit.
+  // Walk every NormalComponent under this group; if its nearest subcircuit
+  // resolves a manual placement for it, treat it like any other relatively
+  // positioned child.
+  const collectManuallyPlacedDescendants = (comp: any) => {
+    const subcircuit = comp?.getSubcircuit?.()
+    const manualPlacement = subcircuit?._getPcbManualPlacementForComponent?.(
+      comp,
+    )
+    if (manualPlacement && comp?.pcb_component_id) {
+      staticPcbComponentIds.add(comp.pcb_component_id)
+    }
+    if (comp?.children) comp.children.forEach(collectManuallyPlacedDescendants)
+  }
+  collectManuallyPlacedDescendants(group)
+
   // Keep all circuit elements; static components will remain fixed during packing
   const filteredCircuitJson = db.toArray()
 

--- a/tests/pcb-packing/manual-edits-respected-by-packer.test.tsx
+++ b/tests/pcb-packing/manual-edits-respected-by-packer.test.tsx
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Repro for: components placed via the board's `manualEdits.pcb_placements`
+// were applied during _computePcbGlobalTransformBeforeLayout but then the
+// auto-packer re-positioned them, silently undoing the user's pin.
+//
+// The packer marks a child as "static" (skip-repack) only if
+// isRelativelyPositioned() returns true — and that helper checks
+// pcbX/pcbY/pcbLeftEdgeX/etc., NOT manualEdits. The fix walks each
+// descendant of the group being packed and adds its pcb_component_id
+// to staticPcbComponentIds when the nearest subcircuit resolves a
+// manual placement for it.
+//
+// Mirrors the failing case in loco-boardv2: a chip inside an anchored
+// region with several auto-placed bottom-side caps. Without the fix the
+// inner packer dumps every cap on top of the chip's network-minimum
+// point; with manualEdits and the fix, the caps land at the requested
+// coordinates instead.
+test("manualEdits placements survive the auto-packer (inner-group case)", () => {
+  const { circuit } = getTestFixture()
+
+  const manualEdits = {
+    pcb_placements: [
+      { selector: "C1", center: { x: 5, y: 3 }, relative_to: "group_center" },
+      { selector: "C2", center: { x: -5, y: 3 }, relative_to: "group_center" },
+      { selector: "C3", center: { x: 5, y: -3 }, relative_to: "group_center" },
+      { selector: "C4", center: { x: -5, y: -3 }, relative_to: "group_center" },
+    ],
+  } as any
+
+  circuit.add(
+    <board width="20mm" height="10mm" manualEdits={manualEdits}>
+      <group name="region" pcbX={0} pcbY={0}>
+        <chip
+          name="U1"
+          footprint="soic8"
+          pinLabels={{ pin1: "VCC", pin8: "GND" }}
+        />
+        <capacitor
+          name="C1"
+          capacitance="100nF"
+          footprint="0402"
+          connections={{ pin1: "U1.VCC", pin2: "U1.GND" }}
+        />
+        <capacitor
+          name="C2"
+          capacitance="100nF"
+          footprint="0402"
+          connections={{ pin1: "U1.VCC", pin2: "U1.GND" }}
+        />
+        <capacitor
+          name="C3"
+          capacitance="100nF"
+          footprint="0402"
+          connections={{ pin1: "U1.VCC", pin2: "U1.GND" }}
+        />
+        <capacitor
+          name="C4"
+          capacitance="100nF"
+          footprint="0402"
+          connections={{ pin1: "U1.VCC", pin2: "U1.GND" }}
+        />
+      </group>
+    </board>,
+  )
+  circuit.render()
+
+  const named = (name: string) => {
+    const src = circuit.db.source_component
+      .list()
+      .find((s) => s.name === name)!
+    return circuit.db.pcb_component
+      .list()
+      .find((p) => p.source_component_id === src.source_component_id)!
+  }
+
+  const c1 = named("C1")
+  const c2 = named("C2")
+  const c3 = named("C3")
+  const c4 = named("C4")
+
+  expect(c1.center.x).toBeCloseTo(5, 1)
+  expect(c1.center.y).toBeCloseTo(3, 1)
+  expect(c2.center.x).toBeCloseTo(-5, 1)
+  expect(c2.center.y).toBeCloseTo(3, 1)
+  expect(c3.center.x).toBeCloseTo(5, 1)
+  expect(c3.center.y).toBeCloseTo(-3, 1)
+  expect(c4.center.x).toBeCloseTo(-5, 1)
+  expect(c4.center.y).toBeCloseTo(-3, 1)
+})


### PR DESCRIPTION
## Summary

The board's `manualEdits.pcb_placements` populates a component's
position via `_computePcbGlobalTransformBeforeLayout`, but the
auto-packer in each group then re-positions the same component,
silently undoing the user's pin. From the user's perspective, dragging
a component in the IDE writes to `manual-edits.json` but the rebuilt
board ignores almost everything they did.

The cause is in `Group_doInitialPcbLayoutPack`: it marks a child as
"static" (skip-repack) only if `isRelativelyPositioned()` returns true,
and that helper only checks `pcbX` / `pcbY` / `pcbLeftEdgeX` / etc. It
doesn't consult `manualEdits`, so any component placed via the IDE
drag-and-pin flow that has no explicit prop coordinates gets repacked
along with the auto-placed siblings.

## Repro

`tests/pcb-packing/manual-edits-respected-by-packer.test.tsx` mirrors
the failing case in a downstream board: a chip plus 4 caps inside an
anchored region, with `manualEdits` pinning each cap to a different
corner.

```tsx
<board width="20mm" height="10mm" manualEdits={{
  pcb_placements: [
    { selector: "C1", center: { x:  5, y:  3 }, relative_to: "group_center" },
    { selector: "C2", center: { x: -5, y:  3 }, relative_to: "group_center" },
    { selector: "C3", center: { x:  5, y: -3 }, relative_to: "group_center" },
    { selector: "C4", center: { x: -5, y: -3 }, relative_to: "group_center" },
  ],
}}>
  <group name="region" pcbX={0} pcbY={0}>
    <chip name="U1" footprint="soic8" .../>
    <capacitor name="C1" .../> {/* and C2-C4, all auto-placed */}
  </group>
</board>
```

Pre-fix on `main`: every cap collapses to (0, 0) — the chip's
network-minimum point — and the test assertion `c1.center.x ≈ 5` fails
with `Received: 0`.

Post-fix: all four caps land at the requested coordinates and the test
passes.

## Fix

Walk every descendant of the group being packed, ask the nearest
subcircuit if it resolves a manual placement for that descendant, and
add the `pcb_component_id` to `staticPcbComponentIds` if so. The packer
then leaves it where the manual placement put it.

```ts
const collectManuallyPlacedDescendants = (comp: any) => {
  const subcircuit = comp?.getSubcircuit?.()
  const manualPlacement =
    subcircuit?._getPcbManualPlacementForComponent?.(comp)
  if (manualPlacement && comp?.pcb_component_id) {
    staticPcbComponentIds.add(comp.pcb_component_id)
  }
  if (comp?.children) comp.children.forEach(collectManuallyPlacedDescendants)
}
collectManuallyPlacedDescendants(group)
```

Two-line change in
`lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts`,
plus a focused recursion helper. No effect on components that already
have `pcbX/pcbY` (those are already marked static via the existing
`isRelativelyPositioned()` path).

## Related (out of scope here)

There is a separate, complementary bug in
`_computePcbGlobalTransformBeforeLayout` where `manualPlacement` (which
is already in subcircuit-absolute coordinates) is composed with the
parent group's transform, double-counting the group anchor for any
component inside an anchored region. A non-zero-anchored group like
`<group pcbX={16} pcbY={0}>` containing a manually-placed cap at
(11.4, 4.3) lands the cap at (27.4, 4.3) instead of (11.4, 4.3). Filed
separately as issue #TBD — that fix is needed for the IDE drag flow to
produce visually-correct positions, but is independent of this PR.
This PR makes the static-marking honest; the position-interpretation
fix lets it land where the user dragged.

## Test plan

- [x] New repro test fails on `main` (cap at x=0), passes with fix
      (cap at x=5)
- [x] `tests/pcb-packing/` (2 tests) — pass
- [x] `tests/components/pcb tests/groups tests/features/pcb-pack-layout`
      (51 tests) — pass
- [ ] CI green
- [ ] Reviewer: confirm the recursion guard is appropriate (the helper
      walks every child, which is consistent with `collectMargins` a
      few lines above; alternative would be to scan `db.toArray()` once
      for `pcb_component` rows, but that's the same big-O for typical
      boards and reads worse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
