### PR TITLE
refactor(core): migrate 3D snapshot rendering to poppygl's current GLB API

### DIFF
--- a/tests/fixtures/extend-expect-3d-matcher.ts
+++ b/tests/fixtures/extend-expect-3d-matcher.ts
@@ -5,9 +5,8 @@ import * as path from "node:path"
 import looksSame from "looks-same"
 import { RootCircuit } from "lib/RootCircuit"
 import {
-  renderGLTFToPNGBufferFromGLBBuffer,
-  decodeImageFromBuffer,
-  type RenderGLTFToPNGBufferFromGLBBufferOptions as PoppyglOptions,
+  renderGLTFToPNGFromGLB,
+  type RenderGLTFToPNGFromGLBOptions as PoppyglOptions,
 } from "poppygl"
 import { convertCircuitJsonToGltf } from "circuit-json-to-gltf"
 import { cju } from "@tscircuit/circuit-json-util"
@@ -124,11 +123,11 @@ async function save3dSnapshotOfCircuitJson({
     ? gltfOrGlb
     : Buffer.from(gltfOrGlb as any)
   const resolvedRenderOpts = await resolvePoppyglOptions(soup, options)
-  const png = await renderGLTFToPNGBufferFromGLBBuffer(
+  const png = await renderGLTFToPNGFromGLB(
     glbBuffer,
     resolvedRenderOpts,
   )
-  const content = Buffer.isBuffer(png) ? png : Buffer.from(png)
+  const content = png
 
   if (!fs.existsSync(snapshotDir)) {
     fs.mkdirSync(snapshotDir, { recursive: true })
@@ -148,9 +147,7 @@ async function save3dSnapshotOfCircuitJson({
   }
 
   const existingSnapshot = fs.readFileSync(filePath)
-  const currentBuffer = Buffer.isBuffer(content)
-    ? content
-    : Buffer.from(content)
+  const currentBuffer = Buffer.from(content)
 
   const lsResult = await looksSame(currentBuffer, existingSnapshot, {
     strict: false,

--- a/tests/fixtures/extend-expect-3d-matcher.ts
+++ b/tests/fixtures/extend-expect-3d-matcher.ts
@@ -123,10 +123,7 @@ async function save3dSnapshotOfCircuitJson({
     ? gltfOrGlb
     : Buffer.from(gltfOrGlb as any)
   const resolvedRenderOpts = await resolvePoppyglOptions(soup, options)
-  const png = await renderGLTFToPNGFromGLB(
-    glbBuffer,
-    resolvedRenderOpts,
-  )
+  const png = await renderGLTFToPNGFromGLB(glbBuffer, resolvedRenderOpts)
   const content = png
 
   if (!fs.existsSync(snapshotDir)) {


### PR DESCRIPTION
## Summary

This PR refactors the 3D snapshot matcher in `tscircuit/core` to use `poppygl`'s current GLB rendering function.

The existing matcher used the older `renderGLTFToPNGBufferFromGLBBuffer` helper. This change migrates that path to `renderGLTFToPNGFromGLB` and keeps the PNG as a `Uint8Array` through the normal write path, only converting to `Buffer` where `looks-same` requires it.

## Changes

- replace `renderGLTFToPNGBufferFromGLBBuffer` with `renderGLTFToPNGFromGLB`
- align the snapshot render path with the current `poppygl` GLB API
- keep PNG data as `Uint8Array` until the image comparison boundary
- preserve existing snapshot matcher behavior

## Why

This keeps `tscircuit/core` aligned with the current renderer surface and simplifies the snapshot pipeline by using the newer GLB render function directly.

## Verification

- passed: `bun test ./tests/fixtures/circuit-3d-snapshot.test.tsx`
