### PR TITLE
feat: add schematic pin length prop

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -52,9 +52,10 @@ import {
   getAllDimensionsForSchematicBox,
   isExplicitPinMappingArrangement,
 } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
-import { getPinsFromPortArrangement } from "lib/utils/schematic/getSizeOfSidesFromPortArrangement"
 import { getNumericSchPinStyle } from "lib/utils/schematic/getNumericSchPinStyle"
 import { getPinNumberFromPinLabelsKey } from "lib/utils/schematic/getPinNumberFromPinLabelsKey"
+import { getSchematicPinLength } from "lib/utils/schematic/getSchematicPinLength"
+import { getPinsFromPortArrangement } from "lib/utils/schematic/getSizeOfSidesFromPortArrangement"
 import { parsePinNumberFromLabelsOrThrow } from "lib/utils/schematic/parsePinNumberFromLabelsOrThrow"
 import {
   type ReactElement,
@@ -1624,6 +1625,7 @@ export class NormalComponent<
     const dimensions = getAllDimensionsForSchematicBox({
       schWidth: props.schWidth,
       schHeight: props.schHeight,
+      portDistanceFromEdge: getSchematicPinLength(props, this.props),
       schPinSpacing: pinSpacing,
       numericSchPinStyle: getNumericSchPinStyle(
         props.schPinStyle,

--- a/lib/components/normal-components/Connector.ts
+++ b/lib/components/normal-components/Connector.ts
@@ -1,25 +1,26 @@
 import { guessCableInsertCenter } from "@tscircuit/infer-cable-insertion-point"
 import {
-  connectorProps,
   type ConnectorProps,
   type PartsEngine,
   type SchematicPinStyle,
   type SchematicPortArrangement,
+  connectorProps,
 } from "@tscircuit/props"
 import type { AnyCircuitElement, SourceSimpleConnector } from "circuit-json"
 import { unknown_error_finding_part } from "circuit-json"
-import { createComponentsFromCircuitJson } from "lib/utils/createComponentsFromCircuitJson"
 import { convertCircuitJsonToUsbCStandardCircuitJson } from "lib/utils/connectors/convertCircuitJsonToUsbCStandardCircuitJson"
+import { extractCadModelFromCircuitJson } from "lib/utils/connectors/extractCadModelFromCircuitJson"
+import { createComponentsFromCircuitJson } from "lib/utils/createComponentsFromCircuitJson"
 import {
-  getAllDimensionsForSchematicBox,
   type SchematicBoxDimensions,
+  getAllDimensionsForSchematicBox,
 } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
 import { getNumericSchPinStyle } from "lib/utils/schematic/getNumericSchPinStyle"
-import { extractCadModelFromCircuitJson } from "lib/utils/connectors/extractCadModelFromCircuitJson"
+import { getSchematicPinLength } from "lib/utils/schematic/getSchematicPinLength"
 import { symbols } from "schematic-symbols"
+import type { Port } from "../primitive-components/Port"
 import { Chip } from "./Chip"
 import { insertInnerSymbolInSchematicBox } from "./Connector_insertInnerSymbolInSchematicBox"
-import type { Port } from "../primitive-components/Port"
 
 const USB_C_SIGNAL_LABELS_IN_ORDER = [
   "VBUS1",
@@ -277,6 +278,7 @@ export class Connector<
     return getAllDimensionsForSchematicBox({
       schWidth: props.schWidth,
       schHeight: props.schHeight,
+      portDistanceFromEdge: getSchematicPinLength(props, this.props),
       schPinSpacing: pinSpacing,
       numericSchPinStyle: getNumericSchPinStyle(
         mergedSchPinStyle,

--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -1,20 +1,21 @@
-import { getRelativeDirection } from "lib/utils/get-relative-direction"
+import { type PinAttributeMap, portProps } from "@tscircuit/props"
+import type { LayerRef, SchematicPort } from "circuit-json"
+import type { INormalComponent } from "lib/components/base-components/NormalComponent/INormalComponent"
 import { SCHEMATIC_COMPONENT_OUTLINE_COLOR } from "lib/utils/constants"
+import { getRelativeDirection } from "lib/utils/get-relative-direction"
 import type {
   SchematicBoxDimensions,
   SchematicBoxPortPositionWithMetadata,
 } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
+import { getSchematicPinLength } from "lib/utils/schematic/getSchematicPinLength"
 import { type SchSymbol } from "schematic-symbols"
 import { applyToPoint, compose, translate } from "transformation-matrix"
 import { z } from "zod"
 import { PrimitiveComponent } from "../../base-components/PrimitiveComponent"
 import type { Trace } from "../Trace/Trace"
-import type { LayerRef, SchematicPort } from "circuit-json"
+import { applyPinAttributesToSourcePort } from "./apply-pin-attributes-to-source-port"
 import { areAllPcbPrimitivesOverlapping } from "./areAllPcbPrimitivesOverlapping"
 import { getCenterOfPcbPrimitives } from "./getCenterOfPcbPrimitives"
-import { type PinAttributeMap, portProps } from "@tscircuit/props"
-import type { INormalComponent } from "lib/components/base-components/NormalComponent/INormalComponent"
-import { applyPinAttributesToSourcePort } from "./apply-pin-attributes-to-source-port"
 
 export class Port extends PrimitiveComponent<typeof portProps> {
   source_port_id: string | null = null
@@ -618,7 +619,8 @@ export class Port extends PrimitiveComponent<typeof portProps> {
 
     if (showPinAliases && labelHints.length > 0) {
       return labelHints.join("/")
-    } else if (labelHints.length > 0) {
+    }
+    if (labelHints.length > 0) {
       return labelHints[0]
     }
 
@@ -682,6 +684,10 @@ export class Port extends PrimitiveComponent<typeof portProps> {
 
     const bestDisplayPinLabel = this._getBestDisplayPinLabel()
     const parentNormalComponent = this.getParentNormalComponent()
+    const parentSchPinLength = getSchematicPinLength(
+      parentNormalComponent?._parsedProps,
+      parentNormalComponent?.props,
+    )
 
     // Derive side_of_component from direction prop for custom symbols
     const sideOfComponent =
@@ -698,7 +704,8 @@ export class Port extends PrimitiveComponent<typeof portProps> {
       center: portCenter,
       source_port_id: this.source_port_id!,
       facing_direction: this.facingDirection,
-      distance_from_component_edge: props.schStemLength ?? 0.4,
+      distance_from_component_edge:
+        props.schStemLength ?? parentSchPinLength ?? 0.4,
       side_of_component: sideOfComponent,
       pin_number: props.pinNumber,
       true_ccw_index: localPortInfo?.trueIndex,

--- a/lib/utils/schematic/getAllDimensionsForSchematicBox.ts
+++ b/lib/utils/schematic/getAllDimensionsForSchematicBox.ts
@@ -613,13 +613,16 @@ export const getAllDimensionsForSchematicBox = (
       return { width: resolvedSchWidth, height: schHeight }
     },
     getSizeIncludingPins(): { width: number; height: number } {
+      const horizontalPinLength =
+        (sidePinCounts.leftSize ? portDistanceFromEdge : 0) +
+        (sidePinCounts.rightSize ? portDistanceFromEdge : 0)
+      const verticalPinLength =
+        (sidePinCounts.topSize ? portDistanceFromEdge : 0) +
+        (sidePinCounts.bottomSize ? portDistanceFromEdge : 0)
+
       return {
-        width:
-          resolvedSchWidth +
-          (sidePinCounts.leftSize || sidePinCounts.rightSize ? 0.4 : 0),
-        height:
-          schHeight +
-          (sidePinCounts.topSize || sidePinCounts.bottomSize ? 0.4 : 0),
+        width: resolvedSchWidth + horizontalPinLength,
+        height: schHeight + verticalPinLength,
       }
     },
     pinCount,

--- a/lib/utils/schematic/getSchematicPinLength.ts
+++ b/lib/utils/schematic/getSchematicPinLength.ts
@@ -1,0 +1,16 @@
+type SchPinLengthSource = {
+  schPinLength?: unknown
+}
+
+export const getSchematicPinLength = (
+  ...sources: Array<SchPinLengthSource | unknown>
+): number | undefined => {
+  for (const source of sources) {
+    if (!source || typeof source !== "object") continue
+    const value = (source as SchPinLengthSource).schPinLength
+    if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+      return value
+    }
+  }
+  return undefined
+}

--- a/tests/repros/repro-sch-pin-length.test.tsx
+++ b/tests/repros/repro-sch-pin-length.test.tsx
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("chip schPinLength controls schematic box pin stem length", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board routingDisabled>
+      <chip
+        name="U1"
+        schX={8}
+        schY={8}
+        schWidth={2}
+        schHeight={2}
+        schPinArrangement={{ leftSize: 1, rightSize: 1 }}
+        pinLabels={{ pin1: "A", pin2: "B" }}
+        {...({ schPinLength: 1 } as any)}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const sourceComponent = circuit.db.source_component.getWhere({ name: "U1" })
+  const schematicComponent = circuit.db.schematic_component.getWhere({
+    source_component_id: sourceComponent?.source_component_id,
+  })
+  expect(schematicComponent?.center).toEqual({ x: 8, y: 8 })
+
+  const ports = circuit.db.schematic_port
+    .list({
+      schematic_component_id: schematicComponent?.schematic_component_id,
+    })
+    .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
+
+  expect(ports).toHaveLength(2)
+  expect(ports[0].center.x).toBe(6)
+  expect(ports[0].center.y).toBe(8)
+  expect(ports[0].distance_from_component_edge).toBe(1)
+  expect(ports[1].center.x).toBe(10)
+  expect(ports[1].center.y).toBe(8)
+  expect(ports[1].distance_from_component_edge).toBe(1)
+})

--- a/tests/utils/schematic/getAllDimensionsForSchematicBox.test.ts
+++ b/tests/utils/schematic/getAllDimensionsForSchematicBox.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { getAllDimensionsForSchematicBox } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
 import { getSchematicBoxSvg } from "./getSchematicBoxSvg"
 import "tests/fixtures/extend-expect-any-svg"
@@ -61,4 +61,29 @@ test("getAllDimensionsForSchematicBox 3 (4 sided with margins)", () => {
     import.meta.path,
     "schematicbox3",
   )
+})
+
+test("getAllDimensionsForSchematicBox respects portDistanceFromEdge", () => {
+  const dimensions = getAllDimensionsForSchematicBox({
+    schWidth: 2,
+    schHeight: 2,
+    schPinSpacing: 0.2,
+    portDistanceFromEdge: 1,
+    pinCount: 2,
+  })
+
+  expect(dimensions.getPortPositionByPinNumber(1)).toMatchObject({
+    side: "left",
+    x: -2,
+    y: 0,
+  })
+  expect(dimensions.getPortPositionByPinNumber(2)).toMatchObject({
+    side: "right",
+    x: 2,
+    y: 0,
+  })
+  expect(dimensions.getSizeIncludingPins()).toEqual({
+    width: 4,
+    height: 2,
+  })
 })


### PR DESCRIPTION
Fixes tscircuit/tscircuit#3046

## Summary
- Wire `schPinLength` into schematic box pin endpoint placement for normal components and connector schematic boxes.
- Propagate the parent `schPinLength` into `schematic_port.distance_from_component_edge` so renderers draw the stem at the same length.
- Update `getSizeIncludingPins()` to account for the configured per-side pin length and add regression coverage.

## Verification
- `bun test tests\\utils\\schematic\\getAllDimensionsForSchematicBox.test.ts tests\\repros\\repro-sch-pin-length.test.tsx`
- `bun x tsc --noEmit`
- `bun x biome format ... --write`

Note: `bun x biome check ...` still reports the pre-existing filename convention warning for `tests/utils/schematic/getAllDimensionsForSchematicBox.test.ts`.