### PR TITLE
Skip solver provided net labels covered by user-defined labels

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/applyNetLabelPlacements.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/applyNetLabelPlacements.ts
@@ -8,22 +8,16 @@ import type { NetLabel } from "../../NetLabel"
 import { getNetNameFromPorts } from "./getNetNameFromPorts"
 import { getNetLabelTextBounds } from "./getNetLabelTextBounds"
 import Debug from "debug"
-import type { SourceNet } from "circuit-json"
-import { doBoundsOverlap, type Bounds, type Point } from "@tscircuit/math-utils"
+import type { SchematicNetLabel, SourceNet } from "circuit-json"
+import { doBoundsOverlap, type Bounds } from "@tscircuit/math-utils"
 
 const debug = Debug("Group_doInitialSchematicTraceRender")
 
 type SchematicPortId = string
-type SchematicNetLabelId = string
-type NetLabelText = string
 
 // User-defined net labels are placed directly via a <netlabel/> in the source,
 // as opposed to labels the trace solver places automatically.
-interface UserDefinedNetLabel {
-  schematic_net_label_id: SchematicNetLabelId
-  text: NetLabelText
-  source_net_id?: string | null
-  center?: Point
+interface UserDefinedNetLabel extends SchematicNetLabel {
   schematicPortIds: SchematicPortId[]
 }
 
@@ -36,7 +30,7 @@ const isUserDefinedNetLabelRedundantWithPlacement = (
   label: UserDefinedNetLabel,
   solverPlacement: {
     sourceNet: SourceNet
-    text: NetLabelText
+    text: string
     schematicPortIds: Set<SchematicPortId>
     bounds: Bounds
   },
@@ -127,20 +121,19 @@ export function applyNetLabelPlacements(args: {
   const userDefinedNetLabels: UserDefinedNetLabel[] = (
     group.selectAll("netlabel") as NetLabel[]
   )
-    .filter((label) => label.schematic_net_label_id)
     .map((label) => {
-      const dbLabel = db.schematic_net_label.get(label.schematic_net_label_id!)
+      if (!label.schematic_net_label_id) return null
+      const dbLabel = db.schematic_net_label.get(label.schematic_net_label_id)
+      if (!dbLabel) return null
       return {
-        schematic_net_label_id: label.schematic_net_label_id!,
-        text: label._getNetName(),
-        source_net_id: label.source_net_label_id,
-        center: dbLabel?.center,
+        ...dbLabel,
         schematicPortIds: label
           ._getConnectedPorts()
           .map((port) => port.schematic_port_id)
           .filter((id): id is string => Boolean(id)),
       }
     })
+    .filter((label): label is UserDefinedNetLabel => label !== null)
 
   for (const placement of dedupedNetLabelPlacements) {
     debug(`processing placement: ${placement.netId}`)

--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/applyNetLabelPlacements.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/applyNetLabelPlacements.ts
@@ -4,11 +4,59 @@ import { computeSchematicNetLabelCenter } from "lib/utils/schematic/computeSchem
 import type { AxisDirection } from "./getSide"
 import { oppositeSide } from "./oppositeSide"
 import { Port } from "../../Port"
+import type { NetLabel } from "../../NetLabel"
 import { getNetNameFromPorts } from "./getNetNameFromPorts"
+import { getNetLabelTextBounds } from "./getNetLabelTextBounds"
 import Debug from "debug"
 import type { SourceNet } from "circuit-json"
+import { doBoundsOverlap, type Bounds, type Point } from "@tscircuit/math-utils"
 
 const debug = Debug("Group_doInitialSchematicTraceRender")
+
+type SchematicPortId = string
+type SchematicNetLabelId = string
+type NetLabelText = string
+
+// User-defined net labels are placed directly via a <netlabel/> in the source,
+// as opposed to labels the trace solver places automatically.
+interface UserDefinedNetLabel {
+  schematic_net_label_id: SchematicNetLabelId
+  text: NetLabelText
+  source_net_id?: string | null
+  center?: Point
+  schematicPortIds: SchematicPortId[]
+}
+
+const isSameNet = (label: UserDefinedNetLabel, sourceNet: SourceNet) =>
+  label.source_net_id != null && label.source_net_id === sourceNet.source_net_id
+
+// A user-defined label is redundant with a solver placement when it labels the
+// same net and either shares one of the placement's ports or visually overlaps it.
+const isUserDefinedNetLabelRedundantWithPlacement = (
+  label: UserDefinedNetLabel,
+  solverPlacement: {
+    sourceNet: SourceNet
+    text: NetLabelText
+    schematicPortIds: Set<SchematicPortId>
+    bounds: Bounds
+  },
+) => {
+  if (!isSameNet(label, solverPlacement.sourceNet)) {
+    return false
+  }
+  if (
+    label.schematicPortIds.some((id) =>
+      solverPlacement.schematicPortIds.has(id),
+    )
+  ) {
+    return true
+  }
+  if (!label.center) return false
+  return doBoundsOverlap(
+    getNetLabelTextBounds({ center: label.center, text: label.text }),
+    solverPlacement.bounds,
+  )
+}
 
 export function applyNetLabelPlacements(args: {
   group: Group<any>
@@ -76,6 +124,23 @@ export function applyNetLabelPlacements(args: {
     }
   }
   const globalConnMap = solver.mspConnectionPairSolver!.globalConnMap
+  const userDefinedNetLabels: UserDefinedNetLabel[] = (
+    group.selectAll("netlabel") as NetLabel[]
+  )
+    .filter((label) => label.schematic_net_label_id)
+    .map((label) => {
+      const dbLabel = db.schematic_net_label.get(label.schematic_net_label_id!)
+      return {
+        schematic_net_label_id: label.schematic_net_label_id!,
+        text: label._getNetName(),
+        source_net_id: label.source_net_label_id,
+        center: dbLabel?.center,
+        schematicPortIds: label
+          ._getConnectedPorts()
+          .map((port) => port.schematic_port_id)
+          .filter((id): id is string => Boolean(id)),
+      }
+    })
 
   for (const placement of dedupedNetLabelPlacements) {
     debug(`processing placement: ${placement.netId}`)
@@ -141,6 +206,22 @@ export function applyNetLabelPlacements(args: {
         anchor_side,
         text,
       })
+
+      if (!isPowerOrGroundNet) {
+        const solverPlacement = {
+          sourceNet,
+          text,
+          schematicPortIds: new Set(schPortIds),
+          bounds: getNetLabelTextBounds({ center, text }),
+        }
+        if (
+          userDefinedNetLabels.some((label) =>
+            isUserDefinedNetLabelRedundantWithPlacement(label, solverPlacement),
+          )
+        ) {
+          continue
+        }
+      }
 
       const netLabel: Parameters<typeof db.schematic_net_label.insert>[0] = {
         text,

--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/getNetLabelTextBounds.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/getNetLabelTextBounds.ts
@@ -1,0 +1,22 @@
+import { getSchematicNetLabelTextWidth } from "lib/utils/schematic/computeSchematicNetLabelCenter"
+import type { Bounds, Point } from "@tscircuit/math-utils"
+
+const NET_LABEL_TEXT_HEIGHT = 0.18
+
+export const getNetLabelTextBounds = ({
+  center,
+  text,
+}: {
+  center: Point
+  text: string
+}): Bounds => {
+  const width = getSchematicNetLabelTextWidth({ text })
+  const halfWidth = width / 2
+  const halfHeight = NET_LABEL_TEXT_HEIGHT / 2
+  return {
+    minX: center.x - halfWidth,
+    maxX: center.x + halfWidth,
+    minY: center.y - halfHeight,
+    maxY: center.y + halfHeight,
+  }
+}

--- a/lib/components/primitive-components/NetLabel.ts
+++ b/lib/components/primitive-components/NetLabel.ts
@@ -17,6 +17,7 @@ import { getEnteringEdgeFromDirection } from "lib/utils/schematic/getEnteringEdg
 
 export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
   source_net_label_id?: string
+  schematic_net_label_id?: string
 
   get config() {
     return {
@@ -133,6 +134,7 @@ export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
     })
 
     this.source_net_label_id = netLabel.source_net_id
+    this.schematic_net_label_id = netLabel.schematic_net_label_id
   }
 
   _resolveConnectsTo(): string[] | undefined {

--- a/tests/repros/__snapshots__/repro126-trace-overlap-box-resistor-schematic.snap.svg
+++ b/tests/repros/__snapshots__/repro126-trace-overlap-box-resistor-schematic.snap.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="tscircuit-schematic" width="1200" height="600" style="background-color: rgb(245, 241, 237)" data-real-to-screen-transform="matrix(64.9341279347,0,0,-64.9341279347,665.5228640279,320.9304339043)" data-software-used-string="@tscircuit/core@0.0.1353"><style>
+<svg xmlns="http://www.w3.org/2000/svg" class="tscircuit-schematic" width="1200" height="600" style="background-color: rgb(245, 241, 237)" data-real-to-screen-transform="matrix(64.9341279347,0,0,-64.9341279347,665.5228640279,320.9304339043)" data-software-used-string="@tscircuit/core@0.0.1375"><style>
               .boundary { fill: rgb(245, 241, 237); }
               .schematic-boundary { fill: none; stroke: #fff; }
               .component { fill: none; stroke: rgb(132, 0, 0); }
@@ -61,13 +61,6 @@ svg:has(:is(g.trace[data-subcircuit-connectivity-map-key="TPS63802_3V3_BuckBoost
     L 797.5339461191451,338.5275825746037
     Z
   " fill="rgba(255, 255, 255, 0.6)" stroke="rgb(132, 0, 0)" stroke-width="1.298682558694px"/><text class="net-label-text sch-net-label-text" x="790.5210603021975" y="336.18995396895446" fill="rgb(132, 0, 0)" text-anchor="start" dominant-baseline="central" font-family="sans-serif" font-variant-numeric="tabular-nums" font-size="11.688143028246px" transform="rotate(-90 790.5210603021975 336.18995396895446)">FB</text><path class="net-label sch-net-label" d="
-    M 766.170762326685,304.696901920625
-    L 773.1836481436326,308.2033448290988
-    L 773.1836481436326,331.7701043275326
-    L 759.1578765097374,331.7701043275326
-    L 759.1578765097374,308.2033448290988
-    Z
-  " fill="rgba(255, 255, 255, 0.6)" stroke="rgb(132, 0, 0)" stroke-width="1.298682558694px"/><text class="net-label-text sch-net-label-text" x="766.170762326685" y="310.540973434748" fill="rgb(132, 0, 0)" text-anchor="start" dominant-baseline="central" font-family="sans-serif" font-variant-numeric="tabular-nums" font-size="11.688143028246px" transform="rotate(90 766.170762326685 310.540973434748)">PG</text><path class="net-label sch-net-label" d="
     M 782.40429431036,257.6196591679675
     L 785.9107372188338,250.60677335101988
     L 824.7326878400597,250.60677335101988


### PR DESCRIPTION
When the schematic trace solver places a net label that duplicates a user-authored ```<netlabel/>``` for the same net — sharing a port or visually overlapping it — keep the explicit label and skip the solver one, avoiding double labels.

<img width="131" height="177" alt="Screenshot 2026-07-01 at 8 31 31 AM" src="https://github.com/user-attachments/assets/f7ff9603-f4b0-4164-a6fa-5d34b7c8f29d" />

<img width="83" height="107" alt="Screenshot 2026-07-01 at 8 31 36 AM" src="https://github.com/user-attachments/assets/b2ad1611-021c-4ba5-af51-517433ffb51a" />
