### PR TITLE
Update circuit-json-to-spice to 0.0.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.23",
     "circuit-json-to-gltf": "^0.0.105",
-    "circuit-json-to-spice": "^0.0.40",
+    "circuit-json-to-spice": "^0.0.43",
     "circuit-to-svg": "^0.0.381",
     "concurrently": "^9.1.2",
     "connectivity-map": "^1.0.0",


### PR DESCRIPTION
## Summary

- update `circuit-json-to-spice` from `^0.0.40` to `^0.0.43`
- keep `@tscircuit/core` aligned with the latest published converter release

## Impact

Consumers of the SPICE simulation path will use the latest compatible `circuit-json-to-spice` release.

## Validation

- `bun test tests/features/spice-analysis tests/features/spice-model-chip-sends-subcircuit-to-engine.test.tsx tests/components/normal-components/ammeter-current-voltage-graph.test.tsx` (29 passed)
- `bunx tsc --noEmit`
- `bun run build`