### PR TITLE
Keep pin alt labels unique when three or more pins share a number

### DIFF
--- a/lib/utils/schematic/normalizePinLabels.ts
+++ b/lib/utils/schematic/normalizePinLabels.ts
@@ -46,6 +46,9 @@ export const normalizePinLabels = (inputPinLabels: string[][]): string[][] => {
    */
   let highestPinNumber = 0
   const alreadyAcceptedDesiredNumbers: Set<number> = new Set()
+  // Number of "_alt" labels already handed out for each desired number, so the
+  // suffixes stay unique when three or more pins request the same number.
+  const altCountByDesiredNumber: Record<number, number> = {}
   for (let i = 0; i < desiredNumbers.length; i++) {
     const desiredNumber = desiredNumbers[i]
 
@@ -60,14 +63,10 @@ export const normalizePinLabels = (inputPinLabels: string[][]): string[][] => {
       continue
     }
 
-    let existingAltsForPin = 0
-    for (const label of result[i]) {
-      if (label.startsWith(`pin${desiredNumber}_alt`)) {
-        existingAltsForPin++
-      }
-    }
+    const altIndex = (altCountByDesiredNumber[desiredNumber] ?? 0) + 1
+    altCountByDesiredNumber[desiredNumber] = altIndex
 
-    result[i].push(`pin${desiredNumber}_alt${existingAltsForPin + 1}`)
+    result[i].push(`pin${desiredNumber}_alt${altIndex}`)
   }
 
   // Assign pin numbers to alternate labels

--- a/tests/utils/schematic/normalizePinLabels.test.ts
+++ b/tests/utils/schematic/normalizePinLabels.test.ts
@@ -52,4 +52,18 @@ describe("normalizePinLabels", () => {
       ["pin3"],
     ])
   })
+
+  test("keeps alt labels unique when 3+ pins share a number", () => {
+    const result = normalizePinLabels([["3"], ["3"], ["3"], ["3"]])
+
+    expect(result).toEqual([
+      ["pin3"],
+      ["pin4", "pin3_alt1"],
+      ["pin5", "pin3_alt2"],
+      ["pin6", "pin3_alt3"],
+    ])
+
+    const allLabels = result.flat()
+    expect(new Set(allLabels).size).toBe(allLabels.length)
+  })
 })


### PR DESCRIPTION
normalizePinLabels is supposed to produce unique labels, but it counted existing alts by scanning the current pin's own (still empty) label list, so every collision after the first got _alt1 and two pins ended up with the same label like pin3_alt1. Count alts per desired number across pins instead, so three or more pins sharing a number get pin3_alt1, pin3_alt2, and so on.