### PR TITLE
Update copper-pour-solver to 0.0.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@tscircuit/checks": "0.0.142",
     "@tscircuit/circuit-json-util": "^0.0.97",
     "@tscircuit/common": "^0.0.20",
-    "@tscircuit/copper-pour-solver": "0.0.38",
+    "@tscircuit/copper-pour-solver": "0.0.39",
     "@tscircuit/footprinter": "^0.0.371",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/infer-cable-insertion-point": "^0.0.2",


### PR DESCRIPTION
## What changed

Update the exact `@tscircuit/copper-pour-solver` development dependency from `0.0.38` to `0.0.39`.

## Why

Version `0.0.39` consumes `@tscircuit/manifold-2d` from npm instead of the previous JSCDN tarball dependency.

## Validation

- installed and verified `@tscircuit/copper-pour-solver@0.0.39`
- 16 focused copper-pour tests passed
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`
