### PR TITLE
Fix SRJ obstacles for rotated and polygon SMT pads

### DIFF
--- a/lib/utils/obstacles/getAxisAlignedRectFromPolygon.ts
+++ b/lib/utils/obstacles/getAxisAlignedRectFromPolygon.ts
@@ -1,0 +1,33 @@
+export const getAxisAlignedRectFromPolygon = (
+  points: Array<{ x: number; y: number }>,
+): {
+  center: { x: number; y: number }
+  width: number
+  height: number
+} | null => {
+  if (points.length !== 4) return null
+
+  const xs = [...new Set(points.map((point) => point.x))]
+  const ys = [...new Set(points.map((point) => point.y))]
+  if (xs.length !== 2 || ys.length !== 2) return null
+
+  const minX = Math.min(...xs)
+  const maxX = Math.max(...xs)
+  const minY = Math.min(...ys)
+  const maxY = Math.max(...ys)
+  const corners = new Set(points.map((point) => `${point.x},${point.y}`))
+  const expectedCorners = [
+    `${minX},${minY}`,
+    `${minX},${maxY}`,
+    `${maxX},${minY}`,
+    `${maxX},${maxY}`,
+  ]
+
+  if (!expectedCorners.every((corner) => corners.has(corner))) return null
+
+  return {
+    center: { x: (minX + maxX) / 2, y: (minY + maxY) / 2 },
+    width: maxX - minX,
+    height: maxY - minY,
+  }
+}

