### PR TITLE
Propagate board solderMaskColor/silkscreenColor to pcb_board

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -525,6 +525,12 @@ export class Board
         y: point.y + (props.outlineOffsetY ?? 0) + outlineTranslation.y,
       })),
       material: props.material,
+      ...(props.solderMaskColor !== undefined && {
+        solder_mask_color: props.solderMaskColor,
+      }),
+      ...(props.silkscreenColor !== undefined && {
+        silkscreen_color: props.silkscreenColor,
+      }),
 
       min_trace_width:
         subcircuitProps.minTraceWidth ?? jlcMinTolerances.min_trace_width,

--- a/tests/components/normal-components/board-solder-mask-color.test.tsx
+++ b/tests/components/normal-components/board-solder-mask-color.test.tsx
@@ -1,24 +1,21 @@
 import { test, expect } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test.failing(
-  "board solderMaskColor and silkscreenColor reach the pcb_board",
-  async () => {
-    const { circuit } = getTestFixture()
+test("board solderMaskColor and silkscreenColor reach the pcb_board", async () => {
+  const { circuit } = getTestFixture()
 
-    circuit.add(
-      <board
-        width={20}
-        height={20}
-        solderMaskColor="black"
-        silkscreenColor="white"
-      />,
-    )
+  circuit.add(
+    <board
+      width={20}
+      height={20}
+      solderMaskColor="black"
+      silkscreenColor="white"
+    />,
+  )
 
-    await circuit.renderUntilSettled()
+  await circuit.renderUntilSettled()
 
-    const pcb_board = circuit.db.pcb_board.list()[0]
-    expect(pcb_board.solder_mask_color).toBe("black")
-    expect(pcb_board.silkscreen_color).toBe("white")
-  },
-)
+  const pcb_board = circuit.db.pcb_board.list()[0]
+  expect(pcb_board.solder_mask_color).toBe("black")
+  expect(pcb_board.silkscreen_color).toBe("white")
+})


### PR DESCRIPTION
Closes tscircuit/tscircuit#3277. Repro: #2573.

The `<board>` `solderMaskColor`/`silkscreenColor` props typecheck and render fine, but `@tscircuit/core` never copied them into the `pcb_board` circuit-json element, so the value was a silent no-op (identical circuit-json regardless of the prop). `circuit-json`'s `pcb_board` already has `solder_mask_color`/`silkscreen_color` fields, so this just wires them through in `Board.ts` next to `material`. Flips the repro test to passing; sibling board tests unaffected.