### PR TITLE
Update copper pour solver to 0.0.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@tscircuit/checks": "0.0.142",
     "@tscircuit/circuit-json-util": "^0.0.97",
     "@tscircuit/common": "^0.0.20",
-    "@tscircuit/copper-pour-solver": "0.0.35",
+    "@tscircuit/copper-pour-solver": "0.0.37",
     "@tscircuit/footprinter": "^0.0.371",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/infer-cable-insertion-point": "^0.0.2",


### PR DESCRIPTION
## Summary

- update `@tscircuit/copper-pour-solver` from `0.0.35` to `0.0.37`
- pick up the latest copper-pour solver fixes and improvements in `@tscircuit/core`

## Validation

- `bun test tests/components/primitive-components/copperpour-with-via.test.tsx tests/components/primitive-components/copperpour-multiple-outlines.test.tsx tests/components/primitive-components/copperpour-connectsto-net.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format`

The full test suite was also exercised locally. Copper-pour coverage passed; environment-dependent tests requiring local listeners, remote model assets, or the simulation backend could not run inside the sandbox.
