### PR TITLE
Warn when chips use reserved refdes prefixes

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialCheckRefDesConvention.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialCheckRefDesConvention.ts
@@ -39,6 +39,19 @@ export const getDefaultExpectedRefDesPrefixesForFtype = (
 const getRefDesPrefix = (refDes: string): string | undefined =>
   refDes.match(/^[A-Za-z]+/)?.[0]?.toUpperCase()
 
+const refDesPrefixesReservedForNonChipComponents = [
+  "J",
+  "Q",
+  "C",
+  "R",
+  "L",
+  "Y",
+  "X",
+  "F",
+  "S",
+  "TP",
+]
+
 export const NormalComponent_doInitialCheckRefDesConvention = (
   component: NormalComponent,
 ) => {
@@ -48,10 +61,22 @@ export const NormalComponent_doInitialCheckRefDesConvention = (
   const sourceComponent = db.source_component.get(component.source_component_id)
   if (!sourceComponent?.name || !sourceComponent.ftype) return
 
-  const expectedPrefixes = component.getRefDesPrefixes()
+  const actualPrefix = getRefDesPrefix(sourceComponent.name)
+  const isChipUsingReservedPrefix =
+    component.componentName === "Chip" &&
+    sourceComponent.ftype === "simple_chip" &&
+    actualPrefix !== undefined &&
+    refDesPrefixesReservedForNonChipComponents.some((prefix) =>
+      actualPrefix.startsWith(prefix),
+    )
+
+  const expectedPrefixes =
+    component.getRefDesPrefixes() ??
+    (isChipUsingReservedPrefix
+      ? getDefaultExpectedRefDesPrefixesForFtype("simple_chip")
+      : undefined)
   if (!expectedPrefixes || expectedPrefixes.length === 0) return
 
-  const actualPrefix = getRefDesPrefix(sourceComponent.name)
   if (actualPrefix && expectedPrefixes.includes(actualPrefix)) return
 
   const expectedPrefixMessage =

--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialCheckRefDesConvention.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialCheckRefDesConvention.ts
@@ -39,17 +39,17 @@ export const getDefaultExpectedRefDesPrefixesForFtype = (
 const getRefDesPrefix = (refDes: string): string | undefined =>
   refDes.match(/^[A-Za-z]+/)?.[0]?.toUpperCase()
 
-const refDesPrefixesReservedForNonChipComponents = [
-  "J",
-  "Q",
-  "C",
-  "R",
-  "L",
-  "Y",
-  "X",
-  "F",
-  "S",
-  "TP",
+const chipRefDesRecommendations = [
+  { prefix: "J", recommendation: "a <connector /> or <jumper />" },
+  { prefix: "Q", recommendation: "a <transistor />" },
+  { prefix: "C", recommendation: "a <capacitor />" },
+  { prefix: "R", recommendation: "a <resistor />" },
+  { prefix: "L", recommendation: "an <inductor />" },
+  { prefix: "Y", recommendation: "a <crystal />" },
+  { prefix: "X", recommendation: "a <crystal />" },
+  { prefix: "F", recommendation: "a <fuse />" },
+  { prefix: "S", recommendation: "a <switch /> or <pushbutton />" },
+  { prefix: "TP", recommendation: "a <testpoint />" },
 ]
 
 export const NormalComponent_doInitialCheckRefDesConvention = (
@@ -62,17 +62,18 @@ export const NormalComponent_doInitialCheckRefDesConvention = (
   if (!sourceComponent?.name || !sourceComponent.ftype) return
 
   const actualPrefix = getRefDesPrefix(sourceComponent.name)
-  const isChipUsingReservedPrefix =
+  const chipRefDesRecommendation =
     component.componentName === "Chip" &&
     sourceComponent.ftype === "simple_chip" &&
-    actualPrefix !== undefined &&
-    refDesPrefixesReservedForNonChipComponents.some((prefix) =>
-      actualPrefix.startsWith(prefix),
-    )
+    actualPrefix !== undefined
+      ? chipRefDesRecommendations.find(({ prefix }) =>
+          actualPrefix.startsWith(prefix),
+        )
+      : undefined
 
   const expectedPrefixes =
     component.getRefDesPrefixes() ??
-    (isChipUsingReservedPrefix
+    (chipRefDesRecommendation
       ? getDefaultExpectedRefDesPrefixesForFtype("simple_chip")
       : undefined)
   if (!expectedPrefixes || expectedPrefixes.length === 0) return
@@ -83,11 +84,14 @@ export const NormalComponent_doInitialCheckRefDesConvention = (
     expectedPrefixes.length === 1
       ? expectedPrefixes[0]
       : `one of ${expectedPrefixes.join(", ")}`
+  const message = chipRefDesRecommendation
+    ? `The "${chipRefDesRecommendation.prefix}" prefix is being used with a <chip />, try using it with ${chipRefDesRecommendation.recommendation}`
+    : `Component ${sourceComponent.name} has ftype="${sourceComponent.ftype}" but reference designator should start with ${expectedPrefixMessage}`
 
   db.insert({
     type: "source_refdes_convention_warning",
     warning_type: "source_refdes_convention_warning",
-    message: `Component ${sourceComponent.name} has ftype="${sourceComponent.ftype}" but reference designator should start with ${expectedPrefixMessage}`,
+    message,
     source_component_id: sourceComponent.source_component_id,
     refdes: sourceComponent.name,
     source_component_ftype: sourceComponent.ftype,

--- a/tests/components/normal-components/chip-source-refdes-convention-warning.test.tsx
+++ b/tests/components/normal-components/chip-source-refdes-convention-warning.test.tsx
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("source_refdes_convention_warning is emitted when a chip uses a refdes reserved for another component type", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board>
+      <chip name="J1" />
+      <chip name="Q1" />
+      <chip name="C1" />
+      <chip name="R1" />
+      <chip name="L1" />
+      <chip name="Y1" />
+      <chip name="X1" />
+      <chip name="F1" />
+      <chip name="S1" />
+      <chip name="TP1" />
+      <chip name="U1" />
+      <jumper name="J2" />
+      <connector name="J3" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const warnings = (circuit.db as any).source_refdes_convention_warning.list()
+
+  expect(warnings).toHaveLength(10)
+  expect(warnings.map((warning: any) => warning.refdes).sort()).toEqual(
+    ["J1", "Q1", "C1", "R1", "L1", "Y1", "X1", "F1", "S1", "TP1"].sort(),
+  )
+  expect(warnings).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ actual_prefix: "J" }),
+      expect.objectContaining({ actual_prefix: "Q" }),
+      expect.objectContaining({ actual_prefix: "C" }),
+      expect.objectContaining({ actual_prefix: "R" }),
+      expect.objectContaining({ actual_prefix: "L" }),
+      expect.objectContaining({ actual_prefix: "Y" }),
+      expect.objectContaining({ actual_prefix: "X" }),
+      expect.objectContaining({ actual_prefix: "F" }),
+      expect.objectContaining({ actual_prefix: "S" }),
+      expect.objectContaining({ actual_prefix: "TP" }),
+    ]),
+  )
+  for (const warning of warnings) {
+    expect(warning).toMatchObject({
+      type: "source_refdes_convention_warning",
+      warning_type: "source_refdes_convention_warning",
+      source_component_ftype: "simple_chip",
+      expected_prefixes: ["U", "IC"],
+    })
+  }
+})

--- a/tests/components/normal-components/chip-source-refdes-convention-warning.test.tsx
+++ b/tests/components/normal-components/chip-source-refdes-convention-warning.test.tsx
@@ -30,6 +30,18 @@ test("source_refdes_convention_warning is emitted when a chip uses a refdes rese
   expect(warnings.map((warning: any) => warning.refdes).sort()).toEqual(
     ["J1", "Q1", "C1", "R1", "L1", "Y1", "X1", "F1", "S1", "TP1"].sort(),
   )
+  const expectedMessagesByRefDes: Record<string, string> = {
+    J1: 'The "J" prefix is being used with a <chip />, try using it with a <connector /> or <jumper />',
+    Q1: 'The "Q" prefix is being used with a <chip />, try using it with a <transistor />',
+    C1: 'The "C" prefix is being used with a <chip />, try using it with a <capacitor />',
+    R1: 'The "R" prefix is being used with a <chip />, try using it with a <resistor />',
+    L1: 'The "L" prefix is being used with a <chip />, try using it with an <inductor />',
+    Y1: 'The "Y" prefix is being used with a <chip />, try using it with a <crystal />',
+    X1: 'The "X" prefix is being used with a <chip />, try using it with a <crystal />',
+    F1: 'The "F" prefix is being used with a <chip />, try using it with a <fuse />',
+    S1: 'The "S" prefix is being used with a <chip />, try using it with a <switch /> or <pushbutton />',
+    TP1: 'The "TP" prefix is being used with a <chip />, try using it with a <testpoint />',
+  }
   expect(warnings).toEqual(
     expect.arrayContaining([
       expect.objectContaining({ actual_prefix: "J" }),
@@ -50,6 +62,7 @@ test("source_refdes_convention_warning is emitted when a chip uses a refdes rese
       warning_type: "source_refdes_convention_warning",
       source_component_ftype: "simple_chip",
       expected_prefixes: ["U", "IC"],
+      message: expectedMessagesByRefDes[warning.refdes],
     })
   }
 })


### PR DESCRIPTION
## Summary

- emit `source_refdes_convention_warning` when a generic chip uses a refdes prefix reserved for connectors, transistors, capacitors, resistors, inductors, crystals, fuses, switches, or test points
- keep actual connectors and jumpers exempt from the `J*` chip warning
- cover every reserved prefix and valid control components in a focused test

## Why

Generic `<chip>` components source-render as `simple_chip`, but do not expose a default source ftype through their component config. As a result, the existing convention checker skipped them entirely and could not flag refdes names that strongly indicate a more specific component primitive should be used.

## Impact

Authors now receive a Circuit JSON warning for generic chips named with `J*`, `Q*`, `C*`, `R*`, `L*`, `Y*`, `X*`, `F*`, `S*`, or `TP*`. Valid `U*` chips and actual connector/jumper components are unchanged.

## Validation

- `bun test tests/components/normal-components/chip-source-refdes-convention-warning.test.tsx tests/components/normal-components/source-refdes-convention-warning.test.tsx`
- `bunx biome check lib/components/base-components/NormalComponent/NormalComponent_doInitialCheckRefDesConvention.ts tests/components/normal-components/chip-source-refdes-convention-warning.test.tsx`
- `bunx tsc --noEmit`
- `git diff --check`
