### PR TITLE
Respect schematic trace auto-label opt-out

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
@@ -18,6 +18,10 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
   if (!group.isSubcircuit) return
   if (group.root?.schematicDisabled) return
 
+  const shouldInsertAutoNetLabels =
+    group.getInheritedProperty("schTraceAutoLabelEnabled") !== false &&
+    group._getBoard()?._parsedProps.schTraceAutoLabelEnabled !== false
+
   // Prepare the solver input and context
   const {
     inputProblem,
@@ -27,6 +31,7 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
     schPortIdToSourcePortId,
     userNetIdToConnKey,
     connKeysWithExplicitPortNetTraces,
+    explicitPortNetDisplayLabelsByConnKey,
   } = createSchematicTraceSolverInputProblem(group)
 
   if (inputProblem.chips.length === 0) return
@@ -39,12 +44,14 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
     inputProblem.netConnections.length > 0
 
   if (!hasRouteableSchematicConnections) {
-    insertNetLabelsForPortsMissingTrace({
-      group,
-      allSourceAndSchematicPortIdsInScope,
-      schPortIdToSourcePortId,
-      connKeyToSourceNet,
-    })
+    if (shouldInsertAutoNetLabels) {
+      insertNetLabelsForPortsMissingTrace({
+        group,
+        allSourceAndSchematicPortIdsInScope,
+        schPortIdToSourcePortId,
+        connKeyToSourceNet,
+      })
+    }
     return
   }
 
@@ -83,14 +90,18 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
     pinIdToSchematicPortId,
     userNetIdToConnKey,
     connKeysWithExplicitPortNetTraces,
+    explicitPortNetDisplayLabelsByConnKey,
     schematicPortIdsWithPreExistingNetLabels,
     schematicPortIdsWithRoutedTraces,
+    shouldInsertAutoNetLabels,
   })
 
-  insertNetLabelsForPortsMissingTrace({
-    group,
-    allSourceAndSchematicPortIdsInScope,
-    schPortIdToSourcePortId,
-    connKeyToSourceNet,
-  })
+  if (shouldInsertAutoNetLabels) {
+    insertNetLabelsForPortsMissingTrace({
+      group,
+      allSourceAndSchematicPortIdsInScope,
+      schPortIdToSourcePortId,
+      connKeyToSourceNet,
+    })
+  }
 }

