### PR TITLE
fix: honor disabled schematic auto net labels

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
@@ -1,12 +1,12 @@
-import { Group } from "../Group"
 import { SchematicTracePipelineSolver } from "@tscircuit/schematic-trace-solver"
 import Debug from "debug"
-import { createSchematicTraceSolverInputProblem } from "./createSchematicTraceSolverInputProblem"
-import { applyTracesFromSolverOutput } from "./applyTracesFromSolverOutput"
+import { Group } from "../Group"
 import { applyNetLabelPlacements } from "./applyNetLabelPlacements"
-import { insertNetLabelsForPortsMissingTrace } from "./insertNetLabelsForPortsMissingTrace"
+import { applyTracesFromSolverOutput } from "./applyTracesFromSolverOutput"
+import { createSchematicTraceSolverInputProblem } from "./createSchematicTraceSolverInputProblem"
 import { getSchematicPortIdsWithAssignedNetLabels } from "./getSchematicPortIdsWithAssignedNetLabels"
 import { getSchematicPortIdsWithRoutedTraces } from "./getSchematicPortIdsWithRoutedTraces"
+import { insertNetLabelsForPortsMissingTrace } from "./insertNetLabelsForPortsMissingTrace"
 
 const debug = Debug("Group_doInitialSchematicTraceRender")
 
@@ -37,14 +37,18 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
   const hasRouteableSchematicConnections =
     inputProblem.directConnections.length > 0 ||
     inputProblem.netConnections.length > 0
+  const shouldCreateAutoNetLabels =
+    group._parsedProps.schTraceAutoLabelEnabled !== false
 
   if (!hasRouteableSchematicConnections) {
-    insertNetLabelsForPortsMissingTrace({
-      group,
-      allSourceAndSchematicPortIdsInScope,
-      schPortIdToSourcePortId,
-      connKeyToSourceNet,
-    })
+    if (shouldCreateAutoNetLabels) {
+      insertNetLabelsForPortsMissingTrace({
+        group,
+        allSourceAndSchematicPortIdsInScope,
+        schPortIdToSourcePortId,
+        connKeyToSourceNet,
+      })
+    }
     return
   }
 
@@ -75,22 +79,24 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
     schematicPortIdsWithPreExistingNetLabels,
   })
 
-  // Apply net labels (from solver placements and net-only ports)
-  applyNetLabelPlacements({
-    group,
-    solver,
-    connKeyToSourceNet,
-    pinIdToSchematicPortId,
-    userNetIdToConnKey,
-    connKeysWithExplicitPortNetTraces,
-    schematicPortIdsWithPreExistingNetLabels,
-    schematicPortIdsWithRoutedTraces,
-  })
+  if (shouldCreateAutoNetLabels) {
+    // Apply net labels (from solver placements and net-only ports)
+    applyNetLabelPlacements({
+      group,
+      solver,
+      connKeyToSourceNet,
+      pinIdToSchematicPortId,
+      userNetIdToConnKey,
+      connKeysWithExplicitPortNetTraces,
+      schematicPortIdsWithPreExistingNetLabels,
+      schematicPortIdsWithRoutedTraces,
+    })
 
-  insertNetLabelsForPortsMissingTrace({
-    group,
-    allSourceAndSchematicPortIdsInScope,
-    schPortIdToSourcePortId,
-    connKeyToSourceNet,
-  })
+    insertNetLabelsForPortsMissingTrace({
+      group,
+      allSourceAndSchematicPortIdsInScope,
+      schPortIdToSourcePortId,
+      connKeyToSourceNet,
+    })
+  }
 }

--- a/tests/repros/repro-sch-trace-auto-label-disabled.test.tsx
+++ b/tests/repros/repro-sch-trace-auto-label-disabled.test.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("schTraceAutoLabelEnabled false suppresses automatic named-net labels", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" schTraceAutoLabelEnabled={false}>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin2: "GND" }}
+        connections={{ VCC: "net.V3_3", GND: "net.GND" }}
+      />
+      <resistor
+        name="R1"
+        resistance="10k"
+        footprint="0402"
+        connections={{ pin1: "net.V3_3", pin2: "net.GND" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.schematic_net_label.list()).toHaveLength(0)
+})


### PR DESCRIPTION
﻿Fixes #2243

@algora-pbc /claim #2243

## Summary
- Honor `schTraceAutoLabelEnabled={false}` when the group schematic trace renderer creates automatic net labels.
- Skip both solver-suggested auto label placement and fallback labels for ports missing rendered traces when the prop is explicitly disabled.
- Add a regression test covering named-net connections that previously still produced `schematic_net_label` records.

## Verification
- `bun test tests\repros\repro-sch-trace-auto-label-disabled.test.tsx`
- `bun x biome check lib\components\primitive-components\Group\Group_doInitialSchematicTraceRender\Group_doInitialSchematicTraceRender.ts tests\repros\repro-sch-trace-auto-label-disabled.test.tsx`
- `bun x tsc --noEmit`
- `git diff --check`
