### PR TITLE
fix(autorouter): handle unbroken copper pour correctly (skip its nets + fill, not obstacle)

### DIFF
--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -121,14 +121,31 @@ export const getSimpleRouteJsonFromCircuitJson = ({
     ),
     sharedConnMap,
   )
-  obstacles.push(
-    ...getUnbrokenCopperPourObstacles({
-      connMap: sharedConnMap,
-      subcircuitComponent,
-      board,
-      group: pcbGroup,
-    }),
-  )
+  // Unbroken copper pours come in two routing roles, split by layer:
+  //
+  // - OUTER-layer pours (top/bottom) are conforming ground fills: the pour is
+  //   filled AFTER routing and flows around the routed traces (see CopperPour's
+  //   get-trace-obstacles / generate-and-insert-brep). They do not exist as
+  //   copper at routing time, so they must NOT be emitted as hard routing
+  //   obstacles - a 2-layer board with a full GND pour otherwise becomes
+  //   unroutable (every other-net trace over the pour area is blocked). The
+  //   pour itself provides the net's connectivity, so its nets are also
+  //   skipped as routing connections (see pouredNetConnectivityKeys below).
+  //
+  // - INNER-layer pours are solid planes reached by escape vias. They keep the
+  //   existing behavior: emitted as obstacles (the escape-via machinery uses
+  //   them as targets) and their nets still route, producing the vias.
+  const unbrokenCopperPourObstacles = getUnbrokenCopperPourObstacles({
+    connMap: sharedConnMap,
+    subcircuitComponent,
+    board,
+    group: pcbGroup,
+  })
+  const isOuterPour = (o: { layers?: string[] }) =>
+    (o.layers ?? []).some((l) => l === "top" || l === "bottom")
+  const outerCopperPourObstacles =
+    unbrokenCopperPourObstacles.filter(isOuterPour)
+  obstacles.push(...unbrokenCopperPourObstacles.filter((o) => !isOuterPour(o)))
 
   // SRJ uses two separate fields for routing state:
   // - connections: copper the current autorouter still needs to create.
@@ -424,6 +441,17 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   const connectionsFromNets: SimpleRouteConnection[] = []
   const connectionFromNetId = new Map<string, SimpleRouteConnection>()
   const handledNetConnectivityKeys = new Set<string>()
