### PR TITLE
Add a repro test for board solderMaskColor/silkscreenColor being dropped

### DIFF
--- a/tests/components/normal-components/board-solder-mask-color.test.tsx
+++ b/tests/components/normal-components/board-solder-mask-color.test.tsx
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test.failing(
+  "board solderMaskColor and silkscreenColor reach the pcb_board",
+  async () => {
+    const { circuit } = getTestFixture()
+
+    circuit.add(
+      <board
+        width={20}
+        height={20}
+        solderMaskColor="black"
+        silkscreenColor="white"
+      />,
+    )
+
+    await circuit.renderUntilSettled()
+
+    const pcb_board = circuit.db.pcb_board.list()[0]
+    expect(pcb_board.solder_mask_color).toBe("black")
+    expect(pcb_board.silkscreen_color).toBe("white")
+  },
+)


### PR DESCRIPTION
Repro for tscircuit/tscircuit#3277.

`test.failing` documenting that `<board solderMaskColor="black" silkscreenColor="white">` renders without error but the props never reach `pcb_board` — `pcb_board.solder_mask_color` / `silkscreen_color` come back `undefined`. The fix flips this to passing.