### PR TITLE
Cache local autorouting results per phase

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -1061,12 +1061,15 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         simpleRouteJson,
       })
 
-      const cacheEngine = this.root?.platform?.localCacheEngine
-      const cacheKey = getLocalAutoroutingCacheKey(simpleRouteJson)
-      const cachedResult = await getCachedLocalAutoroutingPhaseResult({
-        cacheEngine,
-        cacheKey,
-      })
+      const cacheEngine = phaseAutorouterConfig.algorithmFn
+        ? undefined
+        : this.root?.platform?.localCacheEngine
+      const cacheKey = cacheEngine
+        ? getLocalAutoroutingCacheKey(simpleRouteJson)
+        : undefined
+      const cachedResult = cacheKey
+        ? await getCachedLocalAutoroutingPhaseResult({ cacheEngine, cacheKey })
+        : null
       let autorouter: GenericLocalAutorouter | undefined
 
       try {
@@ -1140,7 +1143,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
           traces,
         }
 
-        if (!cachedResult) {
+        if (!cachedResult && cacheKey) {
           await cacheLocalAutoroutingPhaseResult({
             cacheEngine,
             cacheKey,

--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -72,6 +72,11 @@ import { Group_doInitialSimulationSpiceEngineRender } from "./Group_doInitialSim
 import { Group_doInitialSourceAddConnectivityMapKey } from "./Group_doInitialSourceAddConnectivityMapKey"
 import { Group_getRoutingPhasePlans } from "./Group_getRoutingPhasePlans"
 import {
+  cacheLocalAutoroutingPhaseResult,
+  getCachedLocalAutoroutingPhaseResult,
+  getLocalAutoroutingCacheKey,
+} from "./Group_localAutoroutingCache"
+import {
   Group_applyDrcTolerancesToSimpleRouteJson,
   Group_filterSimpleRouteJsonForPhase,
   Group_getObstaclesFromRoutedTraces,
@@ -1056,69 +1061,91 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         simpleRouteJson,
       })
 
-      // Create the autorouter instance
-      let autorouter: GenericLocalAutorouter
-      if (phaseAutorouterConfig.algorithmFn) {
-        autorouter = await phaseAutorouterConfig.algorithmFn(simpleRouteJson)
-      } else {
-        const autorouterVersion = this.props.autorouterVersion
-        const effortLevel = this.props.autorouterEffortLevel
-        const effort = effortLevel
-          ? Number.parseInt(effortLevel.replace("x", ""), 10)
-          : undefined
-        autorouter = new TscircuitAutorouter(simpleRouteJson, {
-          // Optional configuration parameters
-          capacityDepth: phaseAutorouterConfig.capacityDepth,
-          targetMinCapacity: phaseAutorouterConfig.targetMinCapacity,
-          useAssignableSolver: phaseIsLaserPrefabPreset || isSingleLayerBoard,
-          useAutoJumperSolver: phaseIsAutoJumperPreset,
-          useLaserPrefabSolver: phaseIsLaserPrefabPreset,
-          autorouterVersion,
-          effort,
-          onSolverStarted: ({ solverName, solverParams }) =>
-            this.root?.emit("solver:started", {
-              type: "solver:started",
-              solverName,
-              solverParams,
-              componentName: this.getString(),
-            }),
-        })
-      }
-
-      // Create a promise that will resolve when autorouting is complete
-      const routingPromise = new Promise<SimplifiedPcbTrace[]>(
-        (resolve, reject) => {
-          autorouter.on("complete", (event) => {
-            debug(`[${this.getString()}] local autorouting complete`)
-            resolve(event.traces)
-          })
-
-          autorouter.on("error", (event) => {
-            debug(
-              `[${this.getString()}] local autorouting error: ${event.error.message}`,
-            )
-            reject(event.error)
-          })
-        },
-      )
-
-      autorouter.on("progress", (event) => {
-        this.root?.emit("autorouting:progress", {
-          subcircuit_id: this.subcircuit_id,
-          componentDisplayName: this.getString(),
-          ...event,
-        })
+      const cacheEngine = this.root?.platform?.localCacheEngine
+      const cacheKey = getLocalAutoroutingCacheKey(simpleRouteJson)
+      const cachedResult = await getCachedLocalAutoroutingPhaseResult({
+        cacheEngine,
+        cacheKey,
       })
-
-      // Start the autorouting process
-      autorouter.start()
+      let autorouter: GenericLocalAutorouter | undefined
 
       try {
-        // Wait for the autorouting to complete
-        const traces = await routingPromise
+        let traces: SimplifiedPcbTrace[]
+        if (cachedResult) {
+          debug(`[${this.getString()}] using cached local autorouting result`)
+          traces = cachedResult.traces
+        } else {
+          if (phaseAutorouterConfig.algorithmFn) {
+            autorouter =
+              await phaseAutorouterConfig.algorithmFn(simpleRouteJson)
+          } else {
+            const autorouterVersion = this.props.autorouterVersion
+            const effortLevel = this.props.autorouterEffortLevel
+            const effort = effortLevel
+              ? Number.parseInt(effortLevel.replace("x", ""), 10)
+              : undefined
+            autorouter = new TscircuitAutorouter(simpleRouteJson, {
+              capacityDepth: phaseAutorouterConfig.capacityDepth,
+              targetMinCapacity: phaseAutorouterConfig.targetMinCapacity,
+              useAssignableSolver:
+                phaseIsLaserPrefabPreset || isSingleLayerBoard,
+              useAutoJumperSolver: phaseIsAutoJumperPreset,
+              useLaserPrefabSolver: phaseIsLaserPrefabPreset,
+              autorouterVersion,
+              effort,
+              onSolverStarted: ({ solverName, solverParams }) =>
+                this.root?.emit("solver:started", {
+                  type: "solver:started",
+                  solverName,
+                  solverParams,
+                  componentName: this.getString(),
+                }),
+            })
+          }
+
+          if (!autorouter) {
+            throw new Error("Failed to create local autorouter")
+          }
+          const activeAutorouter = autorouter
+          const routingPromise = new Promise<SimplifiedPcbTrace[]>(
+            (resolve, reject) => {
+              activeAutorouter.on("complete", (event) => {
+                debug(`[${this.getString()}] local autorouting complete`)
+                resolve(event.traces)
+              })
+
+              activeAutorouter.on("error", (event) => {
+                debug(
+                  `[${this.getString()}] local autorouting error: ${event.error.message}`,
+                )
+                reject(event.error)
+              })
+            },
+          )
+
+          activeAutorouter.on("progress", (event) => {
+            this.root?.emit("autorouting:progress", {
+              subcircuit_id: this.subcircuit_id,
+              componentDisplayName: this.getString(),
+              ...event,
+            })
+          })
+
+          activeAutorouter.start()
+          traces = await routingPromise
+        }
+
         const outputSimpleRouteJson = {
           ...simpleRouteJson,
           traces,
+        }
+
+        if (!cachedResult) {
+          await cacheLocalAutoroutingPhaseResult({
+            cacheEngine,
+            cacheKey,
+            result: outputSimpleRouteJson,
+          })
         }
 
         this.root?.emit("autorouting:end", {
@@ -1131,7 +1158,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         // Create source_traces for interconnect ports that were connected via
         // off-board paths during routing. This allows DRC to understand that
         // these ports are intentionally connected.
-        if (autorouter.getConnectedOffboardObstacles) {
+        if (autorouter?.getConnectedOffboardObstacles) {
           const connectedOffboardObstacles =
             autorouter.getConnectedOffboardObstacles()
           createSourceTracesFromOffboardConnections({
@@ -1143,7 +1170,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         }
 
         // Get jumper output from solver
-        const solver = (autorouter as any).solver
+        const solver = (autorouter as any)?.solver
         if (solver?.getOutputJumpers) {
           outputJumpers.push(...(solver.getOutputJumpers() || []))
         }
@@ -1199,7 +1226,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         throw error
       } finally {
         // Ensure the autorouter is stopped
-        autorouter.stop()
+        autorouter?.stop()
       }
     }
 

--- a/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
+++ b/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
@@ -1,0 +1,56 @@
+import type { LocalCacheEngine } from "lib/local-cache-engine"
+import type {
+  SimpleRouteJson,
+  SimplifiedPcbTrace,
+} from "lib/utils/autorouting/SimpleRouteJson"
+import md5 from "js-md5"
+import pkgJson from "../../../../package.json"
+
+const getMd5Hash = md5 as unknown as (message: string) => string
+
+type CachedAutoroutingPhaseResult = SimpleRouteJson & {
+  traces: SimplifiedPcbTrace[]
+}
+
+export const getLocalAutoroutingCacheKey = (
+  simpleRouteJson: SimpleRouteJson,
+): string =>
+  `core@${pkgJson.version}:srj:${getMd5Hash(JSON.stringify(simpleRouteJson))}`
+
+export const getCachedLocalAutoroutingPhaseResult = async ({
+  cacheEngine,
+  cacheKey,
+}: {
+  cacheEngine: LocalCacheEngine | undefined
+  cacheKey: string
+}): Promise<CachedAutoroutingPhaseResult | null> => {
+  if (!cacheEngine) return null
+
+  try {
+    const cachedResult = await cacheEngine.getItem(cacheKey)
+    if (!cachedResult) return null
+
+    const parsedResult = JSON.parse(cachedResult)
+    if (!parsedResult || !Array.isArray(parsedResult.traces)) return null
+
+    return parsedResult as CachedAutoroutingPhaseResult
+  } catch {
+    return null
+  }
+}
+
+export const cacheLocalAutoroutingPhaseResult = async ({
+  cacheEngine,
+  cacheKey,
+  result,
+}: {
+  cacheEngine: LocalCacheEngine | undefined
+  cacheKey: string
+  result: CachedAutoroutingPhaseResult
+}): Promise<void> => {
+  if (!cacheEngine) return
+
+  try {
+    await cacheEngine.setItem(cacheKey, JSON.stringify(result))
+  } catch {}
+}

--- a/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
+++ b/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
@@ -15,7 +15,7 @@ type CachedAutoroutingPhaseResult = SimpleRouteJson & {
 export const getLocalAutoroutingCacheKey = (
   simpleRouteJson: SimpleRouteJson,
 ): string =>
-  `core@${pkgJson.version}:srj:${getMd5Hash(JSON.stringify(simpleRouteJson))}`
+  `routes:core@${pkgJson.version}:srj:${getMd5Hash(JSON.stringify(simpleRouteJson))}`
 
 export const getCachedLocalAutoroutingPhaseResult = async ({
   cacheEngine,

--- a/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
+++ b/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
@@ -3,10 +3,25 @@ import type {
   SimpleRouteJson,
   SimplifiedPcbTrace,
 } from "lib/utils/autorouting/SimpleRouteJson"
-import md5 from "js-md5"
 import pkgJson from "../../../../package.json"
 
-const getMd5Hash = md5 as unknown as (message: string) => string
+const getFnv1aHash = (value: string): number => {
+  let hash = 2166136261
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
+const getSrjHash = (simpleRouteJson: SimpleRouteJson): string => {
+  const serializedSrj = JSON.stringify(simpleRouteJson)
+  const hash1 = getFnv1aHash(serializedSrj)
+  const hash2 = getFnv1aHash(`${serializedSrj}${hash1}`)
+  return `${hash1.toString(16).padStart(8, "0")}${hash2
+    .toString(16)
+    .padStart(8, "0")}`
+}
 
 type CachedAutoroutingPhaseResult = SimpleRouteJson & {
   traces: SimplifiedPcbTrace[]
@@ -14,8 +29,7 @@ type CachedAutoroutingPhaseResult = SimpleRouteJson & {
 
 export const getLocalAutoroutingCacheKey = (
   simpleRouteJson: SimpleRouteJson,
-): string =>
-  `routes:core@${pkgJson.version}:srj:${getMd5Hash(JSON.stringify(simpleRouteJson))}`
+): string => `routes:core@${pkgJson.version}:srj:${getSrjHash(simpleRouteJson)}`
 
 export const getCachedLocalAutoroutingPhaseResult = async ({
   cacheEngine,

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "calculate-packing": "0.0.75",
     "css-select": "5.1.0",
     "format-si-unit": "^0.0.7",
+    "js-md5": "^0.8.3",
     "nanoid": "^5.0.7",
     "performance-now": "^2.1.0",
     "react-reconciler": "^0.32.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "calculate-packing": "0.0.75",
     "css-select": "5.1.0",
     "format-si-unit": "^0.0.7",
-    "js-md5": "^0.8.3",
     "nanoid": "^5.0.7",
     "performance-now": "^2.1.0",
     "react-reconciler": "^0.32.0",

--- a/tests/features/local-autorouting-phase-cache.test.tsx
+++ b/tests/features/local-autorouting-phase-cache.test.tsx
@@ -109,7 +109,7 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
   expect(new Set(setKeys).size).toBe(2)
   for (const key of setKeys) {
     expect(key).toMatch(
-      new RegExp(`^routes:core@${pkgJson.version}:srj:[a-f0-9]{32}$`),
+      new RegExp(`^routes:core@${pkgJson.version}:srj:[a-f0-9]{16}$`),
     )
   }
 

--- a/tests/features/local-autorouting-phase-cache.test.tsx
+++ b/tests/features/local-autorouting-phase-cache.test.tsx
@@ -109,7 +109,7 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
   expect(new Set(setKeys).size).toBe(2)
   for (const key of setKeys) {
     expect(key).toMatch(
-      new RegExp(`^core@${pkgJson.version}:srj:[a-f0-9]{32}$`),
+      new RegExp(`^routes:core@${pkgJson.version}:srj:[a-f0-9]{32}$`),
     )
   }
 

--- a/tests/features/local-autorouting-phase-cache.test.tsx
+++ b/tests/features/local-autorouting-phase-cache.test.tsx
@@ -1,0 +1,114 @@
+import { expect, test } from "bun:test"
+import type { LocalCacheEngine } from "lib/local-cache-engine"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+import pkgJson from "../../package.json"
+import { createBasicAutorouter } from "../fixtures/createBasicAutorouter"
+import { getTestFixture } from "../fixtures/get-test-fixture"
+
+test("local autorouting caches and restores results for each phase", async () => {
+  const cache = new Map<string, string>()
+  const getKeys: string[] = []
+  const setKeys: string[] = []
+  const localCacheEngine: LocalCacheEngine = {
+    getItem: (key) => {
+      getKeys.push(key)
+      return cache.get(key) ?? null
+    },
+    setItem: (key, value) => {
+      setKeys.push(key)
+      cache.set(key, value)
+    },
+  }
+
+  let solverCallCount = 0
+  const algorithmFn = createBasicAutorouter(
+    async (simpleRouteJson: SimpleRouteJson) => {
+      solverCallCount++
+      return simpleRouteJson.connections.map((connection) => {
+        const [start, end] = connection.pointsToConnect
+        return {
+          type: "pcb_trace" as const,
+          pcb_trace_id: `cached_${connection.name}`,
+          connection_name: connection.name,
+          route: [
+            {
+              route_type: "wire" as const,
+              x: start.x,
+              y: start.y,
+              width:
+                connection.nominalTraceWidth ?? simpleRouteJson.minTraceWidth,
+              layer: start.layer,
+            },
+            {
+              route_type: "wire" as const,
+              x: end.x,
+              y: end.y,
+              width:
+                connection.nominalTraceWidth ?? simpleRouteJson.minTraceWidth,
+              layer: end.layer,
+            },
+          ],
+        }
+      })
+    },
+  )
+
+  const renderCircuit = async () => {
+    const { circuit } = getTestFixture({ platform: { localCacheEngine } })
+    circuit.add(
+      <board width="20mm" height="20mm" autorouter={{ algorithmFn }}>
+        <resistor
+          name="R1"
+          resistance="1k"
+          footprint="0402"
+          pcbX={-7}
+          pcbY={-3}
+        />
+        <resistor
+          name="R2"
+          resistance="1k"
+          footprint="0402"
+          pcbX={7}
+          pcbY={-3}
+        />
+        <resistor
+          name="R3"
+          resistance="1k"
+          footprint="0402"
+          pcbX={-7}
+          pcbY={3}
+        />
+        <resistor
+          name="R4"
+          resistance="1k"
+          footprint="0402"
+          pcbX={7}
+          pcbY={3}
+        />
+        <trace from=".R1 > .pin1" to=".R2 > .pin1" routingPhaseIndex={0} />
+        <trace from=".R3 > .pin1" to=".R4 > .pin1" routingPhaseIndex={1} />
+      </board>,
+    )
+    await circuit.renderUntilSettled()
+    return circuit
+  }
+
+  const firstCircuit = await renderCircuit()
+  expect(solverCallCount).toBe(2)
+  expect(firstCircuit.db.pcb_trace.list()).toHaveLength(2)
+  expect(setKeys).toHaveLength(2)
+  expect(new Set(setKeys).size).toBe(2)
+  for (const key of setKeys) {
+    expect(key).toMatch(
+      new RegExp(`^core@${pkgJson.version}:srj:[a-f0-9]{32}$`),
+    )
+  }
+
+  const secondCircuit = await renderCircuit()
+  expect(solverCallCount).toBe(2)
+  expect(secondCircuit.db.pcb_trace.list()).toEqual(
+    firstCircuit.db.pcb_trace.list(),
+  )
+  expect(getKeys.slice(-2)).toEqual(setKeys)
+  expect(setKeys).toHaveLength(2)
+})

--- a/tests/features/local-autorouting-phase-cache.test.tsx
+++ b/tests/features/local-autorouting-phase-cache.test.tsx
@@ -5,7 +5,7 @@ import pkgJson from "../../package.json"
 import { createBasicAutorouter } from "../fixtures/createBasicAutorouter"
 import { getTestFixture } from "../fixtures/get-test-fixture"
 
-test("local autorouting caches and restores results for each phase", async () => {
+test("built-in local autorouting caches each phase and custom algorithms bypass the cache", async () => {
   const cache = new Map<string, string>()
   const getKeys: string[] = []
   const setKeys: string[] = []
@@ -20,10 +20,10 @@ test("local autorouting caches and restores results for each phase", async () =>
     },
   }
 
-  let solverCallCount = 0
-  const algorithmFn = createBasicAutorouter(
+  let customSolverCallCount = 0
+  const customAlgorithmFn = createBasicAutorouter(
     async (simpleRouteJson: SimpleRouteJson) => {
-      solverCallCount++
+      customSolverCallCount++
       return simpleRouteJson.connections.map((connection) => {
         const [start, end] = connection.pointsToConnect
         return {
@@ -53,10 +53,18 @@ test("local autorouting caches and restores results for each phase", async () =>
     },
   )
 
-  const renderCircuit = async () => {
+  const renderCircuit = async (algorithmFn?: typeof customAlgorithmFn) => {
     const { circuit } = getTestFixture({ platform: { localCacheEngine } })
+    let autoroutingProgressCount = 0
+    circuit.on("autorouting:progress", () => {
+      autoroutingProgressCount++
+    })
     circuit.add(
-      <board width="20mm" height="20mm" autorouter={{ algorithmFn }}>
+      <board
+        width="20mm"
+        height="20mm"
+        autorouter={algorithmFn ? { algorithmFn } : undefined}
+      >
         <resistor
           name="R1"
           resistance="1k"
@@ -90,11 +98,12 @@ test("local autorouting caches and restores results for each phase", async () =>
       </board>,
     )
     await circuit.renderUntilSettled()
-    return circuit
+    return { circuit, autoroutingProgressCount }
   }
 
-  const firstCircuit = await renderCircuit()
-  expect(solverCallCount).toBe(2)
+  const firstRender = await renderCircuit()
+  expect(firstRender.autoroutingProgressCount).toBeGreaterThan(0)
+  const firstCircuit = firstRender.circuit
   expect(firstCircuit.db.pcb_trace.list()).toHaveLength(2)
   expect(setKeys).toHaveLength(2)
   expect(new Set(setKeys).size).toBe(2)
@@ -104,11 +113,20 @@ test("local autorouting caches and restores results for each phase", async () =>
     )
   }
 
-  const secondCircuit = await renderCircuit()
-  expect(solverCallCount).toBe(2)
+  const secondRender = await renderCircuit()
+  expect(secondRender.autoroutingProgressCount).toBe(0)
+  const secondCircuit = secondRender.circuit
   expect(secondCircuit.db.pcb_trace.list()).toEqual(
     firstCircuit.db.pcb_trace.list(),
   )
   expect(getKeys.slice(-2)).toEqual(setKeys)
   expect(setKeys).toHaveLength(2)
+
+  const getCountBeforeCustomAutorouting = getKeys.length
+  const setCountBeforeCustomAutorouting = setKeys.length
+  const customRender = await renderCircuit(customAlgorithmFn)
+  expect(customSolverCallCount).toBe(2)
+  expect(customRender.circuit.db.pcb_trace.list()).toHaveLength(2)
+  expect(getKeys).toHaveLength(getCountBeforeCustomAutorouting)
+  expect(setKeys).toHaveLength(setCountBeforeCustomAutorouting)
 })


### PR DESCRIPTION
## Summary

- cache each built-in local autorouting phase through `platform.localCacheEngine`
- namespace cache keys as `routes:core@<core version>:srj:<phase SRJ hash>`
- hash serialized phase SRJ with the same dependency-free, two-round FNV-1a approach already used by core's subcircuit cache
- restore cached phase traces before creating or starting `TscircuitAutorouter`
- write completed phase Simple Route JSON back to the cache
- bypass local caching entirely for custom `algorithmFn` autorouters
- treat cache read, parse, and write failures as non-fatal cache misses

## Why

Phased autorouting currently recomputes every built-in local routing phase even when the exact phase input has already been solved. Keying the cache from each phase's Simple Route JSON lets unchanged phases be reused independently, while the core-version namespace invalidates results whenever core is upgraded.

Custom autorouter functions are intentionally excluded for now because core cannot safely infer their implementation version or caching semantics.

## Validation

- `bun test tests/features/local-autorouting-phase-cache.test.tsx tests/components/normal-components/parts-engine-cache.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`

The regression test renders the same two-phase board twice with the built-in local autorouter, verifies two distinct `routes:`-prefixed versioned cache keys, and confirms the second render produces identical PCB traces without starting autorouting. It also verifies that a custom `algorithmFn` runs normally without any local cache reads or writes.