### PR TITLE
Scope parent net autorouting source traces

### DIFF
--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -450,8 +450,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   const currentSubcircuitSourceTraces = db.source_trace
     .list()
     .filter(
-      (st) =>
-        !subcircuit_id || (st as any).subcircuit_id === subcircuit_id,
+      (st) => !subcircuit_id || (st as any).subcircuit_id === subcircuit_id,
     )
   const exposedDescendantSourceNetIds = new Set<string>()
   for (const st of currentSubcircuitSourceTraces) {

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -446,7 +446,50 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   const connectionsFromNets: SimpleRouteConnection[] = []
   const connectionFromNetId = new Map<string, SimpleRouteConnection>()
   const handledNetConnectivityKeys = new Set<string>()
-  const sourceTraces = db.source_trace.list()
+  const sourceNetIds = new Set(source_nets.map((net) => net.source_net_id))
+  const currentSubcircuitSourceTraces = db.source_trace
+    .list()
+    .filter(
+      (st) =>
+        !subcircuit_id || (st as any).subcircuit_id === subcircuit_id,
+    )
+  const exposedDescendantSourceNetIds = new Set<string>()
+  for (const st of currentSubcircuitSourceTraces) {
+    if (!st.name?.startsWith("exposed_net.")) continue
+    for (const sourceNetId of st.connected_source_net_ids ?? []) {
+      if (!sourceNetIds.has(sourceNetId)) {
+        exposedDescendantSourceNetIds.add(sourceNetId)
+      }
+    }
+  }
+  const routedDescendantTraceIds = new Set(
+    subcircuit_id
+      ? db.pcb_trace
+          .list()
+          .filter(
+            (t) =>
+              t.subcircuit_id &&
+              t.subcircuit_id !== subcircuit_id &&
+              relevantSubcircuitIds?.has(t.subcircuit_id),
+          )
+          .map((t) => t.source_trace_id)
+          .filter((id): id is string => Boolean(id))
+      : [],
+  )
+  const sourceTraces = db.source_trace
+    .list()
+    .filter(
+      (st) =>
+        !subcircuit_id ||
+        st.subcircuit_id === subcircuit_id ||
+        (st.connected_source_net_ids?.some((id) => sourceNetIds.has(id)) ??
+          false) ||
+        ((st.connected_source_net_ids?.some((id) =>
+          exposedDescendantSourceNetIds.has(id),
+        ) ??
+          false) &&
+          !routedDescendantTraceIds.has(st.source_trace_id)),
+    )
   const getSourceConnectivityKey = (id?: string | null) =>
     id ? (connMap.getNetConnectedToId(id) ?? id) : null
   for (const net of source_nets) {

--- a/tests/subcircuits/parent-autorouting-net-scope.test.tsx
+++ b/tests/subcircuits/parent-autorouting-net-scope.test.tsx
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("parent autorouting net connections do not include child subcircuit internals", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <net name="VCC" />
+      <net name="GND" />
+
+      <subcircuit name="MOD">
+        <net name="VCC" />
+        <net name="GND" />
+        <resistor
+          name="R_CHILD"
+          resistance="1k"
+          footprint="0402"
+          pcbX={-4}
+          pcbY={0}
+        />
+        <capacitor
+          name="C_CHILD"
+          capacitance="100nF"
+          footprint="0402"
+          pcbX={-2}
+          pcbY={0}
+        />
+        <trace name="CHILD_R_VCC" from=".R_CHILD > .pin1" to="net.VCC" />
+        <trace name="CHILD_R_GND" from=".R_CHILD > .pin2" to="net.GND" />
+        <trace name="CHILD_C_VCC" from=".C_CHILD > .pin1" to="net.VCC" />
+        <trace name="CHILD_C_GND" from=".C_CHILD > .pin2" to="net.GND" />
+      </subcircuit>
+
+      <resistor
+        name="R_PARENT"
+        resistance="1k"
+        footprint="0402"
+        pcbX={4}
+        pcbY={0}
+      />
+      <trace name="PARENT_VCC" from=".R_PARENT > .pin1" to="net.VCC" />
+      <trace name="PARENT_GND" from=".R_PARENT > .pin2" to="net.GND" />
+      <trace name="MOD_VCC" from="net.VCC" to=".MOD net.VCC" />
+      <trace name="MOD_GND" from="net.GND" to=".MOD net.GND" />
+      <trace name="MOD_DIRECT" from=".R_PARENT > .pin1" to=".MOD net.VCC" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const sourceBoard = circuit.db.source_board.list()[0]
+  const boardSubcircuitId = `subcircuit_${sourceBoard.source_group_id}`
+  const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
+    circuitJson: circuit.getCircuitJson(),
+    subcircuit_id: boardSubcircuitId,
+  })
+
+  const connectionComponentNames = simpleRouteJson.connections.flatMap((conn) =>
+    conn.pointsToConnect
+      .map((pt) => {
+        if (!pt.pcb_port_id) return null
+        const pcbPort = circuit.db.pcb_port.get(pt.pcb_port_id)
+        if (!pcbPort?.source_port_id) return null
+        const sourcePort = circuit.db.source_port.get(pcbPort.source_port_id)
+        if (!sourcePort?.source_component_id) return null
+        return circuit.db.source_component.get(sourcePort.source_component_id)
+          ?.name
+      })
+      .filter((name): name is string => Boolean(name)),
+  )
+
+  expect(connectionComponentNames).toContain("R_PARENT")
+  expect(connectionComponentNames).not.toContain("R_CHILD")
+  expect(connectionComponentNames).not.toContain("C_CHILD")
+})


