### PR TITLE
Skip solver labels covered by explicit labels

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/applyNetLabelPlacements.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/applyNetLabelPlacements.ts
@@ -1,9 +1,13 @@
 import { Group } from "../Group"
 import { SchematicTracePipelineSolver } from "@tscircuit/schematic-trace-solver"
-import { computeSchematicNetLabelCenter } from "lib/utils/schematic/computeSchematicNetLabelCenter"
+import {
+  computeSchematicNetLabelCenter,
+  getSchematicNetLabelTextWidth,
+} from "lib/utils/schematic/computeSchematicNetLabelCenter"
 import type { AxisDirection } from "./getSide"
 import { oppositeSide } from "./oppositeSide"
 import { Port } from "../../Port"
+import type { NetLabel } from "../../NetLabel"
 import { getNetNameFromPorts } from "./getNetNameFromPorts"
 import Debug from "debug"
 import type { SourceNet } from "circuit-json"
@@ -11,8 +15,73 @@ import {
   getPortIdsInsideExpandedTextBounds,
   snapPointToPinInsideExpandedBoundingBox,
 } from "./snap-to-pins-inside-expanded-bounding-box"
+import { doBoundsOverlap, type Bounds, type Point } from "@tscircuit/math-utils"
 
 const debug = Debug("Group_doInitialSchematicTraceRender")
