### PR TITLE
fix: manual edits inside positioned group should use absolute manual center

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -506,11 +506,8 @@ export abstract class PrimitiveComponent<
     ) {
       const rotation = this._getPcbRotationBeforeLayout() ?? 0
       return compose(
-        this.parent?._computePcbGlobalTransformBeforeLayout() ?? identity(),
-        compose(
-          translate(manualPlacement.x, manualPlacement.y),
-          rotate((rotation * Math.PI) / 180),
-        ),
+        translate(manualPlacement.x, manualPlacement.y),
+        rotate((rotation * Math.PI) / 180),
       )
     }
 

--- a/tests/components/normal-components/board-layout.test.tsx
+++ b/tests/components/normal-components/board-layout.test.tsx
@@ -60,3 +60,47 @@ test("board with manual layout edits", () => {
 
   expect(circuit.getCircuitJson()).toMatchPcbSnapshot(import.meta.path)
 })
+
+test("manual layout edits inside positioned group use absolute manual center", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board
+      width="40mm"
+      height="20mm"
+      manualEdits={{
+        pcb_placements: [
+          {
+            selector: ".C1",
+            center: { x: 11.4, y: 4.3 },
+            relative_to: "group_center",
+          },
+        ],
+      }}
+    >
+      <group name="region" pcbX={16} pcbY={0}>
+        <chip
+          name="U1"
+          footprint="soic8"
+          pinLabels={{ pin1: "VCC", pin8: "GND" }}
+        />
+        <capacitor
+          name="C1"
+          capacitance="100nF"
+          footprint="0402"
+          connections={{ pin1: "U1.VCC", pin2: "U1.GND" }}
+        />
+      </group>
+    </board>,
+  )
+
+  circuit.render()
+
+  const capacitor = circuit.selectOne(".C1")
+  expect(capacitor).not.toBeNull()
+
+  const capacitorPosition = capacitor!._getGlobalPcbPositionBeforeLayout()
+
+  expect(capacitorPosition.x).toBeCloseTo(11.4, 1)
+  expect(capacitorPosition.y).toBeCloseTo(4.3, 1)
+})


### PR DESCRIPTION
## Problem

When a component is placed via `manualEdits` with `relative_to: "group_center"` inside a `<group>` that has `pcbX`/`pcbY` offsets, the parent group's transform is applied **twice** — once inside `_getPcbManualPlacementForComponent()` (which already returns the absolute PCB center) and again when composing with `this.parent?._computePcbGlobalTransformBeforeLayout()`.

This causes components to land at `parent_offset + manual_placement` instead of the intended absolute position.

Reproduction: placing a capacitor at `{ x: 11.4, y: 4.3 }` inside a group with `pcbX=16` yields `x=27.4` instead of `x=11.4`.

## Fix

Remove the parent transform composition from `_computePcbGlobalTransformBeforeLayout()` when manual placement is active. The manual placement already returns absolute coordinates, so the parent transform should not be re-applied.

```diff
- this.parent?._computePcbGlobalTransformBeforeLayout() ?? identity(),
- compose(
-   translate(manualPlacement.x, manualPlacement.y),
-   rotate((rotation * Math.PI) / 180),
- ),
+ translate(manualPlacement.x, manualPlacement.y),
+ rotate((rotation * Math.PI) / 180),
```

## Verification

```
bun test \
  tests/components/normal-components/manual-placement-conflicts.test.tsx \
  tests/components/normal-components/manual-edit-conflict-warning-2.test.tsx \
  tests/components/normal-components/board-layout.test.tsx \
  tests/components/primitive-components/group-anchor-position.test.tsx
```

Result: **9 pass, 0 fail** (1 snapshot, 22 expect() calls)

New test `manual layout edits inside positioned group use absolute manual center` verifies the fix directly by asserting the capacitor lands at the intended `(11.4, 4.3)` position.

Fixes #2281
