### PR TITLE
Preserve explicit vias from autorouter, avoid duplicate via insertion, prevents reroute from causing vias to not appear

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -1381,10 +1381,27 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     // Create vias for layer transitions (this shouldn't be necessary, but
     // the Circuit JSON spec is ambiguous as to whether a via should have a
     // separate element from the route)
+    const viaPositionEpsilon = 1e-6
     for (const pcb_trace of output_pcb_traces) {
       if (pcb_trace.type === "pcb_via") {
-        // TODO handling here- may need to handle if redundant with pcb_trace
-        // below (i.e. don't insert via if one already exists at that location)
+        const explicitVia = pcb_trace as PcbVia
+        const existingVia = db.pcb_via
+          .list()
+          .find(
+            (via) =>
+              via.pcb_via_id === explicitVia.pcb_via_id ||
+              (via.pcb_trace_id === explicitVia.pcb_trace_id &&
+                Math.abs(via.x - explicitVia.x) <= viaPositionEpsilon &&
+                Math.abs(via.y - explicitVia.y) <= viaPositionEpsilon),
+          )
+        if (!existingVia) {
+          db.pcb_via.insert({
+            ...explicitVia,
+            subcircuit_id: explicitVia.subcircuit_id ?? this.subcircuit_id!,
+            pcb_group_id:
+              explicitVia.pcb_group_id ?? this.pcb_group_id ?? undefined,
+          })
+        }
         continue
       }
       if (pcb_trace.type === "pcb_trace") {

--- a/tests/features/autoroutingphase-reroute-vias.test.tsx
+++ b/tests/features/autoroutingphase-reroute-vias.test.tsx
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test"
+import type { PcbVia } from "circuit-json"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+type Point = { x: number; y: number; layer?: string }
+
+const createLayerChangingAutorouter = async (
+  simpleRouteJson: SimpleRouteJson,
+) => {
+  let complete: ((event: any) => void) | undefined
+
+  const solveSync = () => {
+    const connection = simpleRouteJson.connections[0]
+    const [start, end] = connection.pointsToConnect as [Point, Point]
+    const width = connection.nominalTraceWidth ?? 0.15
+
+    return [
+      {
+        type: "pcb_trace" as const,
+        pcb_trace_id: `${connection.name}_rerouted_with_explicit_via`,
+        connection_name: connection.source_trace_id ?? connection.name,
+        route: [
+          {
+            route_type: "wire" as const,
+            x: start.x,
+            y: start.y,
+            width,
+            layer: "top",
+          },
+          {
+            route_type: "wire" as const,
+            x: 0,
+            y: 0,
+            width,
+            layer: "bottom",
+          },
+          {
+            route_type: "wire" as const,
+            x: end.x,
+            y: end.y,
+            width,
+            layer: "bottom",
+          },
+        ],
+      },
+      {
+        type: "pcb_via" as const,
+        pcb_via_id: `${connection.name}_rerouted_explicit_via`,
+        pcb_trace_id: `${connection.name}_rerouted_with_explicit_via`,
+        x: 0,
+        y: 0,
+        outer_diameter: 0.6,
+        hole_diameter: 0.3,
+        layers: ["top", "bottom"],
+        from_layer: "top",
+        to_layer: "bottom",
+      } satisfies PcbVia,
+    ]
+  }
+
+  return {
+    isRouting: false,
+    on: (event: string, callback: any) => {
+      if (event === "complete") complete = callback
+    },
+    start: () => complete?.({ type: "complete", traces: solveSync() }),
+    stop: () => {},
+    solveSync,
+  } as any
+}
+
+test("autoroutingphase reroute preserves explicit vias returned by autorouter", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <testpoint name="A" pcbX={-3} pcbY={0} padDiameter="0.8mm" />
+      <testpoint name="B" pcbX={3} pcbY={0} padDiameter="0.8mm" />
+
+      <autoroutingphase
+        reroute
+        region={{
+          shape: "rect",
+          minX: -4,
+          maxX: 4,
+          minY: -4,
+          maxY: 4,
+        }}
+        autorouter={{ algorithmFn: createLayerChangingAutorouter }}
+      />
+
+      <trace from="A.pin1" to="B.pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const vias = circuit.db.pcb_via.list()
+  expect(vias).toHaveLength(1)
+  expect(vias[0]).toMatchObject({
+    x: 0,
+    y: 0,
+    outer_diameter: 0.6,
+    hole_diameter: 0.3,
+    layers: ["top", "bottom"],
+  })
+})


### PR DESCRIPTION
### Motivation

- Avoid inserting duplicate PCB vias when an autorouter returns explicit `pcb_via` elements and ensure those explicit vias are preserved and associated with the correct group/subcircuit metadata.

### Description

- Add a small position epsilon `viaPositionEpsilon = 1e-6` and check existing vias before inserting an explicit `pcb_via` by matching `pcb_via_id` or matching `pcb_trace_id` and coordinates within the epsilon.
- Insert explicit vias only if no matching via exists, and populate `subcircuit_id` and `pcb_group_id` from the explicit via or fall back to the current group context when missing.
- Keep existing trace splitting and trace insertion logic intact while skipping explicit-via entries from the trace insertion path.
- Add a new test `tests/features/autoroutingphase-reroute-vias.test.tsx` that simulates an autorouter which returns a layer-changing route and an explicit via and asserts the via is inserted with the expected properties.

### Testing

- Ran the automated tests with `bun:test` including the new `tests/features/autoroutingphase-reroute-vias.test.tsx` and the new test passed.
- No failures were observed in the autorouting-related tests after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a419956cf88832e83f9e113f17380d6)