### PR TITLE
chore: remove unused circuit-json-to-simple-3d dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.23",
     "circuit-json-to-gltf": "^0.0.105",
-    "circuit-json-to-simple-3d": "^0.0.9",
     "circuit-json-to-spice": "^0.0.40",
     "circuit-to-svg": "^0.0.367",
     "concurrently": "^9.1.2",


### PR DESCRIPTION
## Summary
Remove the unused `circuit-json-to-simple-3d` dependency from `package.json`.

## Why
This package was originally added for the older simple-3d SVG snapshot path, but the repo later migrated 3D snapshot rendering to `circuit-json-to-gltf` + `poppygl`.

I checked the current tree and found:
- no remaining imports of `circuit-json-to-simple-3d` in `lib/`, `tests/`, or `scripts`
- the current 3D snapshot matcher uses `circuit-json-to-gltf` and `poppygl` instead
- the package appears to be stale dependency baggage from the old snapshot implementation

## Verification
- searched the repo for `circuit-json-to-simple-3d` references
- confirmed the historical usage was test-only and tied to the old simple-3d snapshot matcher
- ran focused 3D snapshot tests after the removal

## Notes
The local test/typecheck environment is currently failing for unrelated dependency/type issues, notably an `@tscircuit/props` mismatch (`ammeterProps` missing) and broader existing TypeScript errors. The dependency removal itself did not surface any direct usage regressions.