### PR TITLE
Fix parent SRJ conversion leaking descendant subcircuit nets

### DIFF
--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -442,7 +442,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   const source_nets = db.source_net
     .list()
     .filter(
-      (e) => !subcircuit_id || relevantSubcircuitIds?.has(e.subcircuit_id!),
+      (e) => !subcircuit_id || e.subcircuit_id === subcircuit_id,
     )
 
   const connectionsFromNets: SimpleRouteConnection[] = []

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -441,9 +441,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
 
   const source_nets = db.source_net
     .list()
-    .filter(
-      (e) => !subcircuit_id || e.subcircuit_id === subcircuit_id,
-    )
+    .filter((e) => !subcircuit_id || e.subcircuit_id === subcircuit_id)
 
   const connectionsFromNets: SimpleRouteConnection[] = []
   for (const net of source_nets) {


### PR DESCRIPTION

```md
## Summary

Fixes `getSimpleRouteJsonFromCircuitJson` so parent subcircuit routing does not include descendant subcircuit `source_net`s as new route connections.

Previously, the converter used `relevantSubcircuitIds` when collecting `source_net`s. That set includes the current subcircuit plus all descendant subcircuits. This is correct for collecting obstacles and already-routed child traces, but incorrect for creating route connections. It caused parent autorouting SRJ to include inner subcircuit nets that were already routed.

## Problem

For boards with nested subcircuits, parent SRJ generation could produce both:

- existing child `pcb_trace`s in `traces`
- duplicate route requests for the child subcircuit's `source_net`s in `connections`

That made the autorouter try to route already-routed inner nets again, leading to static reachability failures.

## Fix

When collecting `source_net`s for `connectionsFromNets`, only include nets whose `subcircuit_id` matches the current `subcircuit_id`.

Descendant subcircuits are still included for obstacles and existing child traces, but their nets are no longer emitted as parent-level route requests.

## Verification

Tested against the subcircuit autorouting repro:

Before:

- `connections: 8`
- included `source_trace_34` plus descendant `source_net_0..source_net_6`
- autorouter failed with static reachability errors

After:

- `connections: 1`
- includes only `source_trace_34`
- keeps `traces: 21` existing child routes
- autorouter solves successfully
```
