### PR TITLE
fix(layout): manualEdits position no longer double-counts parent group anchor

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -499,13 +499,19 @@ export abstract class PrimitiveComponent<
       this.props.pcbX === undefined &&
       this.props.pcbY === undefined
     ) {
+      // `manualPlacement` is already in subcircuit-global coordinates —
+      // `_getPcbManualPlacementForComponent` returns
+      //   applyToPoint(subcircuit.globalTransform, position.center)
+      // so the value is the absolute (board-frame) position the user
+      // dragged the component to. Composing it with the parent's
+      // transform on top of that translates by the parent's anchor a
+      // second time, double-counting any positioned ancestor group: a
+      // cap manually placed at (11.4, 4.3) inside `<group pcbX={16}>`
+      // ended up at (27.4, 4.3). Just translate to the absolute pos.
       const rotation = this._getPcbRotationBeforeLayout() ?? 0
       return compose(
-        this.parent?._computePcbGlobalTransformBeforeLayout() ?? identity(),
-        compose(
-          translate(manualPlacement.x, manualPlacement.y),
-          rotate((rotation * Math.PI) / 180),
-        ),
+        translate(manualPlacement.x, manualPlacement.y),
+        rotate((rotation * Math.PI) / 180),
       )
     }
 

--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
@@ -112,6 +112,24 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
     }
   }
 
+  // Also mark any descendant component that has a manualEdits placement
+  // as static — otherwise the packer would happily reposition it on top
+  // of the user's pinned location, silently undoing the manual edit.
+  // Walk every NormalComponent under this group; if its nearest subcircuit
+  // resolves a manual placement for it, treat it like any other relatively
+  // positioned child.
+  const collectManuallyPlacedDescendants = (comp: any) => {
+    const subcircuit = comp?.getSubcircuit?.()
+    const manualPlacement = subcircuit?._getPcbManualPlacementForComponent?.(
+      comp,
+    )
+    if (manualPlacement && comp?.pcb_component_id) {
+      staticPcbComponentIds.add(comp.pcb_component_id)
+    }
+    if (comp?.children) comp.children.forEach(collectManuallyPlacedDescendants)
+  }
+  collectManuallyPlacedDescendants(group)
+
   // Keep all circuit elements; static components will remain fixed during packing
   const filteredCircuitJson = db.toArray()
 

