### PR TITLE
Fix jlcpcb CAD fallback for library footprints

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -1621,12 +1621,18 @@ export class NormalComponent<
       cadModelProp === undefined ? this._asyncFootprintCadModel : cadModelProp
     const footprint =
       this.getFootprinterString() ?? this._getImpliedFootprintString()
-    const footprintString = typeof footprint === "string" ? footprint : null
-    const canUseFootprinterStringFallback =
-      !!footprintString &&
-      !parseLibraryFootprintRef(footprintString) &&
-      !isHttpUrl(footprintString) &&
-      !isStaticAssetPath(footprintString)
+    let footprintString: string | undefined
+    if (typeof footprint === "string") {
+      footprintString = footprint
+    }
+
+    let footprintIsFootprinterString = false
+    if (footprintString) {
+      footprintIsFootprinterString =
+        !parseLibraryFootprintRef(footprintString) &&
+        !isHttpUrl(footprintString) &&
+        !isStaticAssetPath(footprintString)
+    }
 
     if (!this.pcb_component_id) return
     if (cadModel === null) return
@@ -1680,7 +1686,7 @@ export class NormalComponent<
         : preLayoutRotation
     const isBottomLayer = computedLayer === "bottom"
 
-    if (!cadModel && !canUseFootprinterStringFallback) {
+    if (!cadModel && !footprintIsFootprinterString) {
       const cad_component = db.cad_component.insert({
         position: {
           x: bounds.center.x,
@@ -1708,6 +1714,10 @@ export class NormalComponent<
 
     const rotationWithOffset = totalRotation + (rotationOffset.z ?? 0)
     const cadRotationZ = normalizeDegrees(rotationWithOffset)
+    let footprinterStringForCadComponent: string | undefined
+    if (!cadModel && footprintIsFootprinterString) {
+      footprinterStringForCadComponent = footprintString
+    }
 
     const cad_model = db.cad_component.insert({
       // TODO z maybe depends on layer
@@ -1770,11 +1780,7 @@ export class NormalComponent<
       model_origin_alignment: "center_of_component_on_board_surface",
       anchor_alignment: "center_of_component_on_board_surface",
       model_origin_position: cadModel?.modelOriginPosition,
-
-      footprinter_string:
-        canUseFootprinterStringFallback && !cadModel
-          ? footprintString
-          : undefined,
+      footprinter_string: footprinterStringForCadComponent,
       show_as_translucent_model: this._parsedProps.showAsTranslucentModel,
     } as any)
     this.cad_component_id = cad_model.cad_component_id

--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -1621,6 +1621,12 @@ export class NormalComponent<
       cadModelProp === undefined ? this._asyncFootprintCadModel : cadModelProp
     const footprint =
       this.getFootprinterString() ?? this._getImpliedFootprintString()
+    const footprintString = typeof footprint === "string" ? footprint : null
+    const canUseFootprinterStringFallback =
+      !!footprintString &&
+      !parseLibraryFootprintRef(footprintString) &&
+      !isHttpUrl(footprintString) &&
+      !isStaticAssetPath(footprintString)
 
     if (!this.pcb_component_id) return
     if (cadModel === null) return
@@ -1674,7 +1680,7 @@ export class NormalComponent<
         : preLayoutRotation
     const isBottomLayer = computedLayer === "bottom"
 
-    if (!cadModel && !footprint) {
+    if (!cadModel && !canUseFootprinterStringFallback) {
       const cad_component = db.cad_component.insert({
         position: {
           x: bounds.center.x,
@@ -1766,7 +1772,9 @@ export class NormalComponent<
       model_origin_position: cadModel?.modelOriginPosition,
 
       footprinter_string:
-        typeof footprint === "string" && !cadModel ? footprint : undefined,
+        canUseFootprinterStringFallback && !cadModel
+          ? footprintString
+          : undefined,
       show_as_translucent_model: this._parsedProps.showAsTranslucentModel,
     } as any)
     this.cad_component_id = cad_model.cad_component_id

--- a/tests/footprint/footprint-library-map-jlcpcb-cadmodel-fallback.test.tsx
+++ b/tests/footprint/footprint-library-map-jlcpcb-cadmodel-fallback.test.tsx
@@ -1,14 +1,14 @@
 import { test, expect } from "bun:test"
 import type { CadComponent } from "circuit-json"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
-import usbCC165948CircuitJson from "tests/fixtures/assets/usb-c-C165948.circuit.json"
+import external0402Footprint from "tests/fixtures/assets/external-0402-footprint.json"
 
-test("jlcpcb footprint library map extracts cadModel from fetched circuit json", async () => {
+test("jlcpcb footprint library map falls back to a bounding-box cad component when no cad model is available", async () => {
   const { circuit } = getTestFixture({
     platform: {
       footprintLibraryMap: {
         jlcpcb: async () => ({
-          footprintCircuitJson: usbCC165948CircuitJson,
+          footprintCircuitJson: external0402Footprint,
         }),
       },
     },
@@ -16,7 +16,7 @@ test("jlcpcb footprint library map extracts cadModel from fetched circuit json",
 
   circuit.add(
     <board width="20mm" height="20mm">
-      <chip name="U1" footprint="jlcpcb:C165948" />
+      <chip name="U1" footprint="jlcpcb:C51950748" />
     </board>,
   )
 
@@ -29,6 +29,13 @@ test("jlcpcb footprint library map extracts cadModel from fetched circuit json",
     .getCircuitJson()
     .find((el): el is CadComponent => el.type === "cad_component")
 
-  expect(cadComponent?.model_obj_url).toBeDefined()
+  expect(cadComponent).toMatchObject({
+    type: "cad_component",
+    show_as_bounding_box: true,
+  })
   expect(cadComponent?.footprinter_string).toBeUndefined()
+  expect(cadComponent?.model_obj_url).toBeUndefined()
+  expect(
+    circuit.getCircuitJson().filter((el) => el.type.includes("error")),
+  ).toHaveLength(0)
 })

--- a/tests/footprint/footprint-library-map-jlcpcb-cadmodel.test.tsx
+++ b/tests/footprint/footprint-library-map-jlcpcb-cadmodel.test.tsx
@@ -1,0 +1,38 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import type { CadComponent } from "circuit-json"
+import external0402Footprint from "tests/fixtures/assets/external-0402-footprint.json"
+
+test("footprint library map jlcpcb without cadModel falls back to bounding box", async () => {
+  const { circuit } = getTestFixture({
+    platform: {
+      footprintLibraryMap: {
+        jlcpcb: async () => ({
+          footprintCircuitJson: external0402Footprint,
+        }),
+      },
+    },
+  })
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip name="U1" footprint="jlcpcb:C51950748" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const cadComponent = circuit
+    .getCircuitJson()
+    .find((el): el is CadComponent => el.type === "cad_component")
+
+  expect(cadComponent).toMatchObject({
+    type: "cad_component",
+    show_as_bounding_box: true,
+  })
+  expect(cadComponent).not.toHaveProperty("footprinter_string")
+  expect(cadComponent?.model_obj_url).toBeUndefined()
+  expect(
+    circuit.getCircuitJson().filter((el) => el.type.includes("error")),
+  ).toHaveLength(0)
+})

--- a/tests/footprint/footprint-library-map-jlcpcb-cadmodel.test.tsx
+++ b/tests/footprint/footprint-library-map-jlcpcb-cadmodel.test.tsx
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test"
 import type { CadComponent } from "circuit-json"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 import usbCC165948CircuitJson from "tests/fixtures/assets/usb-c-C165948.circuit.json"
+import external0402Footprint from "tests/fixtures/assets/external-0402-footprint.json"
 
 test("jlcpcb footprint library map extracts cadModel from fetched circuit json", async () => {
   const { circuit } = getTestFixture({
@@ -31,4 +32,41 @@ test("jlcpcb footprint library map extracts cadModel from fetched circuit json",
 
   expect(cadComponent?.model_obj_url).toBeDefined()
   expect(cadComponent?.footprinter_string).toBeUndefined()
+})
+
+test("jlcpcb footprint library map falls back to a bounding-box cad component when no cad model is available", async () => {
+  const { circuit } = getTestFixture({
+    platform: {
+      footprintLibraryMap: {
+        jlcpcb: async () => ({
+          footprintCircuitJson: external0402Footprint,
+        }),
+      },
+    },
+  })
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip name="U1" footprint="jlcpcb:C51950748" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const loadErrors = circuit.db.external_footprint_load_error.list()
+  expect(loadErrors).toHaveLength(0)
+
+  const cadComponent = circuit
+    .getCircuitJson()
+    .find((el): el is CadComponent => el.type === "cad_component")
+
+  expect(cadComponent).toMatchObject({
+    type: "cad_component",
+    show_as_bounding_box: true,
+  })
+  expect(cadComponent?.footprinter_string).toBeUndefined()
+  expect(cadComponent?.model_obj_url).toBeUndefined()
+  expect(
+    circuit.getCircuitJson().filter((el) => el.type.includes("error")),
+  ).toHaveLength(0)
 })


### PR DESCRIPTION
## What changed
This updates CAD fallback generation for library-style footprints so `cad_component.footprinter_string` is only emitted for direct footprinter strings such as `0402` or `soic8`.

For library references like `jlcpcb:C51950748`, KiCad library refs, URLs, and static asset paths, the fallback now emits a bounding-box CAD component instead of forwarding the library reference as a footprinter string.

## Why this changed
The 3D viewer was trying to parse `jlcpcb:...` as a raw footprinter function when no CAD model was available. That produced runtime errors like:

`Invalid footprint function, got "jlcpcb"`

The underlying footprint could still load for PCB rendering, but the CAD fallback path was sending an invalid string into the 3D engine.

## Impact
This fixes 3D rendering for library footprints that do not provide a CAD model by falling back cleanly to a bounding box instead of surfacing a parser error.

## Root cause
`NormalComponent.doInitialCadModelRender()` treated any string footprint as a valid `footprinter_string` fallback. Library refs such as `jlcpcb:...` are valid footprint lookup keys, but they are not valid raw footprinter expressions.

## Validation
- `bun test tests/footprint/footprint-library-map-jlcpcb-cadmodel.test.tsx`
- `bun test tests/components/normal-components/cad-component-bounding-box.test.tsx`

## Notes
Repo-wide build/type generation still has unrelated pre-existing DTS failures in `lib/components/primitive-components/PcbTrace.ts`.
