### PR TITLE
fix: parse scientific notation in pcb coordinate strings

### DIFF
--- a/lib/utils/evaluateCalcString.ts
+++ b/lib/utils/evaluateCalcString.ts
@@ -137,11 +137,6 @@ function tokenize(expr: string, units: Record<string, number>): Token[] {
         throw new Error(`Invalid number: "${numberText}"`)
       }
 
-      // Snap sub-nm float dust to zero (common in CAD-imported footprints)
-      if (Math.abs(num) < 1e-9) {
-        num = 0
-      }
-
       // Optional unit directly after number (e.g. "1mm")
       const unitStart = i
       while (i < expr.length && /[A-Za-z]/.test(expr[i])) {

--- a/lib/utils/evaluateCalcString.ts
+++ b/lib/utils/evaluateCalcString.ts
@@ -38,7 +38,7 @@ export function evaluateCalcString(
   const tokens = tokenize(expr, units)
   const result = parseExpression(tokens, knownVariables)
 
-  return result
+  return result === 0 ? 0 : result
 }
 
 export function extractCalcIdentifiers(input: string): string[] {
@@ -122,10 +122,24 @@ function tokenize(expr: string, units: Record<string, number>): Token[] {
         }
       }
 
+      // optional scientific notation (e.g. 1.1368683772161603e-13)
+      if (i < expr.length && (expr[i] === "e" || expr[i] === "E")) {
+        i++
+        if (i < expr.length && (expr[i] === "+" || expr[i] === "-")) i++
+        const expStart = i
+        while (i < expr.length && isDigit(expr[i])) i++
+        if (i === expStart) throw new Error(`Invalid exponent in number`)
+      }
+
       const numberText = expr.slice(start, i)
       let num = Number(numberText)
       if (Number.isNaN(num)) {
         throw new Error(`Invalid number: "${numberText}"`)
+      }
+
+      // Snap sub-nm float dust to zero (common in CAD-imported footprints)
+      if (Math.abs(num) < 1e-9) {
+        num = 0
       }
 
       // Optional unit directly after number (e.g. "1mm")

--- a/tests/components/primitive-components/smtpad-scientific-notation-coordinates.test.tsx
+++ b/tests/components/primitive-components/smtpad-scientific-notation-coordinates.test.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import type { PcbSmtPadRect } from "circuit-json"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
 test("smtpad with scientific notation pcb coordinates does not emit property errors", () => {
@@ -29,7 +30,7 @@ test("smtpad with scientific notation pcb coordinates does not emit property err
     circuit.db.source_invalid_component_property_error.list()
   expect(invalidPropertyErrors.length).toBe(0)
 
-  const smtPads = circuit.db.pcb_smtpad.list()
+  const smtPads = circuit.db.pcb_smtpad.list() as PcbSmtPadRect[]
   expect(smtPads.length).toBe(1)
-  expect(smtPads[0]?.x).toBeCloseTo(-1.1368683772161603e-13)
+  expect(smtPads[0].x).toBeCloseTo(-1.1368683772161603e-13)
 })

--- a/tests/components/primitive-components/smtpad-scientific-notation-coordinates.test.tsx
+++ b/tests/components/primitive-components/smtpad-scientific-notation-coordinates.test.tsx
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("smtpad with scientific notation pcb coordinates does not emit property errors", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        footprint={
+          <footprint>
+            <smtpad
+              pcbX="-1.1368683772161603e-13mm"
+              pcbY="0mm"
+              width="1mm"
+              height="1mm"
+              shape="rect"
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const invalidPropertyErrors =
+    circuit.db.source_invalid_component_property_error.list()
+  expect(invalidPropertyErrors.length).toBe(0)
+
+  const smtPads = circuit.db.pcb_smtpad.list()
+  expect(smtPads.length).toBe(1)
+  expect(smtPads[0]?.x).toBeCloseTo(-1.1368683772161603e-13)
+})

--- a/tests/utils/evaluate-calc-string.test.ts
+++ b/tests/utils/evaluate-calc-string.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import { evaluateCalcString } from "../../lib/utils/evaluateCalcString"
+
+test("parses scientific notation with unit suffix", () => {
+  expect(
+    evaluateCalcString("-1.1368683772161603e-13mm", { knownVariables: {} }),
+  ).toBeCloseTo(-1.1368683772161603e-13)
+})
+
+test("parses positive scientific notation with unit suffix", () => {
+  expect(evaluateCalcString("1.5e-2mm", { knownVariables: {} })).toBeCloseTo(
+    0.015,
+  )
+})
+
+test("parses uppercase E exponent", () => {
+  expect(evaluateCalcString("2E+3mm", { knownVariables: {} })).toBe(2000)
+})
+
+test("scientific notation works inside calc expressions", () => {
+  expect(
+    evaluateCalcString("calc(1e-13mm + 2mm)", { knownVariables: {} }),
+  ).toBeCloseTo(2.0000000000000002)
+})


### PR DESCRIPTION
## Summary

Footprint primitives with CAD-imported coordinates in scientific notation (e.g. `pcbX="-1.1368683772161603e-13mm"`) were failing with:

```
source_invalid_component_property_error: Invalid pcbY value for SmtPad:
Invalid calc() expression. expression="1.1368683772161603e-13mm"
```

This happens when footprints are auto-imported from EasyEDA/JLC/KiCad sources that serialize near-zero values as IEEE float dust.

**Root cause:** In `evaluateCalcString.ts`, `tokenize()` only consumed digits and `.` for numbers. For `1.1368683772161603e-13mm` it parsed `1.1368683772161603`, stopped at `e`, and treated `e` as a unit suffix → `Unknown unit: "e"`, which upstream is reported as an invalid calc expression.

## Changes

- Extend the number lexer in `tokenize()` to accept optional scientific notation (`e`/`E`, optional sign, exponent digits) before the optional unit suffix (`mm`, etc.)
- Normalize `-0` to `0` in the final result (avoids negative zero from unary `-` on dust values)

## Testing

**Unit tests (`evaluateCalcString`):**
- `1.5e-2mm` → `0.015`
- `2E+3mm` → `2000`
- `calc(1e-13mm + 2mm)` → `2`

**Integration test (`<smtpad>`):**
- Footprint with `pcbX="-1.1368683772161603e-13mm"` and `pcbY="0mm"` renders without `source_invalid_component_property_error`; pad `x` is ~`0`

**Regression checks:**
- Existing calc expression tests pass (`calc(board.minX + 1mm)`, legacy `board.minx`, etc.)
- RP2040 decoupling capacitors repro passes (uses the same scientific-notation coordinate in the RP2040 footprint fixture)

## to reproduce error with and without the fix:

git checkout 34770277 -- lib/utils/evaluateCalcString.ts
bun test tests/utils/evaluate-calc-string.test.ts tests/components/primitive-components/smtpad-scientific-notation-coordinates.test.tsx
git checkout HEAD -- lib/utils/evaluateCalcString.ts   # restore fix