### PR TITLE
fix: correct transistor emitter/collector port map

### DIFF
--- a/lib/components/normal-components/Transistor.ts
+++ b/lib/components/normal-components/Transistor.ts
@@ -39,8 +39,8 @@ export class Transistor extends NormalComponent<
     })
   }
 
-  emitter = this.portMap.pin1
-  collector = this.portMap.pin2
+  collector = this.portMap.pin1
+  emitter = this.portMap.pin2
   base = this.portMap.pin3
 
   doInitialCreateNetsFromProps() {


### PR DESCRIPTION
Fixes tscircuit/tscircuit#3617

The port map had \emitter=this.portMap.pin1\ and \collector=this.portMap.pin2\, but pin1 is aliased as collector and pin2 as emitter. This swapped the emitter and collector ports on NPN transistors.

/claim #3617