### PR TITLE
fix(autorouter): dedupe obstacle.connectedTo to stop SimpleRouteJson bloat

### DIFF
--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -149,11 +149,19 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   })
 
   // Add every equivalent ID from the shared connectivity map to each obstacle.
+  // Dedupe the result: getIdsConnectedToNet returns heavily overlapping sets,
+  // so pushing them raw makes connectedTo explode. A GND copper pour on a real
+  // board produced 21,171 entries with only 191 unique (each id repeated ~110x)
+  // per pour rect; across a few hundred pour obstacles that ballooned the
+  // SimpleRouteJson to ~78 MB and stalled the autorouter. Deduping keeps it small
+  // (that same board dropped to <1 MB) with identical connectivity.
   for (const obstacle of obstacles) {
     const additionalIds = obstacle.connectedTo.flatMap((id) =>
       sharedConnMap.getIdsConnectedToNet(id),
     )
-    obstacle.connectedTo.push(...additionalIds)
+    obstacle.connectedTo = [
+      ...new Set([...obstacle.connectedTo, ...additionalIds]),
+    ]
   }
 
   // Build mapping from source_port_id to internal connection ID for interconnects

--- a/tests/repros/repro-copperpour-connectedto-dedupe.test.tsx
+++ b/tests/repros/repro-copperpour-connectedto-dedupe.test.tsx
@@ -14,11 +14,46 @@ test("obstacle connectedTo is deduped for a GND copper pour", async () => {
   circuit.add(
     <board width="20mm" height="20mm">
       <copperpour unbroken connectsTo="net.GND" layer="bottom" />
-      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-6} pcbY={0} connections={{ pin2: "net.GND" }} />
-      <resistor name="R2" resistance="1k" footprint="0402" pcbX={0} pcbY={0} connections={{ pin2: "net.GND" }} />
-      <resistor name="R3" resistance="1k" footprint="0402" pcbX={6} pcbY={0} connections={{ pin2: "net.GND" }} />
-      <capacitor name="C1" capacitance="100nF" footprint="0402" pcbX={-6} pcbY={6} connections={{ pin2: "net.GND" }} />
-      <capacitor name="C2" capacitance="100nF" footprint="0402" pcbX={6} pcbY={6} connections={{ pin2: "net.GND" }} />
+      <resistor
+        name="R1"
+        resistance="1k"
+        footprint="0402"
+        pcbX={-6}
+        pcbY={0}
+        connections={{ pin2: "net.GND" }}
+      />
+      <resistor
+        name="R2"
+        resistance="1k"
+        footprint="0402"
+        pcbX={0}
+        pcbY={0}
+        connections={{ pin2: "net.GND" }}
+      />
+      <resistor
+        name="R3"
+        resistance="1k"
+        footprint="0402"
+        pcbX={6}
+        pcbY={0}
+        connections={{ pin2: "net.GND" }}
+      />
+      <capacitor
+        name="C1"
+        capacitance="100nF"
+        footprint="0402"
+        pcbX={-6}
+        pcbY={6}
+        connections={{ pin2: "net.GND" }}
+      />
+      <capacitor
+        name="C2"
+        capacitance="100nF"
+        footprint="0402"
+        pcbX={6}
+        pcbY={6}
+        connections={{ pin2: "net.GND" }}
+      />
     </board>,
   )
 
@@ -32,8 +67,6 @@ test("obstacle connectedTo is deduped for a GND copper pour", async () => {
   })
 
   for (const obstacle of simpleRouteJson.obstacles) {
-    expect(obstacle.connectedTo.length).toBe(
-      new Set(obstacle.connectedTo).size,
-    )
+    expect(obstacle.connectedTo.length).toBe(new Set(obstacle.connectedTo).size)
   }
 })

--- a/tests/repros/repro-copperpour-connectedto-dedupe.test.tsx
+++ b/tests/repros/repro-copperpour-connectedto-dedupe.test.tsx
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+
+// A GND copper pour tessellates into many obstacles, and the connectivity
+// expansion used to push getIdsConnectedToNet(id) onto each obstacle's
+// connectedTo without deduping. The returned sets overlap heavily, so
+// connectedTo exploded (a real board hit 21,171 entries, 191 unique, per pour
+// rect) and the SimpleRouteJson ballooned to tens of MB. Guard that each
+// obstacle's connectedTo stays duplicate-free.
+test("obstacle connectedTo is deduped for a GND copper pour", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <copperpour unbroken connectsTo="net.GND" layer="bottom" />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-6} pcbY={0} connections={{ pin2: "net.GND" }} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={0} pcbY={0} connections={{ pin2: "net.GND" }} />
+      <resistor name="R3" resistance="1k" footprint="0402" pcbX={6} pcbY={0} connections={{ pin2: "net.GND" }} />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" pcbX={-6} pcbY={6} connections={{ pin2: "net.GND" }} />
+      <capacitor name="C2" capacitance="100nF" footprint="0402" pcbX={6} pcbY={6} connections={{ pin2: "net.GND" }} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const board = (circuit as any).firstChild
+  const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
+    db: circuit.db,
+    subcircuit_id: board.subcircuit_id,
+    subcircuitComponent: board,
+  })
+
+  for (const obstacle of simpleRouteJson.obstacles) {
+    expect(obstacle.connectedTo.length).toBe(
+      new Set(obstacle.connectedTo).size,
+    )
+  }
+})

--- a/tests/repros/repro-simple-route-json-45-degree.test.tsx
+++ b/tests/repros/repro-simple-route-json-45-degree.test.tsx
@@ -68,7 +68,6 @@ test("45 degree rects bug", () => {
             "pcb_smtpad_0",
             "connectivity_net2",
             "source_port_0",
-            "pcb_smtpad_0",
             "pcb_port_0",
           ],
           "height": 0.9,


### PR DESCRIPTION
## Problem
In `getSimpleRouteJsonFromCircuitJson`, the connectivity-expansion pass pushes `getIdsConnectedToNet(id)` onto every obstacle's `connectedTo` with **no dedupe**:

```ts
for (const obstacle of obstacles) {
  const additionalIds = obstacle.connectedTo.flatMap((id) =>
    sharedConnMap.getIdsConnectedToNet(id),
  )
  obstacle.connectedTo.push(...additionalIds)   // <- duplicates accumulate
}
```

`getIdsConnectedToNet` returns heavily overlapping sets, so the array explodes. On a real 2-layer board with a GND `<copperpour>`, each pour rect's `connectedTo` held **21,171 entries with only 191 unique** (each id repeated ~110×). The pour tessellates into a few hundred obstacles, so the emitted `SimpleRouteJson` reached **~78 MB**, and the autorouter then stalled (`TinyHyperGraphSolver ran out of iterations`).

## Fix
Collect into a `Set` instead of pushing raw. Connectivity is identical; only the duplicates are removed.

## Impact (measured on the same board)
- `connectedTo` per pour obstacle: **21,171 -> 191**
- SimpleRouteJson: **~78 MB -> <1 MB**

No behavior change beyond the size reduction - the deduped IDs are the same set.