### PR TITLE
fix: respect schematic trace auto-label opt-out

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
@@ -37,14 +37,18 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
   const hasRouteableSchematicConnections =
     inputProblem.directConnections.length > 0 ||
     inputProblem.netConnections.length > 0
+  const autoNetLabelsEnabled =
+    group.getSubcircuit()._parsedProps.schTraceAutoLabelEnabled !== false
 
   if (!hasRouteableSchematicConnections) {
-    insertNetLabelsForPortsMissingTrace({
-      group,
-      allSourceAndSchematicPortIdsInScope,
-      schPortIdToSourcePortId,
-      connKeyToSourceNet,
-    })
+    if (autoNetLabelsEnabled) {
+      insertNetLabelsForPortsMissingTrace({
+        group,
+        allSourceAndSchematicPortIdsInScope,
+        schPortIdToSourcePortId,
+        connKeyToSourceNet,
+      })
+    }
     return
   }
 
@@ -76,21 +80,23 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
   })
 
   // Apply net labels (from solver placements and net-only ports)
-  applyNetLabelPlacements({
-    group,
-    solver,
-    connKeyToSourceNet,
-    pinIdToSchematicPortId,
-    userNetIdToConnKey,
-    connKeysWithExplicitPortNetTraces,
-    schematicPortIdsWithPreExistingNetLabels,
-    schematicPortIdsWithRoutedTraces,
-  })
+  if (autoNetLabelsEnabled) {
+    applyNetLabelPlacements({
+      group,
+      solver,
+      connKeyToSourceNet,
+      pinIdToSchematicPortId,
+      userNetIdToConnKey,
+      connKeysWithExplicitPortNetTraces,
+      schematicPortIdsWithPreExistingNetLabels,
+      schematicPortIdsWithRoutedTraces,
+    })
 
-  insertNetLabelsForPortsMissingTrace({
-    group,
-    allSourceAndSchematicPortIdsInScope,
-    schPortIdToSourcePortId,
-    connKeyToSourceNet,
-  })
+    insertNetLabelsForPortsMissingTrace({
+      group,
+      allSourceAndSchematicPortIdsInScope,
+      schPortIdToSourcePortId,
+      connKeyToSourceNet,
+    })
+  }
 }

--- a/tests/repros/repro2243-sch-trace-auto-label-disabled.test.tsx
+++ b/tests/repros/repro2243-sch-trace-auto-label-disabled.test.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("schTraceAutoLabelEnabled={false} suppresses automatic schematic net labels", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" schTraceAutoLabelEnabled={false}>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin2: "GND" }}
+        connections={{ VCC: "net.V3_3", GND: "net.GND" }}
+      />
+      <resistor
+        name="R1"
+        resistance="10k"
+        footprint="0402"
+        connections={{ pin1: "net.V3_3", pin2: "net.GND" }}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  expect(circuit.db.schematic_net_label.list()).toHaveLength(0)
+  expect(circuit.db.schematic_trace.list().length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Summary

Fixes #2243.

`schTraceAutoLabelEnabled={false}` is typechecked but the grouped schematic trace render path still inserted automatic schematic net labels. This made the prop ineffective for named-net connections rendered through the MSP schematic trace routing flow.

This PR gates the automatic net-label insertion paths in `Group_doInitialSchematicTraceRender` behind `schTraceAutoLabelEnabled !== false` while keeping trace rendering itself unchanged.

## Test plan

- `npx bun test tests/repros/repro2243-sch-trace-auto-label-disabled.test.tsx`
- `npx bun test tests/repros/repro13-schematic-trace-hop.test.tsx tests/repros/repro14-double-schematic-traces.test.tsx tests/components/normal-components/pcb-component-relative-positioning1.test.tsx tests/components/trace`
- `npx tsc --noEmit`