+
+const NET_LABEL_TEXT_HEIGHT = 0.18
+type SchematicPortId = string
+type SchematicNetLabelId = string
+type NetLabelText = string
+
+// "Explicit" net labels are user-authored (placed directly via a <netlabel/> in
+// the source), as opposed to labels the trace solver places automatically.
+interface ExplicitNetLabel {
+  schematic_net_label_id: SchematicNetLabelId
+  text: NetLabelText
+  source_net_id?: string | null
+  center?: Point
+  schematicPortIds: SchematicPortId[]
+}
+
+const getNetLabelTextBounds = ({
+  center,
+  text,
+}: {
+  center: Point
+  text: NetLabelText
+}): Bounds => {
+  const width = getSchematicNetLabelTextWidth({ text })
+  const halfWidth = width / 2
+  const halfHeight = NET_LABEL_TEXT_HEIGHT / 2
+  return {
+    minX: center.x - halfWidth,
+    maxX: center.x + halfWidth,
+    minY: center.y - halfHeight,
+    maxY: center.y + halfHeight,
+  }
+}
+
+const isSameNet = (label: ExplicitNetLabel, sourceNet: SourceNet) =>
+  label.source_net_id != null && label.source_net_id === sourceNet.source_net_id
+
+// An explicit label is redundant with a solver placement when it labels the same
+// net and either shares one of the placement's ports or visually overlaps it.
+const isExplicitNetLabelRedundantWithPlacement = (
+  label: ExplicitNetLabel,
+  solverPlacement: {
+    sourceNet: SourceNet
+    text: NetLabelText
+    schematicPortIds: Set<SchematicPortId>
+    bounds: Bounds
+  },
+) => {
+  if (!isSameNet(label, solverPlacement.sourceNet)) {
+    return false
+  }
+  if (
+    label.schematicPortIds.some((id) =>
+      solverPlacement.schematicPortIds.has(id),
+    )
+  ) {
+    return true
+  }
+  if (!label.center) return false
+  return doBoundsOverlap(
+    getNetLabelTextBounds({ center: label.center, text: label.text }),
+    solverPlacement.bounds,
+  )
+}
 
 export function applyNetLabelPlacements(args: {
   group: Group<any>
@@ -81,6 +150,23 @@ export function applyNetLabelPlacements(args: {
     }
   }
   const globalConnMap = solver.mspConnectionPairSolver!.globalConnMap
+  const explicitNetLabels: ExplicitNetLabel[] = (
+    group.selectAll("netlabel") as NetLabel[]
+  )
+    .filter((label) => label.schematic_net_label_id)
+    .map((label) => {
+      const dbLabel = db.schematic_net_label.get(label.schematic_net_label_id!)
+      return {
+        schematic_net_label_id: label.schematic_net_label_id!,
+        text: label._getNetName(),
+        source_net_id: label.source_net_label_id,
+        center: dbLabel?.center,
+        schematicPortIds: label
+          ._getConnectedPorts()
+          .map((port) => port.schematic_port_id)
+          .filter((id): id is string => Boolean(id)),
+      }
+    })
 
   for (const placement of dedupedNetLabelPlacements) {
     debug(`processing placement: ${placement.netId}`)
@@ -159,6 +245,22 @@ export function applyNetLabelPlacements(args: {
         anchor_side,
         text,
       })
+
+      if (!isPowerOrGroundNet) {
+        const solverPlacement = {
+          sourceNet,
+          text,
+          schematicPortIds: new Set(schPortIds),
+          bounds: getNetLabelTextBounds({ center, text }),
+        }
+        if (
+          explicitNetLabels.some((label) =>
+            isExplicitNetLabelRedundantWithPlacement(label, solverPlacement),
+          )
+        ) {
+          continue
+        }
+      }
 
       const netLabel: Parameters<typeof db.schematic_net_label.insert>[0] = {
         text,

--- a/lib/components/primitive-components/NetLabel.ts
+++ b/lib/components/primitive-components/NetLabel.ts
@@ -17,6 +17,7 @@ import { getEnteringEdgeFromDirection } from "lib/utils/schematic/getEnteringEdg
 
 export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
   source_net_label_id?: string
+  schematic_net_label_id?: string
 
   get config() {
     return {
@@ -133,6 +134,7 @@ export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
     })
 
     this.source_net_label_id = netLabel.source_net_id
+    this.schematic_net_label_id = netLabel.schematic_net_label_id
   }
 
   _resolveConnectsTo(): string[] | undefined {

--- a/tests/repros/__snapshots__/repro126-trace-overlap-box-resistor-schematic.snap.svg
+++ b/tests/repros/__snapshots__/repro126-trace-overlap-box-resistor-schematic.snap.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="tscircuit-schematic" width="1200" height="600" style="background-color: rgb(245, 241, 237)" data-real-to-screen-transform="matrix(64.7938834574,0,0,-64.7938834574,665.3813480007,321.533167269)" data-software-used-string="@tscircuit/core@0.0.1371"><style>
+<svg xmlns="http://www.w3.org/2000/svg" class="tscircuit-schematic" width="1200" height="600" style="background-color: rgb(245, 241, 237)" data-real-to-screen-transform="matrix(64.7938834574,0,0,-64.7938834574,665.3813480007,321.533167269)" data-software-used-string="@tscircuit/core@0.0.1372"><style>
               .boundary { fill: rgb(245, 241, 237); }
               .schematic-boundary { fill: none; stroke: #fff; }
               .component { fill: none; stroke: rgb(132, 0, 0); }
@@ -61,13 +61,6 @@ svg:has(:is(g.trace[data-subcircuit-connectivity-map-key="TPS63802_3V3_BuckBoost
     L 797.1073130695942,339.09230968595534
     Z
   " fill="rgba(255, 255, 255, 0.6)" stroke="rgb(132, 0, 0)" stroke-width="1.295877669148px"/><text class="net-label-text sch-net-label-text" x="790.1095736561949" y="336.75972988148897" fill="rgb(132, 0, 0)" text-anchor="start" dominant-baseline="central" font-family="sans-serif" font-variant-numeric="tabular-nums" font-size="11.662899022331999px" transform="rotate(-90 790.1095736561949 336.75972988148897)">FB</text><path class="net-label sch-net-label" d="
-    M 765.81186735967,305.33469640465
-    L 772.8096067730693,308.8335661113496
-    L 772.8096067730693,332.3494262141553
-    L 758.8141279462708,332.3494262141553
-    L 758.8141279462708,308.8335661113496
-    Z
-  " fill="rgba(255, 255, 255, 0.6)" stroke="rgb(132, 0, 0)" stroke-width="1.295877669148px"/><text class="net-label-text sch-net-label-text" x="765.81186735967" y="311.166145915816" fill="rgb(132, 0, 0)" text-anchor="start" dominant-baseline="central" font-family="sans-serif" font-variant-numeric="tabular-nums" font-size="11.662899022331999px" transform="rotate(90 765.81186735967 311.166145915816)">PG</text><path class="net-label sch-net-label" d="
     M 782.01033822402,258.359130898035
     L 785.5092079307195,251.36139148463582
     L 824.2473110537837,251.36139148463582


### PR DESCRIPTION
Stacked PR 3/3. Base: #2535.

When a solver placement overlaps or shares a port with a user-authored net label for the same net, leave the explicit label in place and skip inserting the solver label. Track rendered net label ids on NetLabel so placement cleanup can compare against existing explicit labels without deleting them.

Before: 
<img width="66" height="57" alt="Screenshot 2026-06-30 at 5 15 34 PM" src="https://github.com/user-attachments/assets/aad93222-33c2-4aac-8e67-17b73cd4d445" />


After(PG net label is inside the chip cause it has <netlabel /> with manual schX and schY):
<img width="71" height="71" alt="Screenshot 2026-06-30 at 5 15 27 PM" src="https://github.com/user-attachments/assets/5ad342cd-1401-4262-9f72-9bd8371c8f06" />