--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/applyPackOutput.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/applyPackOutput.ts
@@ -106,9 +106,6 @@ export const applyPackOutput = (
 
     const pcbComponent = db.pcb_component.get(componentId)
     if (pcbComponent) {
-      db.pcb_component.update(componentId, {
-        position_mode: "packed",
-      })
       const currentGroupId = group.source_group_id
       const sourceComponent = db.source_component.get(
         pcbComponent.source_component_id,
@@ -120,6 +117,32 @@ export const applyPackOutput = (
       ) {
         continue
       }
+
+      // If a manual placement positioned this component, skip the
+      // pack transform — `pcb_component.center` is already at the
+      // absolute manual position (set by
+      // `_computePcbGlobalTransformBeforeLayout`), and the static
+      // pack output's `center` is also in board-absolute coords, so
+      // composing the group's transform on top would double-count
+      // the group anchor (a cap manually placed at (11.4, 4.3) inside
+      // `<group pcbX={16}>` would land at (27.4, 4.3)). The child
+      // pcb primitives were already placed at the absolute position
+      // during initial render — nothing to do here.
+      const manualEdits = (group as any).getSubcircuit?.()?._parsedProps
+        ?.manualEdits
+      if (manualEdits?.pcb_placements && sourceComponent?.name) {
+        const hit = manualEdits.pcb_placements.find(
+          (p: any) => p.selector === sourceComponent.name,
+        )
+        if (hit) {
+          db.pcb_component.update(componentId, { position_mode: "packed" })
+          continue
+        }
+      }
+
+      db.pcb_component.update(componentId, {
+        position_mode: "packed",
+      })
 
       const originalCenter = pcbComponent.center
       const rotationDegrees = ccwRotationDegrees ?? ccwRotationOffset ?? 0

--- a/tests/pcb-packing/manual-edits-position-no-double-count.test.tsx
+++ b/tests/pcb-packing/manual-edits-position-no-double-count.test.tsx
@@ -1,0 +1,100 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Repro for: manualEdits.pcb_placements double-count the parent group's
+// anchor. _computePcbGlobalTransformBeforeLayout composed manualPlacement
+// (already absolute in the subcircuit's frame) with the parent's
+// transform, so a cap manually placed at (11.4, 4.3) inside
+// `<group pcbX={16}>` ended up at (27.4, 4.3) — the +16 region anchor
+// was added on top of the absolute manual position.
+test("manualEdits placement lands at absolute position, not parent-anchor + manual", () => {
+  const { circuit } = getTestFixture()
+
+  const manualEdits = {
+    pcb_placements: [
+      {
+        selector: "C1",
+        center: { x: 11.4, y: 4.3 },
+        relative_to: "group_center",
+      },
+    ],
+  } as any
+
+  circuit.add(
+    <board width="40mm" height="20mm" manualEdits={manualEdits}>
+      <group name="region" pcbX={16} pcbY={0}>
+        <chip
+          name="U1"
+          footprint="soic8"
+          pinLabels={{ pin1: "VCC", pin8: "GND" }}
+        />
+        <capacitor
+          name="C1"
+          capacitance="100nF"
+          footprint="0402"
+          connections={{ pin1: "U1.VCC", pin2: "U1.GND" }}
+        />
+      </group>
+    </board>,
+  )
+  circuit.render()
+
+  const c1 = (() => {
+    const src = circuit.db.source_component
+      .list()
+      .find((s) => s.name === "C1")!
+    return circuit.db.pcb_component
+      .list()
+      .find((p) => p.source_component_id === src.source_component_id)!
+  })()
+
+  // Without the fix the cap would land at (11.4 + 16, 4.3) = (27.4, 4.3).
+  // With the fix it lands at the absolute manual position (11.4, 4.3).
+  expect(c1.center.x).toBeCloseTo(11.4, 1)
+  expect(c1.center.y).toBeCloseTo(4.3, 1)
+})
+
+test("manualEdits placement also works when parent group is at origin (no regression)", () => {
+  const { circuit } = getTestFixture()
+
+  const manualEdits = {
+    pcb_placements: [
+      {
+        selector: "C1",
+        center: { x: 5, y: 2 },
+        relative_to: "group_center",
+      },
+    ],
+  } as any
+
+  circuit.add(
+    <board width="20mm" height="10mm" manualEdits={manualEdits}>
+      <group name="region" pcbX={0} pcbY={0}>
+        <chip
+          name="U1"
+          footprint="soic8"
+          pinLabels={{ pin1: "VCC", pin8: "GND" }}
+        />
+        <capacitor
+          name="C1"
+          capacitance="100nF"
+          footprint="0402"
+          connections={{ pin1: "U1.VCC", pin2: "U1.GND" }}
+        />
+      </group>
+    </board>,
+  )
+  circuit.render()
+
+  const c1 = (() => {
+    const src = circuit.db.source_component
+      .list()
+      .find((s) => s.name === "C1")!
+    return circuit.db.pcb_component
+      .list()
+      .find((p) => p.source_component_id === src.source_component_id)!
+  })()
+
+  expect(c1.center.x).toBeCloseTo(5, 1)
+  expect(c1.center.y).toBeCloseTo(2, 1)
+})

--- a/tests/pcb-packing/manual-edits-respected-by-packer.test.tsx
+++ b/tests/pcb-packing/manual-edits-respected-by-packer.test.tsx
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Repro for: components placed via the board's `manualEdits.pcb_placements`
+// were applied during _computePcbGlobalTransformBeforeLayout but then the
+// auto-packer re-positioned them, silently undoing the user's pin.
+//
+// The packer marks a child as "static" (skip-repack) only if
+// isRelativelyPositioned() returns true — and that helper checks
+// pcbX/pcbY/pcbLeftEdgeX/etc., NOT manualEdits. The fix walks each
+// descendant of the group being packed and adds its pcb_component_id
+// to staticPcbComponentIds when the nearest subcircuit resolves a
+// manual placement for it.
+//
+// Mirrors the failing case in loco-boardv2: a chip inside an anchored
+// region with several auto-placed bottom-side caps. Without the fix the
+// inner packer dumps every cap on top of the chip's network-minimum
+// point; with manualEdits and the fix, the caps land at the requested
+// coordinates instead.
+test("manualEdits placements survive the auto-packer (inner-group case)", () => {
+  const { circuit } = getTestFixture()
+
+  const manualEdits = {
+    pcb_placements: [
+      { selector: "C1", center: { x: 5, y: 3 }, relative_to: "group_center" },
+      { selector: "C2", center: { x: -5, y: 3 }, relative_to: "group_center" },
+      { selector: "C3", center: { x: 5, y: -3 }, relative_to: "group_center" },
+      { selector: "C4", center: { x: -5, y: -3 }, relative_to: "group_center" },
+    ],
+  } as any
+
+  circuit.add(
+    <board width="20mm" height="10mm" manualEdits={manualEdits}>
+      <group name="region" pcbX={0} pcbY={0}>
+        <chip
+          name="U1"
+          footprint="soic8"
+          pinLabels={{ pin1: "VCC", pin8: "GND" }}
+        />
+        <capacitor
+          name="C1"
+          capacitance="100nF"
+          footprint="0402"
+          connections={{ pin1: "U1.VCC", pin2: "U1.GND" }}
+        />
+        <capacitor
+          name="C2"
+          capacitance="100nF"
+          footprint="0402"
+          connections={{ pin1: "U1.VCC", pin2: "U1.GND" }}
+        />
+        <capacitor
+          name="C3"
+          capacitance="100nF"
+          footprint="0402"
+          connections={{ pin1: "U1.VCC", pin2: "U1.GND" }}
+        />
+        <capacitor
+          name="C4"
+          capacitance="100nF"
+          footprint="0402"
+          connections={{ pin1: "U1.VCC", pin2: "U1.GND" }}
+        />
+      </group>
+    </board>,
+  )
+  circuit.render()
+
+  const named = (name: string) => {
+    const src = circuit.db.source_component
+      .list()
+      .find((s) => s.name === name)!
+    return circuit.db.pcb_component
+      .list()
+      .find((p) => p.source_component_id === src.source_component_id)!
+  }
+
+  const c1 = named("C1")
+  const c2 = named("C2")
+  const c3 = named("C3")
+  const c4 = named("C4")
+
+  expect(c1.center.x).toBeCloseTo(5, 1)
+  expect(c1.center.y).toBeCloseTo(3, 1)
+  expect(c2.center.x).toBeCloseTo(-5, 1)
+  expect(c2.center.y).toBeCloseTo(3, 1)
+  expect(c3.center.x).toBeCloseTo(5, 1)
+  expect(c3.center.y).toBeCloseTo(-3, 1)
+  expect(c4.center.x).toBeCloseTo(-5, 1)
+  expect(c4.center.y).toBeCloseTo(-3, 1)
+})


### PR DESCRIPTION
## Summary

Closes #2281.

A component placed via `manualEdits.pcb_placements` inside a positioned `<group pcbX={N}>` landed at `(N + manual.x, manual.y)` instead of `(manual.x, manual.y)` — the group's anchor was added on top of the absolute manual position. From the user's perspective, every IDE drag inside a regional group ended up shifted by that group's anchor on the next rebuild.

Both `_computePcbGlobalTransformBeforeLayout` (initial render) and `applyPackOutput` (post-pack write-back) had the same shape:

```ts
compose(parent_or_group_transform, translate(manualPlacement), ...)
```

`manualPlacement` is the result of `applyToPoint(subcircuit.globalTransform, position.center)`. For the top-level board (transform = identity) it equals `position.center`, which the IDE writes in board-absolute coordinates. Composing the parent group's transform on top of that translates by the group anchor a second time.

## Repro

`tests/pcb-packing/manual-edits-position-no-double-count.test.tsx`:

```tsx
const manualEdits = {
  pcb_placements: [
    { selector: "C1", center: { x: 11.4, y: 4.3 }, relative_to: "group_center" },
  ],
}

<board width="40mm" height="20mm" manualEdits={manualEdits}>
  <group name="region" pcbX={16} pcbY={0}>
    <chip name="U1" footprint="soic8" pinLabels={{ pin1: "VCC", pin8: "GND" }} />
    <capacitor name="C1" capacitance="100nF" footprint="0402"
      connections={{ pin1: "U1.VCC", pin2: "U1.GND" }} />
  </group>
</board>
```

Pre-fix: `c1.center = (27.4, 4.3)` (the +16 region anchor was added on top of the absolute manual position).

Post-fix: `c1.center = (11.4, 4.3)` (lands exactly where the user dragged it).

A second test asserts a group at `pcbX={0} pcbY={0}` continues to work — no regression for the existing-correct case.

## Fix

Two edits, same root cause:

**1. `_computePcbGlobalTransformBeforeLayout` (`PrimitiveComponent.ts`):**
when `manualPlacement` is set, return JUST the manual translate + rotate, without composing the parent's transform.

```ts
if (manualPlacement && this.props.pcbX === undefined && this.props.pcbY === undefined) {
  // `manualPlacement` is already in subcircuit-global coordinates;
  // composing parent transform on top double-counts any positioned
  // ancestor group.
  const rotation = this._getPcbRotationBeforeLayout() ?? 0
  return compose(
    translate(manualPlacement.x, manualPlacement.y),
    rotate((rotation * Math.PI) / 180),
  )
}
```

**2. `applyPackOutput` (`Group_doInitialPcbLayoutPack/`):**
when the component being written back has a matching entry in the subcircuit's manualEdits.pcb_placements, skip the pack transform — the component's child pcb primitives are already at the absolute manual position from initial render. `position_mode` is still flipped to `"packed"` so downstream code sees a consistent state.

```ts
const manualEdits = group.getSubcircuit?.()?._parsedProps?.manualEdits
if (manualEdits?.pcb_placements && sourceComponent?.name) {
  const hit = manualEdits.pcb_placements.find(
    (p) => p.selector === sourceComponent.name,
  )
  if (hit) {
    db.pcb_component.update(componentId, { position_mode: "packed" })
    continue
  }
}
```

## Stacked on #2280

This PR is stacked on [#2280](https://github.com/tscircuit/core/pull/2280) (packer respects manualEdits as static). Without that fix, the packer overrides the manual position with its own (different, also wrong) value, masking this bug. Together both fixes make the IDE drag-and-pin flow behave correctly end-to-end.

## Test plan

- [x] Two new repro tests in `tests/pcb-packing/manual-edits-position-no-double-count.test.tsx` (positioned group + zero-anchored group)
- [x] Static-marking repro from #2280 still passes
- [x] Wider suites: `tests/pcb-packing` (3 tests), `tests/components/pcb` (47), `tests/groups` (2), `tests/features/pcb-pack-layout` (1) — all pass when run individually; two unrelated timing-sensitive tests in the wider parallel run flaked twice but green when re-run alone
- [ ] CI green
- [ ] Reviewer: confirm the schematic equivalent (`_getSchematicGlobalManualPlacementTransform`) at line ~890 has the same shape and may want a parallel fix in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
