### PR TITLE
Add explicit show_as_bounding_box to cad_component when there is no cad model

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -1670,7 +1670,7 @@ export class NormalComponent<
     const isBottomLayer = computedLayer === "bottom"
 
     if (!cadModel && !footprint) {
-      const cad_model = db.cad_component.insert({
+      const cad_component = db.cad_component.insert({
         position: {
           x: bounds.center.x,
           y: bounds.center.y,
@@ -1691,7 +1691,7 @@ export class NormalComponent<
         show_as_bounding_box: true,
         show_as_translucent_model: this._parsedProps.showAsTranslucentModel,
       } as any)
-      this.cad_component_id = cad_model.cad_component_id
+      this.cad_component_id = cad_component.cad_component_id
       return
     }
 

--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -1618,7 +1618,6 @@ export class NormalComponent<
       this.getFootprinterString() ?? this._getImpliedFootprintString()
 
     if (!this.pcb_component_id) return
-    if (!cadModel && !footprint) return
     if (cadModel === null) return
 
     // Use post-layout bounds
@@ -1669,6 +1668,32 @@ export class NormalComponent<
         ? (pcbComponent.rotation ?? preLayoutRotation)
         : preLayoutRotation
     const isBottomLayer = computedLayer === "bottom"
+
+    if (!cadModel && !footprint) {
+      const cad_model = db.cad_component.insert({
+        position: {
+          x: bounds.center.x,
+          y: bounds.center.y,
+          z:
+            computedLayer === "bottom"
+              ? -boardThickness / 2
+              : boardThickness / 2,
+        },
+        rotation: {
+          x: 0,
+          y: isBottomLayer ? 180 : 0,
+          z: normalizeDegrees(isBottomLayer ? -totalRotation : totalRotation),
+        },
+        pcb_component_id: this.pcb_component_id,
+        source_component_id: this.source_component_id!,
+        model_origin_alignment: "center_of_component_on_board_surface",
+        anchor_alignment: "center_of_component_on_board_surface",
+        show_as_bounding_box: true,
+        show_as_translucent_model: this._parsedProps.showAsTranslucentModel,
+      } as any)
+      this.cad_component_id = cad_model.cad_component_id
+      return
+    }
 
     const rotationWithOffset = totalRotation + (rotationOffset.z ?? 0)
     const cadRotationZ = normalizeDegrees(rotationWithOffset)

--- a/lib/components/primitive-components/PcbTrace.ts
+++ b/lib/components/primitive-components/PcbTrace.ts
@@ -1,7 +1,7 @@
 import { PrimitiveComponent } from "../base-components/PrimitiveComponent"
 import { z } from "zod"
 import { pcb_trace_route_point, type PcbTraceRoutePoint } from "circuit-json"
-import { compose, translate, scale, applyToPoint } from "transformation-matrix"
+import { applyToPoint } from "transformation-matrix"
 
 export const pcbTraceProps = z.object({
   route: z.array(pcb_trace_route_point),
@@ -35,16 +35,34 @@ export class PcbTrace extends PrimitiveComponent<typeof pcbTraceProps> {
     const parentTransform = this._computePcbGlobalTransformBeforeLayout()
 
     const transformedRoute = props.route.map((point) => {
-      const { x, y, ...restOfPoint } = point
-      const transformedPoint = applyToPoint(parentTransform, { x, y })
-      if (point.route_type === "wire" && point.layer) {
+      if (point.route_type === "wire") {
+        const { x, y, ...restOfPoint } = point
+        const transformedPoint = applyToPoint(parentTransform, { x, y })
         return {
-          ...transformedPoint,
           ...restOfPoint,
+          ...transformedPoint,
           layer: maybeFlipLayer(point.layer),
         } as PcbTraceRoutePoint
       }
-      return { ...transformedPoint, ...restOfPoint } as PcbTraceRoutePoint
+
+      if (point.route_type === "via") {
+        const { x, y, ...restOfPoint } = point
+        const transformedPoint = applyToPoint(parentTransform, { x, y })
+        return {
+          ...restOfPoint,
+          ...transformedPoint,
+          from_layer: maybeFlipLayer(point.from_layer),
+          to_layer: maybeFlipLayer(point.to_layer),
+        } as PcbTraceRoutePoint
+      }
+
+      return {
+        ...point,
+        start: applyToPoint(parentTransform, point.start),
+        end: applyToPoint(parentTransform, point.end),
+        start_layer: maybeFlipLayer(point.start_layer),
+        end_layer: maybeFlipLayer(point.end_layer),
+      } as PcbTraceRoutePoint
     })
 
     const pcb_trace = db.pcb_trace.insert({
@@ -69,16 +87,44 @@ export class PcbTrace extends PrimitiveComponent<typeof pcbTraceProps> {
       maxY = -Infinity
 
     for (const point of props.route) {
-      minX = Math.min(minX, point.x)
-      maxX = Math.max(maxX, point.x)
-      minY = Math.min(minY, point.y)
-      maxY = Math.max(maxY, point.y)
-      // Consider trace width for a more accurate bounding box if necessary
+      if (point.route_type === "through_pad") {
+        minX = Math.min(minX, point.start.x, point.end.x)
+        maxX = Math.max(maxX, point.start.x, point.end.x)
+        minY = Math.min(minY, point.start.y, point.end.y)
+        maxY = Math.max(maxY, point.start.y, point.end.y)
+      } else {
+        minX = Math.min(minX, point.x)
+        maxX = Math.max(maxX, point.x)
+        minY = Math.min(minY, point.y)
+        maxY = Math.max(maxY, point.y)
+      }
+
       if (point.route_type === "wire") {
         minX = Math.min(minX, point.x - point.width / 2)
         maxX = Math.max(maxX, point.x + point.width / 2)
         minY = Math.min(minY, point.y - point.width / 2)
         maxY = Math.max(maxY, point.y + point.width / 2)
+      } else if (point.route_type === "through_pad") {
+        minX = Math.min(
+          minX,
+          point.start.x - point.width / 2,
+          point.end.x - point.width / 2,
+        )
+        maxX = Math.max(
+          maxX,
+          point.start.x + point.width / 2,
+          point.end.x + point.width / 2,
+        )
+        minY = Math.min(
+          minY,
+          point.start.y - point.width / 2,
+          point.end.y - point.width / 2,
+        )
+        maxY = Math.max(
+          maxY,
+          point.start.y + point.width / 2,
+          point.end.y + point.width / 2,
+        )
       }
     }
 

--- a/lib/components/primitive-components/Trace/Trace_doInitialPcbManualTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialPcbManualTraceRender.ts
@@ -108,16 +108,34 @@ export function Trace_doInitialPcbManualTraceRender(trace: Trace) {
     const { maybeFlipLayer } = trace._getPcbPrimitiveFlippedHelpers()
     const transform = trace._computePcbGlobalTransformBeforeLayout()
     const transformedRoute = inflatedPcbTrace.route.map((point) => {
-      const { x, y, ...restOfPoint } = point
-      const transformedPoint = applyToPoint(transform, { x, y })
-      if (point.route_type === "wire" && point.layer) {
+      if (point.route_type === "wire") {
+        const { x, y, ...restOfPoint } = point
+        const transformedPoint = applyToPoint(transform, { x, y })
         return {
-          ...transformedPoint,
           ...restOfPoint,
+          ...transformedPoint,
           layer: maybeFlipLayer(point.layer),
         } as PcbTraceRoutePoint
       }
-      return { ...transformedPoint, ...restOfPoint } as PcbTraceRoutePoint
+
+      if (point.route_type === "via") {
+        const { x, y, ...restOfPoint } = point
+        const transformedPoint = applyToPoint(transform, { x, y })
+        return {
+          ...restOfPoint,
+          ...transformedPoint,
+          from_layer: maybeFlipLayer(point.from_layer),
+          to_layer: maybeFlipLayer(point.to_layer),
+        } as PcbTraceRoutePoint
+      }
+
+      return {
+        ...point,
+        start: applyToPoint(transform, point.start),
+        end: applyToPoint(transform, point.end),
+        start_layer: maybeFlipLayer(point.start_layer),
+        end_layer: maybeFlipLayer(point.end_layer),
+      } as PcbTraceRoutePoint
     })
 
     const pcb_trace = db.pcb_trace.insert({

--- a/lib/components/primitive-components/Trace/trace-utils/compute-trace-length.ts
+++ b/lib/components/primitive-components/Trace/trace-utils/compute-trace-length.ts
@@ -1,4 +1,5 @@
 import type { PcbTrace } from "circuit-json"
+import { getRoutePointPosition } from "lib/utils/pcb-trace-route-point-utils"
 
 /**
  * Computes the total length of a PCB trace by summing the lengths of all wire segments
@@ -16,8 +17,10 @@ export function getTraceLength(route: PcbTrace["route"]): number {
       // For wire segments, compute straight-line distance
       const nextPoint = route[i + 1]
       if (nextPoint) {
-        const dx = nextPoint.x - point.x
-        const dy = nextPoint.y - point.y
+        const nextPosition = getRoutePointPosition(nextPoint)
+        const position = getRoutePointPosition(point)
+        const dx = nextPosition.x - position.x
+        const dy = nextPosition.y - position.y
         totalLength += Math.sqrt(dx * dx + dy * dy)
       }
     } else if (point.route_type === "via") {

--- a/lib/utils/autorouting/mergeRoutes.ts
+++ b/lib/utils/autorouting/mergeRoutes.ts
@@ -1,7 +1,10 @@
 import type { PcbTrace } from "circuit-json"
+import { getRoutePointPosition } from "../pcb-trace-route-point-utils"
 
 function pdist(a: PcbTrace["route"][number], b: PcbTrace["route"][number]) {
-  return Math.hypot(a.x - b.x, a.y - b.y)
+  const aPosition = getRoutePointPosition(a)
+  const bPosition = getRoutePointPosition(b)
+  return Math.hypot(aPosition.x - bPosition.x, aPosition.y - bPosition.y)
 }
 
 /**

--- a/lib/utils/is-route-outside-board.ts
+++ b/lib/utils/is-route-outside-board.ts
@@ -2,6 +2,7 @@ import { point } from "@flatten-js/core"
 import type { CircuitJsonUtilObjects } from "@tscircuit/circuit-json-util"
 import type { PcbTraceRoutePoint } from "circuit-json"
 import { getPcbBoardOutlinePolygon } from "./get-pcb-board-outline-polygon"
+import { getRoutePointPositions } from "./pcb-trace-route-point-utils"
 
 export const isRouteOutsideBoard = ({
   mergedRoute,
@@ -20,8 +21,10 @@ export const isRouteOutsideBoard = ({
 
   // Check if any route point is outside the board
   return !mergedRoute
-    .flat()
-    .every((routePoint) =>
-      boardOutlinePolygon.contains(point(routePoint.x, routePoint.y)),
+    .flatMap(getRoutePointPositions)
+    .every((routePointPosition) =>
+      boardOutlinePolygon.contains(
+        point(routePointPosition.x, routePointPosition.y),
+      ),
     )
 }

--- a/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
+++ b/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
@@ -343,11 +343,30 @@ export const getObstaclesFromCircuitJson = (
       }
     } else if (element.type === "pcb_trace") {
       const traceObstacles = getObstaclesFromRoute(
-        element.route.map((rp) => ({
-          x: rp.x,
-          y: rp.y,
-          layer: "layer" in rp ? rp.layer : rp.from_layer,
-        })),
+        element.route.flatMap((rp) => {
+          if (rp.route_type === "through_pad") {
+            return [
+              {
+                x: rp.start.x,
+                y: rp.start.y,
+                layer: rp.start_layer,
+              },
+              {
+                x: rp.end.x,
+                y: rp.end.y,
+                layer: rp.end_layer,
+              },
+            ]
+          }
+
+          return [
+            {
+              x: rp.x,
+              y: rp.y,
+              layer: rp.route_type === "wire" ? rp.layer : rp.from_layer,
+            },
+          ]
+        }),
         element.source_trace_id!,
       )
       obstacles.push(...traceObstacles)

--- a/lib/utils/pcb-trace-route-point-utils.ts
+++ b/lib/utils/pcb-trace-route-point-utils.ts
@@ -1,0 +1,11 @@
+import type { Point, PcbTraceRoutePoint } from "circuit-json"
+
+export const getRoutePointPosition = (point: PcbTraceRoutePoint): Point => {
+  if (point.route_type === "through_pad") return point.start
+  return { x: point.x, y: point.y }
+}
+
+export const getRoutePointPositions = (point: PcbTraceRoutePoint): Point[] => {
+  if (point.route_type === "through_pad") return [point.start, point.end]
+  return [{ x: point.x, y: point.y }]
+}

--- a/lib/utils/pcbTraceRouteToPcbPath.ts
+++ b/lib/utils/pcbTraceRouteToPcbPath.ts
@@ -1,4 +1,5 @@
 import type { LayerRef, PcbTraceRoutePoint } from "circuit-json"
+import { getRoutePointPosition } from "./pcb-trace-route-point-utils"
 
 export type ManualPcbPathPoint = {
   x: number
@@ -28,8 +29,13 @@ export function pcbTraceRouteToPcbPath(
     .slice(1, -1)
     .filter((point) => {
       // Filter out points that duplicate the start or end position
-      const isSameAsFirst = point.x === firstPoint.x && point.y === firstPoint.y
-      const isSameAsLast = point.x === lastPoint.x && point.y === lastPoint.y
+      const position = getRoutePointPosition(point)
+      const firstPosition = getRoutePointPosition(firstPoint)
+      const lastPosition = getRoutePointPosition(lastPoint)
+      const isSameAsFirst =
+        position.x === firstPosition.x && position.y === firstPosition.y
+      const isSameAsLast =
+        position.x === lastPosition.x && position.y === lastPosition.y
       return !isSameAsFirst && !isSameAsLast
     })
     .map((point) => {
@@ -42,6 +48,7 @@ export function pcbTraceRouteToPcbPath(
           toLayer: point.to_layer as LayerRef,
         }
       }
-      return { x: point.x, y: point.y }
+      const position = getRoutePointPosition(point)
+      return { x: position.x, y: position.y }
     })
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "bun-match-svg": "0.0.12",
     "calculate-elbow": "^0.0.12",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.423",
+    "circuit-json": "^0.0.425",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.23",
     "circuit-json-to-gltf": "^0.0.96",

--- a/tests/breakout/breakoutpoint-route.test.tsx
+++ b/tests/breakout/breakoutpoint-route.test.tsx
@@ -3,6 +3,7 @@ import { test, expect } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 import { getTestAutoroutingServer } from "tests/fixtures/get-test-autorouting-server"
 import { su } from "@tscircuit/circuit-json-util"
+import { getRoutePointPositions } from "lib/utils/pcb-trace-route-point-utils"
 
 test("autorouter uses breakout point", async () => {
   const { circuit } = getTestFixture()
@@ -35,7 +36,12 @@ test("autorouter uses breakout point", async () => {
 
   const pcb_trace = su(circuit.getCircuitJson()).pcb_trace.list()
   const hasPointNear = pcb_trace.some((t) =>
-    t.route.some((pt) => Math.abs(pt.x - 5) < 0.6 && Math.abs(pt.y - 5) < 0.6),
+    t.route.some((pt) =>
+      getRoutePointPositions(pt).some(
+        (position) =>
+          Math.abs(position.x - 5) < 0.6 && Math.abs(position.y - 5) < 0.6,
+      ),
+    ),
   )
   expect(hasPointNear).toBe(true)
   expect(circuit).toMatchPcbSnapshot(import.meta.path)

--- a/tests/components/normal-components/cad-component-bounding-box.test.tsx
+++ b/tests/components/normal-components/cad-component-bounding-box.test.tsx
@@ -1,0 +1,93 @@
+import { expect, it } from "bun:test"
+import "lib/register-catalogue"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+it("does not emit a bounding-box cad_component when a cad_component already exists", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip name="U1" footprint="soic8" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const cadComponents = circuit
+    .getCircuitJson()
+    .filter((element) => element.type === "cad_component")
+
+  expect(cadComponents).toHaveLength(1)
+  expect(cadComponents[0]).toMatchObject({
+    type: "cad_component",
+    footprinter_string: "soic8",
+  })
+  expect(cadComponents[0]).not.toHaveProperty("show_as_bounding_box")
+})
+
+it("emits a bounding-box cad_component when no cad_component exists", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip name="U1" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const circuitJson = circuit.getCircuitJson()
+  const cadComponents = circuitJson.filter(
+    (element) => element.type === "cad_component",
+  )
+
+  expect(cadComponents).toHaveLength(1)
+  expect(cadComponents[0]).toMatchObject({
+    type: "cad_component",
+    pcb_component_id: expect.any(String),
+    source_component_id: expect.any(String),
+    position: { x: 0, y: 0, z: 0.7 },
+    show_as_bounding_box: true,
+  })
+  expect(cadComponents[0]).not.toHaveProperty("footprinter_string")
+})
+
+it("does not emit a bounding-box cad_component when cadModel is null", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip name="U1" footprint="soic8" cadModel={null} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const cadComponents = circuit
+    .getCircuitJson()
+    .filter((element) => element.type === "cad_component")
+
+  expect(cadComponents).toHaveLength(0)
+})
+
+it("does not emit a bounding-box cad_component for wrappers with cadModel null", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip name="Xpattern1" noSchematicRepresentation cadModel={null}>
+        <footprint>
+          <hole shape="pill" pcbX={0} pcbY={0} width={2} height={1} />
+        </footprint>
+      </chip>
+    </board>,
+  )
+
+  circuit.render()
+
+  const cadComponents = circuit
+    .getCircuitJson()
+    .filter((element) => element.type === "cad_component")
+
+  expect(cadComponents).toHaveLength(0)
+})

--- a/tests/components/normal-components/chip-layer-trace-bug.test.tsx
+++ b/tests/components/normal-components/chip-layer-trace-bug.test.tsx
@@ -56,8 +56,11 @@ test("chip with flipped layer should have traces on correct layer", async () => 
   const traces = circuit.db.pcb_trace.list()
 
   const routeLayers = traces[0].route.flatMap((point) => {
-    if ("layer" in point) {
+    if (point.route_type === "wire") {
       return [point.layer]
+    }
+    if (point.route_type === "through_pad") {
+      return [point.start_layer, point.end_layer]
     }
     return [point.to_layer, point.from_layer]
   })

--- a/tests/features/subcircuit-circuit-json/subcircuit-circuit-json02.test.tsx
+++ b/tests/features/subcircuit-circuit-json/subcircuit-circuit-json02.test.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import type { PcbSmtPad, PcbTrace, PcbVia } from "circuit-json"
+import { getRoutePointPosition } from "lib/utils/pcb-trace-route-point-utils"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
 test("subcircuit-circuit-json02 - chip inflation", async () => {
@@ -157,19 +158,23 @@ test("subcircuit-circuit-json02 - chip inflation", async () => {
     // Check if the routes match in either direction.
     const routesMatchForward = originalRoute.every((origPt, j) => {
       const inflPt = inflatedRoute[j]
+      const originalPosition = getRoutePointPosition(origPt)
+      const inflatedPosition = getRoutePointPosition(inflPt)
       return (
         origPt.route_type === inflPt.route_type &&
-        Math.abs(origPt.x - inflPt.x) < 0.0001 &&
-        Math.abs(origPt.y - inflPt.y) < 0.0001
+        Math.abs(originalPosition.x - inflatedPosition.x) < 0.0001 &&
+        Math.abs(originalPosition.y - inflatedPosition.y) < 0.0001
       )
     })
 
     const routesMatchReverse = originalRoute.every((origPt, j) => {
       const inflPt = inflatedRoute[originalRoute.length - 1 - j]
+      const originalPosition = getRoutePointPosition(origPt)
+      const inflatedPosition = getRoutePointPosition(inflPt)
       return (
         origPt.route_type === inflPt.route_type &&
-        Math.abs(origPt.x - inflPt.x) < 0.0001 &&
-        Math.abs(origPt.y - inflPt.y) < 0.0001
+        Math.abs(originalPosition.x - inflatedPosition.x) < 0.0001 &&
+        Math.abs(originalPosition.y - inflatedPosition.y) < 0.0001
       )
     })
 


### PR DESCRIPTION


This adds support for explicit fallback CAD components using cad_component.show_as_bounding_box.

Core now creates a cad_component in three cases:

  1. Explicit CAD model
     <chip cadModel={{ glbUrl: "..." }} />Emits a normal cad_component with the model URL.
     

  2. <chip footprint="soic8" />
      Emits a normal cad_component with
     footprinter_string.

  3. Fallback bounding box
     <chip name="U1" />

     If no CAD model and no footprinter
     CAD source exists, core emits:

     {
       "type": "cad_component",
       "show_as_bounding_box": true
     }

This tells renderers to draw a generic 3D box using the associated pcb_component bounds.

Core does not create a fallback cad_component when CAD is explicitly disabled:

  <chip name="U1" cadModel={null} />

  That still emits no cad_component.

This makes fallback boxes explicit in Circuit JSON instead of requiring renderers like circuit-json-to-gltf to infer them from bare pcb_components.