### PR TITLE
Update copper pour solver to 0.0.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@tscircuit/checks": "0.0.142",
     "@tscircuit/circuit-json-util": "^0.0.97",
     "@tscircuit/common": "^0.0.20",
-    "@tscircuit/copper-pour-solver": "0.0.37",
+    "@tscircuit/copper-pour-solver": "0.0.38",
     "@tscircuit/footprinter": "^0.0.371",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/infer-cable-insertion-point": "^0.0.2",


### PR DESCRIPTION
## Summary
- update `@tscircuit/copper-pour-solver` from `0.0.37` to `0.0.38`
- adopt `@tscircuit/manifold-2d@0.0.4`, which fixes browser/worker WASM loading and has no production dependencies
- continue the manifold-free release path into `@tscircuit/core`

## Verification
- five focused copper-pour tests: 5 passed
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format`
- `git diff --check`

`@tscircuit/copper-pour-solver@0.0.38` declares only `@tscircuit/manifold-2d@0.0.4`; it does not depend on `manifold-3d`.