--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/applyNetLabelPlacements.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/applyNetLabelPlacements.ts
@@ -17,8 +17,10 @@ export function applyNetLabelPlacements(args: {
   connKeyToSourceNet: Map<string, SourceNet>
   pinIdToSchematicPortId: Map<string, string>
   connKeysWithExplicitPortNetTraces: Set<string>
+  explicitPortNetDisplayLabelsByConnKey: Map<string, string>
   schematicPortIdsWithPreExistingNetLabels: Set<string>
   schematicPortIdsWithRoutedTraces: Set<string>
+  shouldInsertAutoNetLabels?: boolean
 }) {
   const {
     group,
@@ -27,8 +29,10 @@ export function applyNetLabelPlacements(args: {
     userNetIdToConnKey,
     pinIdToSchematicPortId,
     connKeysWithExplicitPortNetTraces,
+    explicitPortNetDisplayLabelsByConnKey,
     schematicPortIdsWithPreExistingNetLabels,
     schematicPortIdsWithRoutedTraces,
+    shouldInsertAutoNetLabels = true,
   } = args
   const { db } = group.root!
 
@@ -86,6 +90,9 @@ export function applyNetLabelPlacements(args: {
       const hasExplicitPortNetTrace = connKeysWithExplicitPortNetTraces.has(
         placementConnKey!,
       )
+      const explicitDisplayLabel = placementConnKey
+        ? explicitPortNetDisplayLabelsByConnKey.get(placementConnKey)
+        : undefined
       const hasRoutedTraceForPlacementPort = schPortIds.some((id) =>
         schematicPortIdsWithRoutedTraces.has(id),
       )
@@ -105,7 +112,11 @@ export function applyNetLabelPlacements(args: {
         continue
       }
 
-      const text = sourceNet.name
+      if (!shouldInsertAutoNetLabels && !explicitDisplayLabel) continue
+
+      const text = shouldInsertAutoNetLabels
+        ? sourceNet.name
+        : (explicitDisplayLabel ?? sourceNet.name)
 
       const center = computeSchematicNetLabelCenter({
         anchor_position,
@@ -129,6 +140,8 @@ export function applyNetLabelPlacements(args: {
       .filter((p) => p._getSubcircuitConnectivityKey() === placementConnKey)
 
     const { name: text, wasAssignedDisplayLabel } = getNetNameFromPorts(ports)
+
+    if (!shouldInsertAutoNetLabels && !wasAssignedDisplayLabel) continue
 
     if (
       !wasAssignedDisplayLabel &&

--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/createSchematicTraceSolverInputProblem.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/createSchematicTraceSolverInputProblem.ts
@@ -43,6 +43,7 @@ export type SolverInputContext = {
    * e.g. <trace from=".D1 > .pin1" to="net.VCC" />.
    */
   connKeysWithExplicitPortNetTraces: Set<string>
+  explicitPortNetDisplayLabelsByConnKey: Map<string, string>
 
   allSourceAndSchematicPortIdsInScope: Set<string>
   schPortIdToSourcePortId: Map<string, string>
@@ -177,6 +178,7 @@ export function createSchematicTraceSolverInputProblem(
     []
   const connectedPairKeys = new Set<string>()
   const connKeysWithExplicitPortNetTraces = new Set<string>()
+  const explicitPortNetDisplayLabelsByConnKey = new Map<string, string>()
   for (const trace of traces as any[]) {
     if (trace.parent !== group) continue
     const sourceTraceId = trace.source_trace_id
@@ -190,6 +192,12 @@ export function createSchematicTraceSolverInputProblem(
       connKeysWithExplicitPortNetTraces.add(
         sourceTrace.subcircuit_connectivity_map_key,
       )
+      if (trace.props.schDisplayLabel) {
+        explicitPortNetDisplayLabelsByConnKey.set(
+          sourceTrace.subcircuit_connectivity_map_key,
+          trace.props.schDisplayLabel,
+        )
+      }
     }
   }
 
@@ -312,6 +320,7 @@ export function createSchematicTraceSolverInputProblem(
     connKeyToSourceNet,
     userNetIdToConnKey,
     connKeysWithExplicitPortNetTraces,
+    explicitPortNetDisplayLabelsByConnKey,
     allSourceAndSchematicPortIdsInScope,
     schPortIdToSourcePortId,
   }

--- a/lib/components/primitive-components/Trace/Trace_doInitialSchematicTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialSchematicTraceRender.ts
@@ -34,6 +34,9 @@ export const Trace_doInitialSchematicTraceRender = (trace: Trace) => {
   // if (trace.getGroup()?._getSchematicLayoutMode() === "match-adapt") return
   const { db } = trace.root!
   const { _parsedProps: props, parent } = trace
+  const shouldInsertAutoNetLabels =
+    trace.getInheritedProperty("schTraceAutoLabelEnabled") !== false &&
+    trace._getBoard()?._parsedProps.schTraceAutoLabelEnabled !== false
 
   if (!parent) throw new Error("Trace has no parent")
 
@@ -165,6 +168,8 @@ export const Trace_doInitialSchematicTraceRender = (trace: Trace) => {
 
       return
     }
+
+    if (!shouldInsertAutoNetLabels) return
 
     const side = getEnteringEdgeFromDirection(port.facingDirection!) ?? "bottom"
     const netLabel = db.schematic_net_label.insert({

--- a/tests/components/trace/sch-trace-autolabel-disabled-group.test.tsx
+++ b/tests/components/trace/sch-trace-autolabel-disabled-group.test.tsx
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("group schTraceAutoLabelEnabled false suppresses auto labels for named net ports", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <group name="G1" subcircuit schTraceAutoLabelEnabled={false}>
+        <chip
+          name="U1"
+          footprint="soic8"
+          pinLabels={{ pin1: "VCC", pin2: "GND" }}
+          connections={{ VCC: "net.V3_3", GND: "net.GND" }}
+        />
+      </group>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.schematic_net_label.list()).toHaveLength(0)
+})

--- a/tests/components/trace/sch-trace-autolabel-disabled-keeps-display-label.test.tsx
+++ b/tests/components/trace/sch-trace-autolabel-disabled-keeps-display-label.test.tsx
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("schTraceAutoLabelEnabled false keeps explicit schDisplayLabel net labels", () => {
+  const { circuit } = getTestFixture()
+
+  circuit._featureMspSchematicTraceRouting = true
+
+  circuit.add(
+    <board width="10mm" height="10mm" schTraceAutoLabelEnabled={false}>
+      <resistor
+        name="R1"
+        resistance="10k"
+        footprint="0402"
+        schX={0}
+        schY={0}
+        schRotation="90deg"
+      />
+      <trace from=".R1 > .pin1" to="net.GND" schDisplayLabel="GND" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const labels = circuit.db.schematic_net_label.list()
+  expect(labels).toHaveLength(1)
+  expect(labels[0].text).toBe("GND")
+  expect(labels[0].symbol_name).toBe("rail_down")
+})
+
+test("group schTraceAutoLabelEnabled false keeps explicit schDisplayLabel net labels", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <group name="G1" subcircuit schTraceAutoLabelEnabled={false}>
+        <resistor
+          name="R1"
+          resistance="10k"
+          footprint="0402"
+          schX={0}
+          schY={0}
+          schRotation="90deg"
+        />
+        <trace from=".R1 > .pin1" to="net.GND" schDisplayLabel="GND" />
+      </group>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const labels = circuit.db.schematic_net_label.list()
+  expect(labels).toHaveLength(1)
+  expect(labels[0].text).toBe("GND")
+  expect(labels[0].symbol_name).toBe("rail_down")
+})

--- a/tests/components/trace/sch-trace-autolabel-disabled.test.tsx
+++ b/tests/components/trace/sch-trace-autolabel-disabled.test.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("schTraceAutoLabelEnabled false suppresses auto labels for named net ports", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" schTraceAutoLabelEnabled={false}>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin2: "GND" }}
+        connections={{ VCC: "net.V3_3", GND: "net.GND" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.schematic_net_label.list()).toHaveLength(0)
+})


### PR DESCRIPTION
Fixes #2243.

## What changed

- Respect `schTraceAutoLabelEnabled={false}` before inserting schematic trace auto labels.
- Apply the same opt-out for board-level traces and subcircuit/group schematic trace routing.
- Preserve explicit `schDisplayLabel` labels even when automatic labels are disabled.

## Validation

- `~/.bun/bin/bun test tests/components/trace`
- `npx biome format .`
- `npx tsc --noEmit`

I also spot-checked the slow repros that had timed out during an earlier full-suite attempt:

- `~/.bun/bin/bun test tests/repros/repro116-arduino-uno-reroute.test.tsx tests/repros/repro116-arduino-uno-reroute-lower-mid.test.tsx`
