### PR TITLE
fix: pass edge placement hint to packer

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
@@ -1,17 +1,17 @@
-import type { Group } from "../Group"
 import {
+  type PackInput,
+  type PackOutput,
   PackSolver2,
   convertCircuitJsonToPackOutput,
   convertPackOutputToPackInput,
   getGraphicsFromPackOutput,
-  type PackInput,
-  type PackOutput,
 } from "calculate-packing"
 import { type PcbComponent, length } from "circuit-json"
 import Debug from "debug"
+import type { NormalComponent } from "lib/components/base-components/NormalComponent"
+import type { Group } from "../Group"
 import { applyComponentConstraintClusters } from "./applyComponentConstraintClusters"
 import { applyPackOutput } from "./applyPackOutput"
-import type { NormalComponent } from "lib/components/base-components/NormalComponent"
 
 const DEFAULT_MIN_GAP = "1mm"
 const debug = Debug("Group_doInitialPcbLayoutPack")
@@ -45,6 +45,7 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
   // Collect pcb_component_ids that should be treated as static by the packer
   // Only collect from DIRECT children, not all descendants
   const staticPcbComponentIds = new Set<string>()
+  const edgePcbComponentIds = new Set<string>()
 
   // Recursively collect margins from all descendants
   const collectMargins = (comp: any) => {
@@ -58,6 +59,9 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
       )
       if (left || right || top || bottom) {
         chipMarginsMap[comp.pcb_component_id] = { left, right, top, bottom }
+      }
+      if (props.shouldBeOnEdgeOfBoard === true) {
+        edgePcbComponentIds.add(comp.pcb_component_id)
       }
     }
     if (comp?.children) comp.children.forEach(collectMargins)
@@ -151,6 +155,14 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
   }
 
   const clusterMap = applyComponentConstraintClusters(group, packInput)
+
+  if (edgePcbComponentIds.size > 0) {
+    for (const component of packInput.components) {
+      if (edgePcbComponentIds.has(component.componentId)) {
+        ;(component as any).mustBeOnBoundary = true
+      }
+    }
+  }
 
   if (debug.enabled) {
     group.root?.emit("debug:logOutput", {

--- a/tests/examples/example36-packing-events.test.tsx
+++ b/tests/examples/example36-packing-events.test.tsx
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { getTestFixture } from "../fixtures/get-test-fixture"
 
 test("packing:start fires when components don't have pcbX/pcbY", async () => {
@@ -17,7 +17,7 @@ test("packing:start fires when components don't have pcbX/pcbY", async () => {
 
   circuit.render()
 
-  expect(circuit).toMatchPcbSnapshot(import.meta.path + "packing-true")
+  expect(circuit).toMatchPcbSnapshot(`${import.meta.path}packing-true`)
 
   // Packing should run when components don't have explicit positions
   expect(packingStarted).toBe(true)
@@ -51,7 +51,7 @@ test("packing:start does NOT fire when components have pcbX/pcbY", async () => {
 
   circuit.render()
 
-  expect(circuit).toMatchPcbSnapshot(import.meta.path + "packing-false")
+  expect(circuit).toMatchPcbSnapshot(`${import.meta.path}packing-false`)
 
   // Packing should NOT run when components have explicit positions
   expect(packingStarted).toBe(false)
@@ -81,4 +81,35 @@ test("solver:started fires with packing solver details", async () => {
   expect(solverStartedEvent?.solverParams).toMatchObject({
     minGap: expect.any(Number),
   })
+})
+
+test("shouldBeOnEdgeOfBoard is forwarded to PackSolver2", async () => {
+  const { circuit } = getTestFixture()
+  let solverStartedEvent: any
+
+  circuit.on("solver:started", (event) => {
+    if (event.solverName === "PackSolver2") {
+      solverStartedEvent = event
+    }
+  })
+
+  circuit.add(
+    <board width="20mm" height="10mm" pcbPack routingDisabled>
+      <resistor
+        name="J1"
+        footprint="0402"
+        resistance="100"
+        shouldBeOnEdgeOfBoard
+      />
+      <capacitor name="C1" footprint="0402" capacitance="100nF" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const boundaryComponents = solverStartedEvent?.solverParams.components.filter(
+    (component: any) => component.mustBeOnBoundary,
+  )
+
+  expect(boundaryComponents).toHaveLength(1)
 })


### PR DESCRIPTION
﻿Fixes #2271

@algora-pbc /claim #2271

Depends on tscircuit/calculate-packing#99 for the packer-side `mustBeOnBoundary` support.

## Summary
- Collect components whose parsed props include `shouldBeOnEdgeOfBoard` during PCB pack input preparation.
- Forward those components to PackSolver2 as `mustBeOnBoundary`.
- Add a regression test that asserts the hint reaches PackSolver2 params.

## Verification
- `bun test tests/examples/example36-packing-events.test.tsx`
- `bun x biome check lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts tests/examples/example36-packing-events.test.tsx`
- `git diff --check`

Note: `bun x tsc --noEmit` currently fails on upstream main in `lib/utils/createComponentsFromCircuitJson.ts` because `pcbRotation` is not accepted by the target prop type. This change does not touch that file.
