### PR TITLE
fix: manualEdits position double-counts parent group's anchor (#2281)

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -28,6 +28,7 @@ import {
   type Matrix,
   applyToPoint,
   compose,
+  decomposeTSR,
   flipY,
   identity,
   rotate,
@@ -504,12 +505,14 @@ export abstract class PrimitiveComponent<
       this.props.pcbY === undefined
     ) {
       const rotation = this._getPcbRotationBeforeLayout() ?? 0
+      const parentGlobalTransform =
+        this.parent?._computePcbGlobalTransformBeforeLayout() ?? identity()
+      const decomposed = decomposeTSR(parentGlobalTransform)
+      const parentRotation = (decomposed.rotation.angle * 180) / Math.PI
+
       return compose(
-        this.parent?._computePcbGlobalTransformBeforeLayout() ?? identity(),
-        compose(
-          translate(manualPlacement.x, manualPlacement.y),
-          rotate((rotation * Math.PI) / 180),
-        ),
+        translate(manualPlacement.x, manualPlacement.y),
+        rotate(((parentRotation + rotation) * Math.PI) / 180),
       )
     }
 

--- a/tests/repro-2281.test.tsx
+++ b/tests/repro-2281.test.tsx
@@ -1,0 +1,75 @@
+import { test, expect } from "bun:test"
+import { RootCircuit } from "lib/RootCircuit"
+import "lib/register-catalogue"
+
+test("manual placement in positioned group does not double-count parent transform", () => {
+  const circuit = new RootCircuit()
+
+  circuit.add(
+    <board
+      width="40mm"
+      height="40mm"
+      manualEdits={{
+        pcb_placements: [
+          {
+            selector: ".R1",
+            center: { x: 5, y: 5 },
+          },
+        ],
+      }}
+    >
+      <group pcbX={10} pcbY={10}>
+        <resistor name="R1" resistance="10k" footprint="0402" />
+      </group>
+    </board>,
+  )
+
+  circuit.render()
+
+  const resistor = circuit.selectOne(".R1")
+  expect(resistor).not.toBeNull()
+
+  const resistorPosition = resistor!._getGlobalPcbPositionBeforeLayout()
+  expect(resistorPosition.x).toBeCloseTo(5, 1)
+  expect(resistorPosition.y).toBeCloseTo(5, 1)
+})
+
+test("manual placement in rotated group inherits parent group's rotation", () => {
+  const circuit = new RootCircuit()
+
+  circuit.add(
+    <board
+      width="40mm"
+      height="40mm"
+      manualEdits={{
+        pcb_placements: [
+          {
+            selector: ".R1",
+            center: { x: 5, y: 5 },
+          },
+        ],
+      }}
+    >
+      <group pcbX={10} pcbY={10} pcbRotation={90}>
+        <resistor
+          name="R1"
+          resistance="10k"
+          footprint="0402"
+          pcbRotation={45}
+        />
+      </group>
+    </board>,
+  )
+
+  circuit.render()
+
+  const resistor = circuit.selectOne(".R1")
+  expect(resistor).not.toBeNull()
+
+  const resistorPosition = resistor!._getGlobalPcbPositionBeforeLayout()
+  expect(resistorPosition.x).toBeCloseTo(5, 1)
+  expect(resistorPosition.y).toBeCloseTo(5, 1)
+
+  const globalRotation = (resistor as any).getGlobalTransformRotation()
+  expect(globalRotation).toBeCloseTo(135, 1)
+})


### PR DESCRIPTION
This PR resolves #2281 where manual placement coordinates inside a positioned group or translated subcircuit were double-counting the parent group's/subcircuit's translation.

### Cause
In `PrimitiveComponent.ts`, `manualPlacement` coordinates (retrieved via `getSubcircuit()._getPcbManualPlacementForComponent(this)`) are already subcircuit-absolute (meaning the subcircuit's global transform has already been pre-multiplied).
However, `_computePcbGlobalTransformBeforeLayout()` composed this with `this.parent?._computePcbGlobalTransformBeforeLayout()`, adding the parent's translation offset a second time.

### Fix
Composed the manual placement coordinate with only the parent's global **rotation** (extracted using `decomposeTSR` on the parent global transform), rather than the entire parent global transform.

### Testing
- Created a standard unit test file `tests/repro-2281.test.tsx` verifying the positioning offset behaves correctly both in plain positioned groups and in rotated parent groups.
