### PR TITLE
Respect disabled schematic trace auto labels

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
@@ -1,12 +1,12 @@
-import { Group } from "../Group"
 import { SchematicTracePipelineSolver } from "@tscircuit/schematic-trace-solver"
 import Debug from "debug"
-import { createSchematicTraceSolverInputProblem } from "./createSchematicTraceSolverInputProblem"
-import { applyTracesFromSolverOutput } from "./applyTracesFromSolverOutput"
+import { Group } from "../Group"
 import { applyNetLabelPlacements } from "./applyNetLabelPlacements"
-import { insertNetLabelsForPortsMissingTrace } from "./insertNetLabelsForPortsMissingTrace"
+import { applyTracesFromSolverOutput } from "./applyTracesFromSolverOutput"
+import { createSchematicTraceSolverInputProblem } from "./createSchematicTraceSolverInputProblem"
 import { getSchematicPortIdsWithAssignedNetLabels } from "./getSchematicPortIdsWithAssignedNetLabels"
 import { getSchematicPortIdsWithRoutedTraces } from "./getSchematicPortIdsWithRoutedTraces"
+import { insertNetLabelsForPortsMissingTrace } from "./insertNetLabelsForPortsMissingTrace"
 
 const debug = Debug("Group_doInitialSchematicTraceRender")
 
@@ -17,6 +17,8 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
   if (!group.root?._featureMspSchematicTraceRouting) return
   if (!group.isSubcircuit) return
   if (group.root?.schematicDisabled) return
+  const schTraceAutoLabelEnabled =
+    group.getInheritedProperty("schTraceAutoLabelEnabled") !== false
 
   // Prepare the solver input and context
   const {
@@ -27,7 +29,9 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
     schPortIdToSourcePortId,
     userNetIdToConnKey,
     connKeysWithExplicitPortNetTraces,
-  } = createSchematicTraceSolverInputProblem(group)
+  } = createSchematicTraceSolverInputProblem(group, {
+    schTraceAutoLabelEnabled,
+  })
 
   if (inputProblem.chips.length === 0) return
 
@@ -39,12 +43,14 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
     inputProblem.netConnections.length > 0
 
   if (!hasRouteableSchematicConnections) {
-    insertNetLabelsForPortsMissingTrace({
-      group,
-      allSourceAndSchematicPortIdsInScope,
-      schPortIdToSourcePortId,
-      connKeyToSourceNet,
-    })
+    if (schTraceAutoLabelEnabled) {
+      insertNetLabelsForPortsMissingTrace({
+        group,
+        allSourceAndSchematicPortIdsInScope,
+        schPortIdToSourcePortId,
+        connKeyToSourceNet,
+      })
+    }
     return
   }
 
@@ -75,22 +81,24 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
     schematicPortIdsWithPreExistingNetLabels,
   })
 
-  // Apply net labels (from solver placements and net-only ports)
-  applyNetLabelPlacements({
-    group,
-    solver,
-    connKeyToSourceNet,
-    pinIdToSchematicPortId,
-    userNetIdToConnKey,
-    connKeysWithExplicitPortNetTraces,
-    schematicPortIdsWithPreExistingNetLabels,
-    schematicPortIdsWithRoutedTraces,
-  })
+  if (schTraceAutoLabelEnabled) {
+    // Apply net labels (from solver placements and net-only ports)
+    applyNetLabelPlacements({
+      group,
+      solver,
+      connKeyToSourceNet,
+      pinIdToSchematicPortId,
+      userNetIdToConnKey,
+      connKeysWithExplicitPortNetTraces,
+      schematicPortIdsWithPreExistingNetLabels,
+      schematicPortIdsWithRoutedTraces,
+    })
 
-  insertNetLabelsForPortsMissingTrace({
-    group,
-    allSourceAndSchematicPortIdsInScope,
-    schPortIdToSourcePortId,
-    connKeyToSourceNet,
-  })
+    insertNetLabelsForPortsMissingTrace({
+      group,
+      allSourceAndSchematicPortIdsInScope,
+      schPortIdToSourcePortId,
+      connKeyToSourceNet,
+    })
+  }
 }

--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/createSchematicTraceSolverInputProblem.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/createSchematicTraceSolverInputProblem.ts
@@ -1,12 +1,12 @@
-import type { SourceNet } from "circuit-json"
-import { Group } from "../Group"
 import {
   type InputChip,
   type InputPin,
   type InputProblem,
 } from "@tscircuit/schematic-trace-solver"
-import type { AxisDirection } from "./getSide"
+import type { SourceNet } from "circuit-json"
 import { getSchematicNetLabelTextWidth } from "lib/utils/schematic/computeSchematicNetLabelCenter"
+import { Group } from "../Group"
+import type { AxisDirection } from "./getSide"
 
 const DEFAULT_MAX_MSP_PAIR_DISTANCE = 2.4
 export type SolverInputContext = {
@@ -51,6 +51,11 @@ export type SolverInputContext = {
 
 export function createSchematicTraceSolverInputProblem(
   group: Group<any>,
+  {
+    schTraceAutoLabelEnabled = true,
+  }: {
+    schTraceAutoLabelEnabled?: boolean
+  } = {},
 ): SolverInputContext {
   const { db } = group.root!
 
@@ -228,6 +233,7 @@ export function createSchematicTraceSolverInputProblem(
           DEFAULT_MAX_MSP_PAIR_DISTANCE
         let netLabelWidth: number | undefined
         if (
+          schTraceAutoLabelEnabled &&
           st.display_name &&
           !st.display_name.startsWith(".") &&
           portDistance > maxMspDist
@@ -287,9 +293,13 @@ export function createSchematicTraceSolverInputProblem(
       )
       userNetIdToConnKey.set(userNetId, connKey)
 
-      const netLabelWidth = Number(
-        getSchematicNetLabelTextWidth({ text: String(userNetId) }).toFixed(2),
-      )
+      const netLabelWidth = schTraceAutoLabelEnabled
+        ? Number(
+            getSchematicNetLabelTextWidth({ text: String(userNetId) }).toFixed(
+              2,
+            ),
+          )
+        : undefined
 
       netConnections.push({
         netId: userNetId,

--- a/tests/components/normal-components/sch-trace-auto-label-disabled.test.tsx
+++ b/tests/components/normal-components/sch-trace-auto-label-disabled.test.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("schTraceAutoLabelEnabled false suppresses automatic schematic net labels", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" schTraceAutoLabelEnabled={false}>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin2: "GND" }}
+        connections={{ VCC: "net.V3_3", GND: "net.GND" }}
+      />
+      <resistor
+        name="R1"
+        resistance="10k"
+        footprint="0402"
+        connections={{ pin1: "net.V3_3", pin2: "net.GND" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.schematic_net_label.list()).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary
- propagate schTraceAutoLabelEnabled into the schematic trace solver input
- skip solver-generated and fallback schematic net labels when auto labels are explicitly disabled
- add a regression test for board-level schTraceAutoLabelEnabled={false}

Fixes #2243

## Testing
- bun test tests/components/normal-components/sch-trace-auto-label-disabled.test.tsx tests/components/normal-components/resistor-pulldown.test.tsx
- bun x biome check lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/createSchematicTraceSolverInputProblem.ts tests/components/normal-components/sch-trace-auto-label-disabled.test.tsx
- npx --yes --package typescript@5.9.3 tsc --noEmit --pretty false