### PR TITLE
fix(autorouter): wire autorouter traceClearance into the capacity router

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -760,6 +760,10 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
                 db,
                 minTraceWidth: Number(props.minTraceWidth ?? 0.15),
                 nominalTraceWidth: this.props.nominalTraceWidth,
+                defaultObstacleMargin:
+                  this.props.autorouter?.traceClearance != null
+                    ? distance.parse(this.props.autorouter.traceClearance)
+                    : undefined,
                 subcircuit_id: this.subcircuit_id,
                 subcircuitComponent: this,
               }).simpleRouteJson,
@@ -893,6 +897,10 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         db,
         minTraceWidth,
         nominalTraceWidth,
+        defaultObstacleMargin:
+          autorouterConfig.traceClearance != null
+            ? distance.parse(autorouterConfig.traceClearance)
+            : undefined,
         subcircuit_id: this.subcircuit_id,
         subcircuitComponent: this,
       })

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -27,6 +27,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   minBoardEdgeClearance,
   minViaHoleDiameter,
   minViaPadDiameter,
+  defaultObstacleMargin,
   nominalTraceWidth,
   subcircuitComponent,
 }: {
@@ -43,6 +44,8 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   minBoardEdgeClearance?: number
   minViaHoleDiameter?: number
   minViaPadDiameter?: number
+  /** trace-to-obstacle clearance for the capacity autorouter (mm) */
+  defaultObstacleMargin?: number
   subcircuitComponent?: {
     selectAll(selector: string): unknown[]
   }
@@ -628,6 +631,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
           : undefined,
       layerCount: board?.num_layers ?? 2,
       minTraceWidth: minTraceWidth ?? board?.min_trace_width ?? 0.1,
+      defaultObstacleMargin,
       minViaDiameter: resolvedMinViaPadDiameter,
       minViaHoleDiameter: resolvedMinViaHoleDiameter,
       minViaPadDiameter: resolvedMinViaPadDiameter,

--- a/tests/repros/repro-simple-route-json-45-degree.test.tsx
+++ b/tests/repros/repro-simple-route-json-45-degree.test.tsx
@@ -42,6 +42,7 @@ test("45 degree rects bug", () => {
         "minY": -2.45,
       },
       "connections": [],
+      "defaultObstacleMargin": undefined,
       "layerCount": 2,
       "minBoardEdgeClearance": 0.2,
       "minPadEdgeToPadEdgeClearance": 0.1,

--- a/tests/utils/autorouting/simple-route-json-default-obstacle-margin.test.tsx
+++ b/tests/utils/autorouting/simple-route-json-default-obstacle-margin.test.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// The board-level autorouter `traceClearance` is surfaced to the capacity
+// autorouter via SimpleRouteJson.defaultObstacleMargin, which sets the
+// trace-to-obstacle spacing. Before this it was dropped and the clearance
+// could not be configured.
+test("getSimpleRouteJsonFromCircuitJson forwards defaultObstacleMargin", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1000pF" footprint="0402" name="C1" />
+      <trace from="R1.pin1" to="C1.pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit
+    .getCircuitJson()
+    .filter((elm) => elm.type !== "pcb_trace")
+
+  const { simpleRouteJson: withMargin } = getSimpleRouteJsonFromCircuitJson({
+    circuitJson,
+    defaultObstacleMargin: 0.3,
+  })
+  expect(withMargin.defaultObstacleMargin).toBe(0.3)
+
+  const { simpleRouteJson: withoutMargin } = getSimpleRouteJsonFromCircuitJson({
+    circuitJson,
+  })
+  expect(withoutMargin.defaultObstacleMargin).toBeUndefined()
+})


### PR DESCRIPTION
## Problem

Setting `autorouter={{ traceClearance: ... }}` on a board/subcircuit has **no effect** — traces are routed at the same spacing regardless. The value is written to the pcb_group's `autorouter_configuration.trace_clearance` (Group.ts) but is never passed to the autorouter, so the capacity mesh router always falls back to its default obstacle margin.

## Fix

`SimpleRouteJson` already has a `defaultObstacleMargin` field — the trace-to-obstacle spacing the capacity solver reads (`obstacleMargin ?? srj.defaultObstacleMargin`). It just wasn't being set. This threads it through:

- `getSimpleRouteJsonFromCircuitJson` gains a `defaultObstacleMargin?` param and emits it on the returned `SimpleRouteJson`.
- `Group` passes the autorouter's `traceClearance` (parsed from `Distance` to mm) as `defaultObstacleMargin`, for both the local capacity autorouter and the legacy solve-endpoint path.

## Test

Adds `simple-route-json-default-obstacle-margin.test.tsx` asserting the field is forwarded when set and `undefined` otherwise. Neighboring autorouting tests still pass; typecheck clean.