### PR TITLE
Support multiple analog simulations per circuit

### DIFF
--- a/lib/components/primitive-components/AnalogSimulation.ts
+++ b/lib/components/primitive-components/AnalogSimulation.ts
@@ -4,6 +4,8 @@ import { PrimitiveComponent } from "../base-components/PrimitiveComponent"
 export class AnalogSimulation extends PrimitiveComponent<
   typeof analogSimulationProps
 > {
+  simulation_experiment_id: string | null = null
+
   get config() {
     return {
       componentName: "AnalogSimulation",
@@ -19,7 +21,7 @@ export class AnalogSimulation extends PrimitiveComponent<
     const durationMs = duration || 10 // ms
     const timePerStepMs = timePerStep || 0.01 // ms
 
-    db.simulation_experiment.insert({
+    const simulationExperiment = db.simulation_experiment.insert({
       name: name ?? "spice_transient_analysis",
       experiment_type: "spice_transient_analysis" as const,
       end_time_ms: durationMs,
@@ -27,5 +29,8 @@ export class AnalogSimulation extends PrimitiveComponent<
       time_per_step: timePerStepMs,
       spice_options: spiceOptions,
     })
+
+    this.simulation_experiment_id =
+      simulationExperiment.simulation_experiment_id
   }
 }

--- a/lib/components/primitive-components/Group/Group_doInitialSimulationSpiceEngineRender.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSimulationSpiceEngineRender.ts
@@ -1,5 +1,5 @@
 import { SpiceNetlist, circuitJsonToSpice } from "circuit-json-to-spice"
-import type { SimulationCurrentProbe } from "circuit-json"
+import type { AnyCircuitElement, SimulationCurrentProbe } from "circuit-json"
 import Debug from "debug"
 import { getTransientVoltageGraphNamesFromSpiceNetlist } from "lib/utils/simulation/get-transient-voltage-graph-names-from-spice-netlist"
 import { resetSimulationColorState } from "lib/utils/simulation/getSimulationColorForId"
@@ -21,6 +21,57 @@ import { isVoltageGraph } from "./isVoltageGraph"
 
 const debug = Debug("tscircuit:core:Group_doInitialSimulationSpiceEngineRender")
 
+const getCircuitJsonForAnalogSimulation = ({
+  circuitJson,
+  simulationExperimentId,
+  voltageProbes,
+  ammeters,
+}: {
+  circuitJson: AnyCircuitElement[]
+  simulationExperimentId: string
+  voltageProbes: VoltageProbe[]
+  ammeters: Ammeter[]
+}) => {
+  const voltageProbeIds = new Set(
+    voltageProbes
+      .map((probe) => probe.simulation_voltage_probe_id)
+      .filter((id): id is string => Boolean(id)),
+  )
+  const currentProbeIds = new Set(
+    ammeters
+      .map((ammeter) => ammeter.simulation_current_probe_id)
+      .filter((id): id is string => Boolean(id)),
+  )
+
+  return circuitJson.filter((element) => {
+    if (element.type === "simulation_experiment") {
+      return element.simulation_experiment_id === simulationExperimentId
+    }
+    if (element.type === "simulation_voltage_probe") {
+      return voltageProbeIds.has(element.simulation_voltage_probe_id)
+    }
+    if (element.type === "simulation_current_probe") {
+      return currentProbeIds.has(element.simulation_current_probe_id)
+    }
+    if (element.type === "simulation_oscilloscope_trace") {
+      if (element.simulation_voltage_probe_id) {
+        return voltageProbeIds.has(element.simulation_voltage_probe_id)
+      }
+      if (element.simulation_current_probe_id) {
+        return currentProbeIds.has(element.simulation_current_probe_id)
+      }
+    }
+    if (
+      element.type === "simulation_transient_voltage_graph" ||
+      element.type === "simulation_transient_current_graph" ||
+      element.type === "simulation_unknown_experiment_error"
+    ) {
+      return false
+    }
+    return true
+  })
+}
+
 export function Group_doInitialSimulationSpiceEngineRender(group: Group<any>) {
   // Only run spice simulation for subcircuits
   if (!group.isSubcircuit) return
@@ -32,9 +83,6 @@ export function Group_doInitialSimulationSpiceEngineRender(group: Group<any>) {
 
   if (analogSims.length === 0) return
 
-  const voltageProbes = group.selectAll<VoltageProbe>("voltageprobe")
-  const ammeters = group.selectAll<Ammeter>("ammeter")
-
   resetSimulationColorState()
 
   // Check if there are any spice engines configured, or use default
@@ -43,84 +91,121 @@ export function Group_doInitialSimulationSpiceEngineRender(group: Group<any>) {
     spiceEngineMap.spicey = getSpiceyEngine()
   }
 
-  // Get circuit JSON for this subcircuit
-  const circuitJson = root.db.toArray()
-
-  // Convert circuit JSON to SPICE string
-  let spiceString: string
-  let spiceNetlist: SpiceNetlist
-  try {
-    spiceNetlist = circuitJsonToSpice(circuitJson)
-    spiceString = spiceNetlist.toSpiceString()
-    debug(`Generated SPICE string:\n${spiceString}`)
-  } catch (error) {
-    debug(`Failed to convert circuit JSON to SPICE: ${error}`)
-    return
-  }
-
-  const graphNameToProbe = new Map<string, VoltageProbe>()
-  for (const probe of voltageProbes) {
-    if (probe.finalProbeName) {
-      graphNameToProbe.set(probe.finalProbeName, probe)
-    }
-  }
-
-  const voltageProbesById = new Map<string, VoltageProbe>()
-  const graphDisplayOverridesByProbeId = new Map<
-    string,
-    GraphDisplayOverrides
-  >()
-  for (const probe of voltageProbes) {
-    if (probe.simulation_voltage_probe_id) {
-      voltageProbesById.set(probe.simulation_voltage_probe_id, probe)
-      graphDisplayOverridesByProbeId.set(
-        probe.simulation_voltage_probe_id,
-        getVoltageProbeGraphDisplayOverrides(probe),
-      )
-    }
-  }
-
-  for (const ammeter of ammeters) {
-    if (ammeter.simulation_current_probe_id) {
-      graphDisplayOverridesByProbeId.set(
-        ammeter.simulation_current_probe_id,
-        getAmmeterGraphDisplayOverrides(ammeter),
-      )
-    }
-  }
-
-  const currentProbesById = new Map<string, SimulationCurrentProbe>()
-  const currentProbesByName = new Map<string, SimulationCurrentProbe>()
-  for (const probe of root.db.simulation_current_probe.list()) {
-    currentProbesById.set(probe.simulation_current_probe_id, probe)
-    if (probe.name !== undefined) {
-      currentProbesByName.set(probe.name, probe)
-    }
-  }
-  const orderedSimulationProbes = root.db.simulation_voltage_probe
-    .list()
-    .filter((probe) => voltageProbesById.has(probe.simulation_voltage_probe_id))
-  const graphNamesFromNetlist =
-    getTransientVoltageGraphNamesFromSpiceNetlist(spiceNetlist)
-
-  if (graphNamesFromNetlist.length === orderedSimulationProbes.length) {
-    for (const [index, simulationProbe] of orderedSimulationProbes.entries()) {
-      const probe = voltageProbesById.get(
-        simulationProbe.simulation_voltage_probe_id,
-      )
-      const graphName = graphNamesFromNetlist[index]
-      if (probe && graphName) {
-        graphNameToProbe.set(graphName, probe)
-      }
-    }
-  } else {
-    debug(
-      `Skipping probe-to-graph order mapping because counts differ: probes=${orderedSimulationProbes.length} graphNames=${graphNamesFromNetlist.length}`,
-    )
-  }
-
   // Run simulation for each analogsimulation component
   for (const analogSim of analogSims) {
+    const simulationExperimentId = analogSim.simulation_experiment_id
+    if (!simulationExperimentId) {
+      debug("No simulation experiment id found, skipping simulation")
+      continue
+    }
+    const simulationExperiment = root.db.simulation_experiment.get(
+      simulationExperimentId,
+    )
+    if (!simulationExperiment) {
+      debug("No simulation experiment found, skipping simulation")
+      continue
+    }
+
+    const simulationScope = analogSim.getGroup() ?? group
+    const voltageProbes =
+      simulationScope.selectAll<VoltageProbe>("voltageprobe")
+    const ammeters = simulationScope.selectAll<Ammeter>("ammeter")
+    const circuitJson = getCircuitJsonForAnalogSimulation({
+      circuitJson: root.db.toArray(),
+      simulationExperimentId,
+      voltageProbes,
+      ammeters,
+    })
+
+    let spiceString: string
+    let spiceNetlist: SpiceNetlist
+    try {
+      spiceNetlist = circuitJsonToSpice(circuitJson)
+      spiceString = spiceNetlist.toSpiceString()
+      debug(`Generated SPICE string:\n${spiceString}`)
+    } catch (error) {
+      debug(`Failed to convert circuit JSON to SPICE: ${error}`)
+      root.db.simulation_unknown_experiment_error.insert({
+        simulation_experiment_id: simulationExperimentId,
+        error_type: "simulation_unknown_experiment_error",
+        message: error instanceof Error ? error.message : String(error),
+      })
+      continue
+    }
+
+    const graphNameToProbe = new Map<string, VoltageProbe>()
+    const voltageProbesById = new Map<string, VoltageProbe>()
+    const graphDisplayOverridesByProbeId = new Map<
+      string,
+      GraphDisplayOverrides
+    >()
+    for (const probe of voltageProbes) {
+      if (probe.finalProbeName) {
+        graphNameToProbe.set(probe.finalProbeName, probe)
+      }
+      if (probe.simulation_voltage_probe_id) {
+        voltageProbesById.set(probe.simulation_voltage_probe_id, probe)
+        graphDisplayOverridesByProbeId.set(
+          probe.simulation_voltage_probe_id,
+          getVoltageProbeGraphDisplayOverrides(probe),
+        )
+      }
+    }
+
+    for (const ammeter of ammeters) {
+      if (ammeter.simulation_current_probe_id) {
+        graphDisplayOverridesByProbeId.set(
+          ammeter.simulation_current_probe_id,
+          getAmmeterGraphDisplayOverrides(ammeter),
+        )
+      }
+    }
+
+    const scopedCurrentProbeIds = new Set(
+      ammeters
+        .map((ammeter) => ammeter.simulation_current_probe_id)
+        .filter((id): id is string => Boolean(id)),
+    )
+    const currentProbesById = new Map<string, SimulationCurrentProbe>()
+    const currentProbesByName = new Map<string, SimulationCurrentProbe>()
+    for (const probe of root.db.simulation_current_probe
+      .list()
+      .filter((probe) =>
+        scopedCurrentProbeIds.has(probe.simulation_current_probe_id),
+      )) {
+      currentProbesById.set(probe.simulation_current_probe_id, probe)
+      if (probe.name !== undefined) {
+        currentProbesByName.set(probe.name, probe)
+      }
+    }
+
+    const orderedSimulationProbes = root.db.simulation_voltage_probe
+      .list()
+      .filter((probe) =>
+        voltageProbesById.has(probe.simulation_voltage_probe_id),
+      )
+    const graphNamesFromNetlist =
+      getTransientVoltageGraphNamesFromSpiceNetlist(spiceNetlist)
+
+    if (graphNamesFromNetlist.length === orderedSimulationProbes.length) {
+      for (const [
+        index,
+        simulationProbe,
+      ] of orderedSimulationProbes.entries()) {
+        const probe = voltageProbesById.get(
+          simulationProbe.simulation_voltage_probe_id,
+        )
+        const graphName = graphNamesFromNetlist[index]
+        if (probe && graphName) {
+          graphNameToProbe.set(graphName, probe)
+        }
+      }
+    } else {
+      debug(
+        `Skipping probe-to-graph order mapping because counts differ: probes=${orderedSimulationProbes.length} graphNames=${graphNamesFromNetlist.length}`,
+      )
+    }
+
     const engineName = analogSim._parsedProps.spiceEngine ?? "spicey"
     const spiceEngine = spiceEngineMap[engineName]
 
@@ -132,7 +217,7 @@ export function Group_doInitialSimulationSpiceEngineRender(group: Group<any>) {
       )
     }
 
-    const effectId = `spice-simulation-${engineName}-${analogSim.source_component_id}`
+    const effectId = `spice-simulation-${engineName}-${simulationExperimentId}`
 
     debug(
       `Queueing simulation for spice engine: ${engineName} (id: ${effectId})`,
@@ -146,12 +231,6 @@ export function Group_doInitialSimulationSpiceEngineRender(group: Group<any>) {
         debug(
           `Simulation completed, received ${result.simulationResultCircuitJson.length} elements`,
         )
-
-        const simulationExperiment = root.db.simulation_experiment.list()[0]
-        if (!simulationExperiment) {
-          debug("No simulation experiment found, skipping result insertion")
-          return
-        }
 
         // Add simulation results to the database
         const insertedVoltageGraphs: InsertedSimulationGraph[] = []
@@ -222,10 +301,8 @@ export function Group_doInitialSimulationSpiceEngineRender(group: Group<any>) {
         group._markDirty("SimulationSpiceEngineRender")
       } catch (error) {
         debug(`Simulation failed for engine ${engineName}: ${error}`)
-        const simulationExperiment = root.db.simulation_experiment.list()[0]
         root.db.simulation_unknown_experiment_error.insert({
-          simulation_experiment_id:
-            simulationExperiment?.simulation_experiment_id,
+          simulation_experiment_id: simulationExperimentId,
           error_type: "simulation_unknown_experiment_error",
           message: error instanceof Error ? error.message : String(error),
         })

--- a/tests/features/spice-analysis/multiple-analog-simulations.test.tsx
+++ b/tests/features/spice-analysis/multiple-analog-simulations.test.tsx
@@ -1,30 +1,26 @@
 import { expect, test } from "bun:test"
-import type { SpiceEngine } from "@tscircuit/props"
+import createNgspiceSpiceEngine from "@tscircuit/ngspice-spice-engine"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
 test("multiple analog simulations keep separate experiments and group probe scopes", async () => {
   const spiceStrings: string[] = []
-  const mockSpiceEngine: SpiceEngine = {
-    async simulate(spiceString) {
+  const ngspiceEngine = await createNgspiceSpiceEngine()
+  let nextSimulation = Promise.resolve()
+  const capturingNgspiceEngine = {
+    async simulate(spiceString: string) {
       spiceStrings.push(spiceString)
-      return {
-        simulationResultCircuitJson: [
-          {
-            type: "simulation_transient_voltage_graph",
-            simulation_transient_voltage_graph_id: "mock_graph",
-            simulation_experiment_id: "mock_experiment",
-            voltage_levels: [0, 1],
-            time_per_step: 1,
-            start_time_ms: 0,
-            end_time_ms: 1,
-            name: "mock_graph",
-          },
-        ],
-      }
+      const simulation = nextSimulation.then(() =>
+        ngspiceEngine.simulate(spiceString),
+      )
+      nextSimulation = simulation.then(
+        () => undefined,
+        () => undefined,
+      )
+      return simulation
     },
   }
   const { circuit } = getTestFixture({
-    platform: { spiceEngineMap: { mock: mockSpiceEngine } },
+    platform: { spiceEngineMap: { ngspice: capturingNgspiceEngine } },
   })
 
   circuit.add(
@@ -43,13 +39,13 @@ test("multiple analog simulations keep separate experiments and group probe scop
         name="root-fast"
         duration="1ms"
         timePerStep="100us"
-        spiceEngine="mock"
+        spiceEngine="ngspice"
       />
       <analogsimulation
         name="root-slow"
         duration="2ms"
         timePerStep="200us"
-        spiceEngine="mock"
+        spiceEngine="ngspice"
       />
 
       <group name="first-stage">
@@ -58,7 +54,7 @@ test("multiple analog simulations keep separate experiments and group probe scop
           name="first-stage-sim"
           duration="3ms"
           timePerStep="300us"
-          spiceEngine="mock"
+          spiceEngine="ngspice"
         />
       </group>
       <group name="second-stage">
@@ -67,7 +63,7 @@ test("multiple analog simulations keep separate experiments and group probe scop
           name="second-stage-sim"
           duration="4ms"
           timePerStep="400us"
-          spiceEngine="mock"
+          spiceEngine="ngspice"
         />
       </group>
     </board>,
@@ -83,15 +79,59 @@ test("multiple analog simulations keep separate experiments and group probe scop
     "first-stage-sim",
     "second-stage-sim",
   ])
-  expect(voltageGraphs).toHaveLength(4)
+  expect(circuit.db.simulation_unknown_experiment_error.list()).toHaveLength(0)
+  expect(voltageGraphs).toHaveLength(8)
+
+  const expectedGraphsByExperiment: Record<
+    string,
+    { names: string[]; endTimeMs: number }
+  > = {
+    "root-fast": {
+      names: ["FIRST_STAGE_PROBE", "ROOT_PROBE", "SECOND_STAGE_PROBE"],
+      endTimeMs: 1,
+    },
+    "root-slow": {
+      names: ["FIRST_STAGE_PROBE", "ROOT_PROBE", "SECOND_STAGE_PROBE"],
+      endTimeMs: 2,
+    },
+    "first-stage-sim": {
+      names: ["FIRST_STAGE_PROBE"],
+      endTimeMs: 3,
+    },
+    "second-stage-sim": {
+      names: ["SECOND_STAGE_PROBE"],
+      endTimeMs: 4,
+    },
+  }
+  const expectedVoltageByProbe: Record<string, number> = {
+    ROOT_PROBE: 5,
+    FIRST_STAGE_PROBE: 5 * (5 / 6),
+    SECOND_STAGE_PROBE: 5 * (3 / 6),
+  }
+
   for (const experiment of experiments) {
-    expect(
-      voltageGraphs.filter(
-        (graph) =>
-          graph.simulation_experiment_id ===
-          experiment.simulation_experiment_id,
-      ),
-    ).toHaveLength(1)
+    const expected = expectedGraphsByExperiment[experiment.name]
+    if (!expected) throw new Error(`Unexpected experiment: ${experiment.name}`)
+    const experimentGraphs = voltageGraphs.filter(
+      (graph) =>
+        graph.simulation_experiment_id === experiment.simulation_experiment_id,
+    )
+    expect(experimentGraphs.map((graph) => graph.name).sort()).toEqual(
+      expected.names,
+    )
+    for (const graph of experimentGraphs) {
+      expect(graph.end_time_ms).toBeCloseTo(expected.endTimeMs)
+      expect(graph.voltage_levels.length).toBeGreaterThan(1)
+      expect(graph.timestamps_ms).toHaveLength(graph.voltage_levels.length)
+      expect(graph.voltage_levels.every(Number.isFinite)).toBe(true)
+      const expectedVoltage = graph.name
+        ? expectedVoltageByProbe[graph.name]
+        : undefined
+      if (expectedVoltage === undefined) {
+        throw new Error(`Unexpected voltage graph: ${graph.name}`)
+      }
+      expect(graph.voltage_levels.at(-1)).toBeCloseTo(expectedVoltage, 2)
+    }
   }
 
   expect(spiceStrings).toHaveLength(4)
@@ -109,4 +149,4 @@ test("multiple analog simulations keep separate experiments and group probe scop
     ".tran 0.0003 0.003 UIC",
     ".tran 0.0004 0.004 UIC",
   ])
-})
+}, 120000)

--- a/tests/features/spice-analysis/multiple-analog-simulations.test.tsx
+++ b/tests/features/spice-analysis/multiple-analog-simulations.test.tsx
@@ -1,0 +1,112 @@
+import { expect, test } from "bun:test"
+import type { SpiceEngine } from "@tscircuit/props"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("multiple analog simulations keep separate experiments and group probe scopes", async () => {
+  const spiceStrings: string[] = []
+  const mockSpiceEngine: SpiceEngine = {
+    async simulate(spiceString) {
+      spiceStrings.push(spiceString)
+      return {
+        simulationResultCircuitJson: [
+          {
+            type: "simulation_transient_voltage_graph",
+            simulation_transient_voltage_graph_id: "mock_graph",
+            simulation_experiment_id: "mock_experiment",
+            voltage_levels: [0, 1],
+            time_per_step: 1,
+            start_time_ms: 0,
+            end_time_ms: 1,
+            name: "mock_graph",
+          },
+        ],
+      }
+    },
+  }
+  const { circuit } = getTestFixture({
+    platform: { spiceEngineMap: { mock: mockSpiceEngine } },
+  })
+
+  circuit.add(
+    <board routingDisabled>
+      <voltagesource name="V1" voltage="5V" />
+      <resistor name="R1" resistance="1k" />
+      <resistor name="R2" resistance="2k" />
+      <resistor name="R3" resistance="3k" />
+      <trace from=".V1 > .pin1" to=".R1 > .pin1" />
+      <trace from=".R1 > .pin2" to=".R2 > .pin1" />
+      <trace from=".R2 > .pin2" to=".R3 > .pin1" />
+      <trace from=".R3 > .pin2" to=".V1 > .pin2" />
+
+      <voltageprobe name="ROOT_PROBE" connectsTo=".V1 > .pin1" />
+      <analogsimulation
+        name="root-fast"
+        duration="1ms"
+        timePerStep="100us"
+        spiceEngine="mock"
+      />
+      <analogsimulation
+        name="root-slow"
+        duration="2ms"
+        timePerStep="200us"
+        spiceEngine="mock"
+      />
+
+      <group name="first-stage">
+        <voltageprobe name="FIRST_STAGE_PROBE" connectsTo=".R1 > .pin2" />
+        <analogsimulation
+          name="first-stage-sim"
+          duration="3ms"
+          timePerStep="300us"
+          spiceEngine="mock"
+        />
+      </group>
+      <group name="second-stage">
+        <voltageprobe name="SECOND_STAGE_PROBE" connectsTo=".R2 > .pin2" />
+        <analogsimulation
+          name="second-stage-sim"
+          duration="4ms"
+          timePerStep="400us"
+          spiceEngine="mock"
+        />
+      </group>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const experiments = circuit.db.simulation_experiment.list()
+  const voltageGraphs = circuit.db.simulation_transient_voltage_graph.list()
+  expect(experiments.map((experiment) => experiment.name)).toEqual([
+    "root-fast",
+    "root-slow",
+    "first-stage-sim",
+    "second-stage-sim",
+  ])
+  expect(voltageGraphs).toHaveLength(4)
+  for (const experiment of experiments) {
+    expect(
+      voltageGraphs.filter(
+        (graph) =>
+          graph.simulation_experiment_id ===
+          experiment.simulation_experiment_id,
+      ),
+    ).toHaveLength(1)
+  }
+
+  expect(spiceStrings).toHaveLength(4)
+  expect(
+    spiceStrings.map(
+      (spiceString) =>
+        spiceString.match(/^\.PRINT TRAN (.+)$/m)?.[1].split(/\s+/).length ?? 0,
+    ),
+  ).toEqual([3, 3, 1, 1])
+  expect(
+    spiceStrings.map((spiceString) => spiceString.match(/^\.tran .+$/m)?.[0]),
+  ).toEqual([
+    ".tran 0.0001 0.001 UIC",
+    ".tran 0.0002 0.002 UIC",
+    ".tran 0.0003 0.003 UIC",
+    ".tran 0.0004 0.004 UIC",
+  ])
+})


### PR DESCRIPTION
## Summary

- associate every `<analogsimulation />` component with the exact `simulation_experiment` it creates
- build and run a separate SPICE netlist for each analog simulation
- scope nested-group simulations to probes in their containing group while root simulations retain root-circuit probe visibility
- attach generated graphs and simulation errors to the correct experiment

## Why

The render path previously converted the complete Circuit JSON once and reused the first simulation experiment for every result. Circuits containing multiple analog simulations therefore could not preserve independent durations, probe scopes, or result ownership.

## Impact

Circuits can now contain multiple root or grouped `<analogsimulation />` elements, and downstream viewers can reliably distinguish their results by `simulation_experiment_id`.

## Validation

- `bunx tsc --noEmit`
- `bun test tests/features/spice-analysis/multiple-analog-simulations.test.tsx`