### PR DESCRIPTION
## Summary

- Prevent parent-board autorouting from turning already-solved child subcircuit internals into new routing endpoints.
- Preserve explicit `exposedNets` behavior, where parent routing must still be able to reach exposed child nets.
- Add a regression test for the GameBoy/Pico failure mode.

## Cause

`getSimpleRouteJsonFromCircuitJson` builds a Simple Route JSON view for the subcircuit currently being routed.

For parent-board routing it intentionally includes descendant subcircuit elements. That is needed so the parent autorouter can see already-routed child copper as geometry and avoid colliding with it.

The bug was in the net-derived connection builder:

- `source_net`s were scoped to the current subcircuit.
- `source_trace`s were taken from the expanded DB that also contained descendants.
- Connectivity keys then collapsed shared nets such as `GND`, `V3V3`, and `VSYS` across parent and child scopes.

That allowed child-only traces and pads from an already-routed subcircuit to be added to the parent board's `pointsToConnect`.

In the GameBoy repro, the Pico subcircuit routed first, but the parent board route later saw Pico internal power/ground pins as endpoints and tried to route inside the Pico again.

## Fix

Scope the `source_trace`s used for net-derived parent connections.

The filter now includes:

- traces in the current `subcircuit_id`
- traces that directly reference a current-scope source net
- unrouted descendant pin traces only when they are connected through explicit `exposed_net.*` bridge traces

The filter excludes:

- descendant-only internals that merely share a collapsed connectivity key
- descendant traces that are already represented by child `pcb_trace`s

This keeps routed child copper available as geometry/obstacles while preventing it from becoming a new parent routing request.

## Why `exposedNets` Needs Special Handling

Some valid parent routes connect to nets exposed by child subcircuits.

In those cases, the parent-scope bridge traces are named `exposed_net.*` and connect the parent net to the child net. The child pin trace may be the only trace with a physical PCB port, so excluding every descendant trace would break existing exposed-net routing.

The fix therefore allows only the descendant source nets reached through those explicit exposed-net bridge traces, and still ignores them if the child route has already produced a `pcb_trace`.

## Validation

- `bun test tests/features/subcircuit-circuit-json/subcircuit-circuit-json14.test.tsx tests/subcircuits/parent-autorouting-net-scope.test.tsx`
  - `2 pass`
  - verifies existing exposed-net behavior still routes
  - verifies parent autorouting does not include child subcircuit internals
- Downstream GameBoy repro:
  - `bun run build`
  - build passed
  - generated `dist/index/circuit.json`
  - `pcb_trace`: `229`
  - `pcb_via`: `260`
  - `pcb_autorouting_error`: `0`

## Notes

The parent autorouter still receives descendant `pcb_trace` geometry for collision avoidance and subcircuit handoff behavior. The change only limits which descendant `source_trace`s are converted into parent net connection endpoints.
