### PR TITLE
Fix invalid source trace IDs in region reroute output

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -1208,7 +1208,10 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       const validSourceTraceIds = Array.from(
         new Set(possibleSourceTraceIds),
       ).filter((possibleSourceTraceId) =>
-        db.source_trace.get(possibleSourceTraceId),
+        Boolean(
+          db.source_trace.get(possibleSourceTraceId) ??
+            db.source_net.get(possibleSourceTraceId),
+        ),
       )
       const sourceTraceId =
         validSourceTraceIds.length === 1 ? validSourceTraceIds[0] : undefined
@@ -1219,7 +1222,8 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       }
       pcb_trace.subcircuit_id ??=
         (sourceTraceId
-          ? db.source_trace.get(sourceTraceId)?.subcircuit_id
+          ? (db.source_trace.get(sourceTraceId)?.subcircuit_id ??
+            db.source_net.get(sourceTraceId)?.subcircuit_id)
           : undefined) ?? this.subcircuit_id!
 
       // Split traces at jumper locations (based on explicit jumper route markers)

--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -74,6 +74,7 @@ import {
   deleteExistingPcbTracesReplacedBy,
   getExistingPcbTracesForReroute,
   getExistingSimplifiedPcbTracesForReroute,
+  getSourceTraceIdsFromRerouteName,
 } from "./region-replacement"
 import { splitPcbTracesOnJumperSegments } from "./split-pcb-traces-on-jumper-segments"
 import { computeCenterFromAnchorPosition } from "./utils/computeCenterFromAnchorPosition"
@@ -1197,10 +1198,24 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       // vias can be included
       if (pcb_trace.type !== "pcb_trace") continue
 
+      const possibleSourceTraceIds = [
+        ...getSourceTraceIdsFromRerouteName((pcb_trace as any).source_trace_id),
+        ...getSourceTraceIdsFromRerouteName((pcb_trace as any).connection_name),
+        ...getSourceTraceIdsFromRerouteName(
+          (pcb_trace as any).rootConnectionName,
+        ),
+      ]
+      const validSourceTraceIds = Array.from(
+        new Set(possibleSourceTraceIds),
+      ).filter((possibleSourceTraceId) =>
+        db.source_trace.get(possibleSourceTraceId),
+      )
       const sourceTraceId =
-        (pcb_trace as any).source_trace_id ?? (pcb_trace as any).connection_name
+        validSourceTraceIds.length === 1 ? validSourceTraceIds[0] : undefined
       if (sourceTraceId) {
         pcb_trace.source_trace_id = sourceTraceId
+      } else {
+        delete (pcb_trace as any).source_trace_id
       }
       pcb_trace.subcircuit_id ??=
         (sourceTraceId

--- a/lib/components/primitive-components/Group/region-replacement/delete-existing-pcb-traces-replaced-by.ts
+++ b/lib/components/primitive-components/Group/region-replacement/delete-existing-pcb-traces-replaced-by.ts
@@ -2,6 +2,7 @@ import type { PcbTrace, PcbVia } from "circuit-json"
 import type { SimplifiedPcbTrace } from "lib/utils/autorouting/SimpleRouteJson"
 import type { Group } from "../Group"
 import { getExistingPcbTracesForReroute } from "./get-existing-pcb-traces-for-reroute"
+import { getSourceTraceIdsFromRerouteName } from "./get-source-trace-ids-from-reroute-name"
 
 /**
  * Adds both the routed trace identifier and its pre-reroute source trace
@@ -16,15 +17,8 @@ function addPossibleReplacementSourceTraceId(
 
   sourceTraceIds.add(value)
 
-  for (const connectionNamePart of value.split("__")) {
-    if (connectionNamePart.length === 0) continue
-
-    sourceTraceIds.add(connectionNamePart)
-
-    const rerouteSuffixIndex = connectionNamePart.indexOf("_reroute_")
-    if (rerouteSuffixIndex > 0) {
-      sourceTraceIds.add(connectionNamePart.slice(0, rerouteSuffixIndex))
-    }
+  for (const sourceTraceId of getSourceTraceIdsFromRerouteName(value)) {
+    sourceTraceIds.add(sourceTraceId)
   }
 }
 

--- a/lib/components/primitive-components/Group/region-replacement/get-source-trace-ids-from-reroute-name.ts
+++ b/lib/components/primitive-components/Group/region-replacement/get-source-trace-ids-from-reroute-name.ts
@@ -1,0 +1,15 @@
+export function getSourceTraceIdsFromRerouteName(value: unknown): string[] {
+  if (typeof value !== "string" || value.length === 0) return []
+
+  return value.split("__").flatMap((connectionNamePart) => {
+    if (connectionNamePart.length === 0) return []
+
+    const sourceTraceIds = [connectionNamePart]
+    const rerouteSuffixIndex = connectionNamePart.indexOf("_reroute_")
+    if (rerouteSuffixIndex > 0) {
+      sourceTraceIds.push(connectionNamePart.slice(0, rerouteSuffixIndex))
+    }
+
+    return sourceTraceIds
+  })
+}

--- a/lib/components/primitive-components/Group/region-replacement/index.ts
+++ b/lib/components/primitive-components/Group/region-replacement/index.ts
@@ -3,3 +3,4 @@ export { deleteExistingPcbTracesReplacedBy } from "./delete-existing-pcb-traces-
 export { getExistingPcbTracesForReroute } from "./get-existing-pcb-traces-for-reroute"
 export { getExistingSimplifiedPcbTracesForReroute } from "./get-existing-simplified-pcb-traces-for-reroute"
 export { getRelevantSubcircuitIdsForReroute } from "./get-relevant-subcircuit-ids-for-reroute"
+export { getSourceTraceIdsFromRerouteName } from "./get-source-trace-ids-from-reroute-name"

--- a/tests/repros/repro116-arduino-uno-reroute-invalid-source-ids.test.tsx
+++ b/tests/repros/repro116-arduino-uno-reroute-invalid-source-ids.test.tsx
@@ -38,5 +38,5 @@ test("repro116: rerouting imported arduino region should not create pcb traces w
       source_trace_id: trace.source_trace_id,
     }))
 
-  expect(tracesWithMissingSourceTrace).toHaveLength(15)
+  expect(tracesWithMissingSourceTrace).toHaveLength(0)
 }, 80_000)

--- a/tests/repros/repro116-arduino-uno-reroute-invalid-source-ids.test.tsx
+++ b/tests/repros/repro116-arduino-uno-reroute-invalid-source-ids.test.tsx
@@ -12,7 +12,7 @@ const rerouteRegion = {
   maxY: 8,
 }
 
-test("repro116: rerouting imported arduino region currently creates pcb traces with invalid source_trace_id", async () => {
+test("repro116: rerouting imported arduino region should not create pcb traces with invalid source_trace_id", async () => {
   const { afterRerouteCircuit, beforeRerouteCircuit } =
     await renderArduinoUnoRerouteRegion({
       label: "INVALID SOURCE ID REPRO",


### PR DESCRIPTION
 Parses reroute output source trace references from _reroute_ and merged __ connection
  names, then only assigns pcb_trace.source_trace_id when it resolves to exactly one real
  source trace. Reuses the parser for existing trace replacement cleanup and updates the
  Arduino Uno invalid-source-id repro to assert the fixed invariant.