### PR TITLE
Extract CAD models from library footprint circuit json

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
@@ -12,6 +12,7 @@ import {
 import { getFileExtension } from "./utils/getFileExtension"
 import { isStaticAssetPath } from "./utils/isStaticAssetPath"
 import { resolveStaticFileImport } from "lib/utils/resolveStaticFileImport"
+import { extractCadModelFromCircuitJson } from "lib/utils/connectors/extractCadModelFromCircuitJson"
 
 interface FootprintLibraryResult {
   footprintCircuitJson: any[]
@@ -175,9 +176,9 @@ export function NormalComponent_doInitialPcbFootprintStringRender(
         const fpWrapper = new Footprint({ src: footprint })
         for (const c of fpComponents) fpWrapper.add(c)
         component.add(fpWrapper)
-        if (!Array.isArray(result) && result.cadModel) {
-          component._asyncFootprintCadModel = result.cadModel
-        }
+        component._asyncFootprintCadModel =
+          (!Array.isArray(result) && result.cadModel) ||
+          extractCadModelFromCircuitJson(circuitJson)
         // Ensure existing Ports re-run PcbPortRender now that pads exist
         for (const child of component.children) {
           if (child.componentName === "Port") {

--- a/tests/footprint/footprint-library-map-jlcpcb-cadmodel.test.tsx
+++ b/tests/footprint/footprint-library-map-jlcpcb-cadmodel.test.tsx
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test"
+import type { CadComponent } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import usbCC165948CircuitJson from "tests/fixtures/assets/usb-c-C165948.circuit.json"
+
+test("jlcpcb footprint library map extracts cadModel from fetched circuit json", async () => {
+  const { circuit } = getTestFixture({
+    platform: {
+      footprintLibraryMap: {
+        jlcpcb: async () => ({
+          footprintCircuitJson: usbCC165948CircuitJson,
+        }),
+      },
+    },
+  })
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip name="U1" footprint="jlcpcb:C165948" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const loadErrors = circuit.db.external_footprint_load_error.list()
+  expect(loadErrors).toHaveLength(0)
+
+  const cadComponent = circuit
+    .getCircuitJson()
+    .find((el): el is CadComponent => el.type === "cad_component")
+
+  expect(cadComponent?.model_obj_url).toBeDefined()
+  expect(cadComponent?.footprinter_string).toBeUndefined()
+})


### PR DESCRIPTION
## What changed
- extract `cadModel` from async `footprintLibraryMap` circuit json when the resolver does not return an explicit `cadModel`
- add a regression test covering a `jlcpcb:` library footprint that embeds CAD data in fetched circuit json

## Why
`jlcpcb:` footprint resolvers can return full circuit json that already includes a `cad_component`. Before this change, the generic library-footprint path only used `result.cadModel`, so embedded CAD metadata was dropped and the 3D render path could fall back incorrectly.

## Impact
Library footprint resolvers can now behave more like the `jlcpcb` path in `eval`: if the fetched footprint circuit json already contains CAD metadata, `core` will preserve it for 3D rendering even without an explicit `cadModel` field.

## Validation
- `bun test tests/footprint/footprint-library-map-jlcpcb-cadmodel.test.tsx tests/footprint/footprint-library-map-cadmodel.test.tsx`
- `bunx tsc --noEmit` *(fails in unrelated existing files such as schematic trace solver, pcb trace typing, and missing optional test deps)*
