### PR TITLE
Respect pcbPositionMode board anchor

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -52,9 +52,9 @@ import {
   getAllDimensionsForSchematicBox,
   isExplicitPinMappingArrangement,
 } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
-import { getPinsFromPortArrangement } from "lib/utils/schematic/getSizeOfSidesFromPortArrangement"
 import { getNumericSchPinStyle } from "lib/utils/schematic/getNumericSchPinStyle"
 import { getPinNumberFromPinLabelsKey } from "lib/utils/schematic/getPinNumberFromPinLabelsKey"
+import { getPinsFromPortArrangement } from "lib/utils/schematic/getSizeOfSidesFromPortArrangement"
 import { parsePinNumberFromLabelsOrThrow } from "lib/utils/schematic/parsePinNumberFromLabelsOrThrow"
 import {
   type ReactElement,
@@ -2156,13 +2156,26 @@ export class NormalComponent<
               componentHeight / 2
             : undefined)
 
+    const positionMode =
+      props.pcbPositionMode === "relative_to_board_anchor"
+        ? "relative_to_board_anchor"
+        : "relative_to_group_anchor"
+    const positionedRelativeToPcbGroupId =
+      positionMode === "relative_to_group_anchor"
+        ? positionedRelativeToGroupId
+        : undefined
+    const positionedRelativeToPcbBoardId =
+      positionMode === "relative_to_board_anchor"
+        ? (this._getBoard()?.pcb_board_id ?? positionedRelativeToBoardId)
+        : positionedRelativeToBoardId
+
     db.pcb_component.update(this.pcb_component_id, {
-      position_mode: "relative_to_group_anchor",
-      positioned_relative_to_pcb_group_id: positionedRelativeToGroupId,
-      positioned_relative_to_pcb_board_id: positionedRelativeToBoardId,
+      position_mode: positionMode,
+      positioned_relative_to_pcb_group_id: positionedRelativeToPcbGroupId,
+      positioned_relative_to_pcb_board_id: positionedRelativeToPcbBoardId,
       display_offset_x: resolvedPcbX as any,
       display_offset_y: resolvedPcbY as any,
-    })
+    } as any)
   }
 
   /**
@@ -2199,7 +2212,10 @@ export class NormalComponent<
       rawProps.pcbLeftEdgeX !== undefined ||
       rawProps.pcbRightEdgeX !== undefined ||
       rawProps.pcbTopEdgeY !== undefined ||
-      rawProps.pcbBottomEdgeY !== undefined
+      rawProps.pcbBottomEdgeY !== undefined ||
+      this._parsedProps.pcbPositionMode === "relative_to_board_anchor" ||
+      this._parsedProps.pcbPositionMode === "relative_to_group_anchor" ||
+      this._parsedProps.pcbPositionMode === "relative_to_component_anchor"
     )
   }
 }

--- a/tests/components/normal-components/pcb-position-mode.test.tsx
+++ b/tests/components/normal-components/pcb-position-mode.test.tsx
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("pcbPositionMode relative_to_board_anchor is reflected in pcb_component metadata", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="22mm" height="20mm">
+      <chip
+        name="U1"
+        footprint="dip8"
+        pcbX={0}
+        pcbY={4}
+        pcbPositionMode="relative_to_board_anchor"
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const board = circuit.db.pcb_board.list()[0]
+  const sourceU1 = circuit.db.source_component.getWhere({ name: "U1" })!
+  const pcbU1 = circuit.db.pcb_component.getWhere({
+    source_component_id: sourceU1.source_component_id,
+  })!
+
+  expect((pcbU1 as any).position_mode).toBe("relative_to_board_anchor")
+  expect(pcbU1.positioned_relative_to_pcb_board_id).toBe(board.pcb_board_id)
+  expect(pcbU1.positioned_relative_to_pcb_group_id).toBeUndefined()
+  expect(Number(pcbU1.display_offset_x)).toBe(0)
+  expect(Number(pcbU1.display_offset_y)).toBe(4)
+})


### PR DESCRIPTION
## Summary
- use explicit pcbPositionMode when writing PCB component positioning metadata
- treat explicit non-auto pcbPositionMode values as relatively positioned so packing does not overwrite them
- add a regression test for pcbPositionMode="relative_to_board_anchor"

Fixes #2242

## Testing
- bun test tests/components/normal-components/pcb-position-mode.test.tsx tests/components/normal-components/pcb-component-relative-positioning1.test.tsx tests/components/normal-components/pcb-component-relative-positioning2.test.tsx
- bun x biome check lib/components/base-components/NormalComponent/NormalComponent.ts tests/components/normal-components/pcb-position-mode.test.tsx
- npx --yes --package typescript@5.9.3 tsc --noEmit --pretty false