### PR TITLE
fix(core): populate pcb_via.layers with all spanned layers

### DIFF
--- a/lib/components/primitive-components/PcbVia.ts
+++ b/lib/components/primitive-components/PcbVia.ts
@@ -1,9 +1,10 @@
 import { type ViaProps, viaProps } from "@tscircuit/props"
 import {
-  layer_ref,
-  type LayerRef,
   type PcbVia as CircuitJsonPcbVia,
+  type LayerRef,
+  layer_ref,
 } from "circuit-json"
+import { getViaSpanLayers } from "lib/utils/getViaSpanLayers"
 import { z } from "zod"
 import { PrimitiveComponent } from "../base-components/PrimitiveComponent"
 
@@ -38,8 +39,16 @@ export class PcbVia extends PrimitiveComponent<typeof pcbViaProps> {
   private _getLayers(): LayerRef[] {
     const { layers, fromLayer = "top", toLayer = "bottom" } = this._parsedProps
     if (layers && layers.length > 0) return layers as LayerRef[]
-    if (fromLayer === toLayer) return [fromLayer as LayerRef]
-    return [fromLayer as LayerRef, toLayer as LayerRef]
+    // Before the via is attached to the tree the board layer count is
+    // unknown — fall back to 2, which yields [fromLayer, toLayer].
+    const layerCount = this.parent
+      ? this.getSubcircuit()._getSubcircuitLayerCount()
+      : 2
+    return getViaSpanLayers({
+      fromLayer: fromLayer as LayerRef,
+      toLayer: toLayer as LayerRef,
+      layerCount,
+    })
   }
 
   getAvailablePcbLayers(): string[] {

--- a/lib/components/primitive-components/Via.ts
+++ b/lib/components/primitive-components/Via.ts
@@ -1,5 +1,6 @@
 import { type PcbStyle, viaProps } from "@tscircuit/props"
 import type { LayerRef, PcbVia } from "circuit-json"
+import { getViaSpanLayers } from "lib/utils/getViaSpanLayers"
 import { getViaDiameterDefaultsWithOverrides } from "lib/utils/pcbStyle/getViaDiameterDefaults"
 import { z } from "zod"
 import { PrimitiveComponent } from "../base-components/PrimitiveComponent"
@@ -81,9 +82,12 @@ export class Via extends PrimitiveComponent<typeof viaProps> {
   }
   _getLayers(): LayerRef[] {
     const { fromLayer = "top", toLayer = "bottom" } = this._parsedProps
-    if (fromLayer === toLayer) return [fromLayer]
-    // TODO calculate layers inbetween top and bottom using layer count
-    return [fromLayer, toLayer]
+    // Before the via is attached to the tree (constructor/port init) the board
+    // layer count is unknown — fall back to 2, which yields [fromLayer, toLayer].
+    const layerCount = this.parent
+      ? this.getSubcircuit()._getSubcircuitLayerCount()
+      : 2
+    return getViaSpanLayers({ fromLayer, toLayer, layerCount })
   }
 
   initPorts() {

--- a/lib/utils/getViaSpanLayers.ts
+++ b/lib/utils/getViaSpanLayers.ts
@@ -1,0 +1,38 @@
+import type { LayerRef } from "circuit-json"
+
+/**
+ * All copper layers a drilled via physically crosses between fromLayer and
+ * toLayer (inclusive), in from→to order, for a board with `layerCount`
+ * copper layers.
+ *
+ * A via barrel passes through every layer between its end layers, so
+ * `pcb_via.layers` must list the intermediate inner layers too — copper pour
+ * solvers and DRC rely on it to bond (same net) or antipad (foreign net) the
+ * via on each plane it crosses. Listing only `[fromLayer, toLayer]` makes
+ * inner planes flood solid over foreign via barrels.
+ *
+ * Falls back to `[fromLayer, toLayer]` when either layer is not part of the
+ * stack implied by `layerCount` (e.g. an inner layer name on a 2-layer board).
+ */
+export const getViaSpanLayers = ({
+  fromLayer,
+  toLayer,
+  layerCount,
+}: {
+  fromLayer: LayerRef
+  toLayer: LayerRef
+  layerCount: number
+}): LayerRef[] => {
+  if (fromLayer === toLayer) return [fromLayer]
+  const stack: LayerRef[] = ["top"]
+  for (let i = 1; i <= layerCount - 2; i++) {
+    stack.push(`inner${i}` as LayerRef)
+  }
+  stack.push("bottom")
+  const fromIndex = stack.indexOf(fromLayer)
+  const toIndex = stack.indexOf(toLayer)
+  if (fromIndex === -1 || toIndex === -1) return [fromLayer, toLayer]
+  return fromIndex <= toIndex
+    ? stack.slice(fromIndex, toIndex + 1)
+    : stack.slice(toIndex, fromIndex + 1).reverse()
+}

--- a/tests/components/primitive-components/via-layer-span.test.tsx
+++ b/tests/components/primitive-components/via-layer-span.test.tsx
@@ -1,0 +1,49 @@
+import { expect, it } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+it("pcb_via.layers includes intermediate inner layers on a 4-layer board", () => {
+  const { project } = getTestFixture()
+
+  project.add(
+    <board width="10mm" height="10mm" layers={4}>
+      <via pcbX="0mm" pcbY="0mm" fromLayer="top" toLayer="bottom" />
+    </board>,
+  )
+
+  project.render()
+
+  const [pcbVia] = project.db.pcb_via.list()
+  expect(pcbVia.layers).toEqual(["top", "inner1", "inner2", "bottom"])
+  expect(pcbVia.from_layer).toBe("top")
+  expect(pcbVia.to_layer).toBe("bottom")
+})
+
+it("pcb_via.layers spans only the crossed layers for a partial-span via", () => {
+  const { project } = getTestFixture()
+
+  project.add(
+    <board width="10mm" height="10mm" layers={4}>
+      <via pcbX="0mm" pcbY="0mm" fromLayer="top" toLayer="inner2" />
+    </board>,
+  )
+
+  project.render()
+
+  const [pcbVia] = project.db.pcb_via.list()
+  expect(pcbVia.layers).toEqual(["top", "inner1", "inner2"])
+})
+
+it("pcb_via.layers stays [top, bottom] on a 2-layer board", () => {
+  const { project } = getTestFixture()
+
+  project.add(
+    <board width="10mm" height="10mm">
+      <via pcbX="0mm" pcbY="0mm" fromLayer="top" toLayer="bottom" />
+    </board>,
+  )
+
+  project.render()
+
+  const [pcbVia] = project.db.pcb_via.list()
+  expect(pcbVia.layers).toEqual(["top", "bottom"])
+})


### PR DESCRIPTION
## Summary

- `pcb_via.layers` listed only `[fromLayer, toLayer]` (the `// TODO calculate layers inbetween top and bottom using layer count` in `Via._getLayers`), so on 4-layer boards a drilled via "skipped" the inner layers it physically crosses. Anything that reads `layers` to decide per-layer interaction gets this wrong — most visibly `@tscircuit/copper-pour-solver`, whose `via.layers.includes(layer)` test makes inner-plane pours flood **solid over foreign-net via barrels** (no antipad → every through-via shorts to the inner plane in the exported gerbers; invisible to DRC because the pour is resolved after checks).
- `pcb_via.layers` now lists every copper layer between `fromLayer` and `toLayer` (inclusive, in from→to order), derived from the subcircuit layer count via a new `getViaSpanLayers` util. Both `<via>` and the imported-circuit-json `PcbVia` path use it; an explicit `layers` prop on `PcbVia` still wins, and 2-layer boards are unchanged (`[top, bottom]`).

## Testing

- Full `bun test` suite green (no existing test depends on the 2-entry shape); `bunx tsc --noEmit` clean.
- New `tests/components/primitive-components/via-layer-span.test.tsx`:
  - 4-layer `top→bottom` via → `["top", "inner1", "inner2", "bottom"]` (fails before this change: `["top", "bottom"]`)
  - 4-layer `top→inner2` via → `["top", "inner1", "inner2"]`
  - 2-layer via unchanged → `["top", "bottom"]`
- Existing via snapshot tests pass unchanged; port initialization is untouched (the span is computed at pcb-primitive render, when the board's layer count is known — before tree attachment the util falls back to `[fromLayer, toLayer]`).