--- a/lib/utils/obstacles/getAxisAlignedRectFromPolygon.ts
+++ b/lib/utils/obstacles/getAxisAlignedRectFromPolygon.ts
@@ -1,3 +1,5 @@
+const AXIS_ALIGNED_RECT_TOLERANCE_MM = 1e-3
+
 export const getAxisAlignedRectFromPolygon = (
   points: Array<{ x: number; y: number }>,
 ): {
@@ -5,8 +7,8 @@ export const getAxisAlignedRectFromPolygon = (
   width: number
   height: number
 } | null => {
-  const tolerance = 1e-3
-  const isCloseTo = (a: number, b: number) => Math.abs(a - b) <= tolerance
+  const isCloseTo = (a: number, b: number) =>
+    Math.abs(a - b) <= AXIS_ALIGNED_RECT_TOLERANCE_MM
   const normalizedPoints = points.filter(
     (point, index) =>
       index === 0 ||

--- a/lib/utils/obstacles/getAxisAlignedRectFromPolygon.ts
+++ b/lib/utils/obstacles/getAxisAlignedRectFromPolygon.ts
@@ -5,25 +5,52 @@ export const getAxisAlignedRectFromPolygon = (
   width: number
   height: number
 } | null => {
-  if (points.length !== 4) return null
+  const tolerance = 1e-3
+  const isCloseTo = (a: number, b: number) => Math.abs(a - b) <= tolerance
+  const normalizedPoints = points.filter(
+    (point, index) =>
+      index === 0 ||
+      !isCloseTo(point.x, points[index - 1].x) ||
+      !isCloseTo(point.y, points[index - 1].y),
+  )
 
-  const xs = [...new Set(points.map((point) => point.x))]
-  const ys = [...new Set(points.map((point) => point.y))]
-  if (xs.length !== 2 || ys.length !== 2) return null
+  if (
+    normalizedPoints.length > 1 &&
+    isCloseTo(normalizedPoints[0].x, normalizedPoints.at(-1)!.x) &&
+    isCloseTo(normalizedPoints[0].y, normalizedPoints.at(-1)!.y)
+  ) {
+    normalizedPoints.pop()
+  }
 
-  const minX = Math.min(...xs)
-  const maxX = Math.max(...xs)
-  const minY = Math.min(...ys)
-  const maxY = Math.max(...ys)
-  const corners = new Set(points.map((point) => `${point.x},${point.y}`))
+  if (normalizedPoints.length < 4) return null
+
+  const minX = Math.min(...normalizedPoints.map((point) => point.x))
+  const maxX = Math.max(...normalizedPoints.map((point) => point.x))
+  const minY = Math.min(...normalizedPoints.map((point) => point.y))
+  const maxY = Math.max(...normalizedPoints.map((point) => point.y))
   const expectedCorners = [
-    `${minX},${minY}`,
-    `${minX},${maxY}`,
-    `${maxX},${minY}`,
-    `${maxX},${maxY}`,
+    { x: minX, y: minY },
+    { x: minX, y: maxY },
+    { x: maxX, y: minY },
+    { x: maxX, y: maxY },
   ]
 
-  if (!expectedCorners.every((corner) => corners.has(corner))) return null
+  if (
+    !normalizedPoints.every(
+      (point) =>
+        isCloseTo(point.x, minX) ||
+        isCloseTo(point.x, maxX) ||
+        isCloseTo(point.y, minY) ||
+        isCloseTo(point.y, maxY),
+    ) ||
+    !expectedCorners.every((corner) =>
+      normalizedPoints.some(
+        (point) => isCloseTo(point.x, corner.x) && isCloseTo(point.y, corner.y),
+      ),
+    )
+  ) {
+    return null
+  }
 
   return {
     center: { x: (minX + maxX) / 2, y: (minY + maxY) / 2 },

--- a/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
+++ b/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
@@ -1,9 +1,10 @@
-import { getObstaclesFromRoute } from "./getObstaclesFromRoute"
-import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type { AnyCircuitElement } from "circuit-json"
-import { type RotatedRect } from "./generateApproximatingRects"
-import { fillPolygonWithRects } from "./fillPolygonWithRects"
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import { fillCircleWithRects } from "./fillCircleWithRects"
+import { fillPolygonWithRects } from "./fillPolygonWithRects"
+import { type RotatedRect } from "./generateApproximatingRects"
+import { getAxisAlignedRectFromPolygon } from "./getAxisAlignedRectFromPolygon"
+import { getObstaclesFromRoute } from "./getObstaclesFromRoute"
 import type { Obstacle } from "./types"
 
 const EVERY_LAYER = ["top", "inner1", "inner2", "bottom"]
@@ -99,7 +100,9 @@ export const getObstaclesFromCircuitJson = (
           center: rect.center,
           width: rect.width,
           height: rect.height,
-          ccwRotationDegrees: element.ccw_rotation,
+          ccwRotationDegrees: axisAlignedRect
+            ? undefined
+            : element.ccw_rotation,
           connectedTo: withNetId([element.pcb_smtpad_id]),
         })
       } else if (element.shape === "pill" || element.shape === "rotated_pill") {
@@ -119,25 +122,36 @@ export const getObstaclesFromCircuitJson = (
           connectedTo: withNetId([element.pcb_smtpad_id]),
         })
       } else if (element.shape === "polygon") {
-        const xs = element.points.map((point) => point.x)
-        const ys = element.points.map((point) => point.y)
-        const minX = Math.min(...xs)
-        const maxX = Math.max(...xs)
-        const minY = Math.min(...ys)
-        const maxY = Math.max(...ys)
+        const axisAlignedRect = getAxisAlignedRectFromPolygon(element.points)
+        if (axisAlignedRect) {
+          obstacles.push({
+            componentId: pcbComponentId,
+            type: "rect",
+            layers: [element.layer],
+            ...axisAlignedRect,
+            connectedTo: withNetId([element.pcb_smtpad_id]),
+          })
+          continue
+        }
 
-        obstacles.push({
-          componentId: pcbComponentId,
-          type: "rect",
-          layers: [element.layer],
-          center: {
-            x: (minX + maxX) / 2,
-            y: (minY + maxY) / 2,
-          },
-          width: maxX - minX,
-          height: maxY - minY,
-          connectedTo: withNetId([element.pcb_smtpad_id]),
+        // A polygon pad may be concave (for example, the curved FAKRA pads
+        // in gmsl-serializer). Its bounding box would block the pad's empty
+        // interior, so approximate its actual copper area with scanlines.
+        const approximatingRects = fillPolygonWithRects(element.points, {
+          rectHeight: 0.1,
         })
+
+        for (const rect of approximatingRects) {
+          obstacles.push({
+            componentId: pcbComponentId,
+            type: "rect",
+            layers: [element.layer],
+            center: rect.center,
+            width: rect.width,
+            height: rect.height,
+            connectedTo: withNetId([element.pcb_smtpad_id]),
+          })
+        }
       }
     } else if (element.type === "pcb_keepout") {
       if (element.shape === "circle") {

--- a/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
+++ b/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
@@ -134,9 +134,6 @@ export const getObstaclesFromCircuitJson = (
           continue
         }
 
-        // A polygon pad may be concave (for example, the curved FAKRA pads
-        // in gmsl-serializer). Its bounding box would block the pad's empty
-        // interior, so approximate its actual copper area with scanlines.
         const approximatingRects = fillPolygonWithRects(element.points, {
           rectHeight: 0.1,
         })

--- a/tests/repros/repro131-overlapping-same-net-crossing-segment.test.tsx
+++ b/tests/repros/repro131-overlapping-same-net-crossing-segment.test.tsx
@@ -498,10 +498,14 @@ const Repro131Subcircuit = (props: SubcircuitProps) => (
   </subcircuit>
 )
 
-test("repro131: overlapping same-net crossing segments", async () => {
-  const { circuit } = getTestFixture()
-  circuit.add(<Repro131Subcircuit />)
-  await circuit.renderUntilSettled()
+test(
+  "repro131: overlapping same-net crossing segments",
+  async () => {
+    const { circuit } = getTestFixture()
+    circuit.add(<Repro131Subcircuit />)
+    await circuit.renderUntilSettled()
 
-  expect(circuit).toMatchSchematicSnapshot(import.meta.path)
-})
+    expect(circuit).toMatchSchematicSnapshot(import.meta.path)
+  },
+  { timeout: 40000 },
+)

--- a/tests/utils/autorouting/simple-route-json-axis-aligned-rotated-rect-obstacles.test.tsx
+++ b/tests/utils/autorouting/simple-route-json-axis-aligned-rotated-rect-obstacles.test.tsx
@@ -91,5 +91,6 @@ test("axis-aligned rotated_rect pads become single simple-route obstacles", asyn
     expect(obstacle.center.y).toBeCloseTo(pad.y, 6)
     expect(obstacle.width).toBeCloseTo(isVertical ? pad.height : pad.width, 6)
     expect(obstacle.height).toBeCloseTo(isVertical ? pad.width : pad.height, 6)
+    expect(obstacle.ccwRotationDegrees).toBeUndefined()
   }
 })


### PR DESCRIPTION
 Preserve axis-aligned rotated pad orientation without applying rotation twice. Approximate non-rectangular polygon pads with scanline obstacles so curved pads retain their empty interior, while keeping rectangular polygons as single obstacles.
before:
<img width="880" height="634" alt="image" src="https://github.com/user-attachments/assets/68ea0899-e44d-430d-85fd-4abc912d91f6" />
after:
<img width="612" height="480" alt="image" src="https://github.com/user-attachments/assets/a809d776-8947-4bd7-a897-d3ad0cc301f0" />