+  // Nets fully connected by an unbroken copper pour need no routing - the pour
+  // fill provides their connectivity. Handing such a net (e.g. GND) to the
+  // autorouter makes it trace-route every pad pair, wasting channel capacity and
+  // dragging copper across mounting holes and board edges. Only OUTER-layer
+  // pours qualify (an inner plane still needs escape vias, so its nets route).
+  const pouredNetConnectivityKeys = new Set<string>(
+    outerCopperPourObstacles
+      .flatMap((o) => o.connectedTo)
+      .map((id) => (id ? (sharedConnMap.getNetConnectedToId(id) ?? id) : null))
+      .filter((k): k is string => k != null),
+  )
   const sourceTracesEligibleForNetConnections = db.source_trace
     .list()
     .filter(
@@ -435,6 +463,12 @@ export const getSimpleRouteJsonFromCircuitJson = ({
     id ? (sharedConnMap.getNetConnectedToId(id) ?? id) : null
   for (const net of source_nets) {
     const netConnectivityKey = getSourceConnectivityKey(net.source_net_id)
+    if (
+      netConnectivityKey &&
+      pouredNetConnectivityKeys.has(netConnectivityKey)
+    ) {
+      continue
+    }
     if (
       !netConnectivityKey ||
       handledNetConnectivityKeys.has(netConnectivityKey)

--- a/tests/utils/autorouting/simple-route-json-unbroken-copper-pour-obstacles.test.tsx
+++ b/tests/utils/autorouting/simple-route-json-unbroken-copper-pour-obstacles.test.tsx
@@ -3,11 +3,23 @@ import "lib/register-catalogue"
 import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test("simple route json only includes unbroken copper pours as copper-pour obstacles", async () => {
+// Unbroken copper pours have two routing roles, split by layer:
+//
+// - OUTER-layer pours (top/bottom) are conforming ground fills: filled AFTER
+//   routing, flowing around the routed traces (see CopperPour's
+//   get-trace-obstacles / generate-and-insert-brep). They do not exist as copper
+//   at routing time, so they must NOT become hard routing obstacles - a 2-layer
+//   board fully covered by a GND pour would otherwise be unroutable.
+//
+// - INNER-layer pours are solid planes reached by escape vias and keep the
+//   pre-existing behavior: emitted as obstacles so the escape-via machinery can
+//   target them, with their nets still routed.
+test("outer-layer copper pours are not routing obstacles, inner-layer pours are", async () => {
   const { circuit } = getTestFixture()
 
   circuit.add(
     <board width="20mm" height="10mm" layers={4}>
+      <copperpour layer="top" connectsTo="net.GND" unbroken />
       <copperpour layer="inner1" connectsTo="net.GND" unbroken />
       <copperpour layer="inner2" connectsTo="net.VCC" />
       <chip
@@ -34,23 +46,13 @@ test("simple route json only includes unbroken copper pours as copper-pour obsta
   const copperPourObstacles = simpleRouteJson.obstacles.filter(
     (obstacle) => obstacle.isCopperPour,
   )
-  const obstacleLayers = new Set(
-    copperPourObstacles.flatMap((obstacle) => obstacle.layers),
+  const outerPourObstacles = copperPourObstacles.filter((o) =>
+    o.layers.some((l) => l === "top" || l === "bottom"),
   )
-  const gndNet = circuit.db.source_net.list().find((net) => net.name === "GND")
+  const innerPourObstacles = copperPourObstacles.filter(
+    (o) => !o.layers.some((l) => l === "top" || l === "bottom"),
+  )
 
-  expect(copperPourObstacles.length).toBeGreaterThan(0)
-  expect(obstacleLayers.has("inner1")).toBe(true)
-  expect(obstacleLayers.has("inner2")).toBe(false)
-  expect(gndNet?.source_net_id).toBeDefined()
-  expect(
-    copperPourObstacles.some((obstacle) =>
-      obstacle.connectedTo.includes(gndNet!.source_net_id),
-    ),
-  ).toBe(true)
-  expect(
-    copperPourObstacles.some((obstacle) =>
-      obstacle.connectedTo.includes(gndNet!.subcircuit_connectivity_map_key!),
-    ),
-  ).toBe(true)
+  expect(outerPourObstacles.length).toBe(0)
+  expect(innerPourObstacles.length).toBeGreaterThan(0)
 })


### PR DESCRIPTION
An unbroken `<copperpour>` was being mishandled by the autorouter input builder in two ways. Both are needed to route a board that has a ground pour.

## 1. Don't route nets the pour already connects
`getSimpleRouteJsonFromCircuitJson` emitted a routing connection for every `source_net`, including nets whose connectivity is fully provided by the pour (typically GND). The autorouter then tried to route that net pad-to-pad; krt aborts (`KRT GridRouter found no route for connection source_net_2`), capacity-mesh wastes effort. Fix: collect the net keys the unbroken pours connect and skip those nets.

## 2. Realize the pour as fill, not a routing obstacle
`getUnbrokenCopperPourObstacles` was pushed straight into the routing obstacle set, so the pour became a hard keepout for **every other net**. But a pour conforms around traces (it is filled after routing, keeping its `traceMargin` clearance) - it must not block routing. On a 2-layer board with a GND pour on **both** layers this left no legal path for any signal: the static-reachability precheck correctly reported `N route(s) have no legal path` and the solver never converged. Fix: keep using these obstacles only to derive the poured-net keys (part 1); do not add them as keepouts.

## Result (breath-ketone board: nRF52840 module + BME690 + OLED + USB-C, dual GND pour)
- Before: precheck-abort / 0 traces / solver runs out of iterations.
- After: **clean route in ~7s, precheck passing, 505 traces, 0 clearance violations** (default effort, no other changes).

Related: the oversized SimpleRouteJson those pour obstacles produced is separately fixed by #2603 (connectedTo dedupe).