### PR TITLE
Deduplicate Board DRC results across check phases

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -1,4 +1,5 @@
 import {
+  dedupePcbDrcErrors,
   runAllNetlistChecks,
   runAllPinSpecificationChecks,
   runAllPlacementChecks,
@@ -645,6 +646,9 @@ export class Board
 
     const runDrcChecks = async (circuitJson: AnyCircuitElement[]) => {
       const checksToRun: Promise<AnyCircuitElement[]>[] = []
+      const existingDrcErrors = db
+        .toArray()
+        .filter((element) => element.type.endsWith("_error"))
 
       if (shouldRunRoutingChecks) {
         checksToRun.push(
@@ -653,12 +657,11 @@ export class Board
       }
 
       if (shouldRunPlacementChecks) {
-        const existingPlacementDiagnostics = db.toArray()
         checksToRun.push(
           runAllPlacementChecks(circuitJson).then((results) =>
             results.filter(
               (result) =>
-                !existingPlacementDiagnostics.some(
+                !existingDrcErrors.some(
                   (existing) =>
                     existing.type === result.type &&
                     "message" in existing &&
@@ -690,7 +693,16 @@ export class Board
       }
 
       const checkResults = await Promise.all(checksToRun)
-      db.insertAll(checkResults.flat())
+      const newResults = checkResults.flat()
+      const newResultSet = new Set(newResults)
+
+      // Initial placement DRC may already contain the typed error. Include it
+      // when choosing canonical reports, but only insert this pass's results.
+      db.insertAll(
+        dedupePcbDrcErrors([...existingDrcErrors, ...newResults]).filter(
+          (result) => newResultSet.has(result),
+        ),
+      )
     }
 
     const subcircuit = db.subtree({ subcircuit_id: this.subcircuit_id })

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
     "@tscircuit/capacity-autorouter": "^0.0.670",
-    "@tscircuit/checks": "0.0.143",
+    "@tscircuit/checks": "0.0.144",
     "@tscircuit/circuit-json-util": "^0.0.97",
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "0.0.39",

--- a/tests/drc/board-dedupes-clearance-errors.test.tsx
+++ b/tests/drc/board-dedupes-clearance-errors.test.tsx
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import type { PcbSmtPadRect } from "circuit-json"
+import type { Board } from "lib/components/normal-components/Board"
+import { getTestFixture } from "../fixtures/get-test-fixture"
+
+test("board DRC inserts one typed error per pad/via trace pair", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(<board width="10mm" height="10mm" />)
+  await circuit.renderUntilSettled()
+
+  const board = circuit.firstChild as Board
+  const subcircuitId = board.subcircuit_id
+  if (!subcircuitId) throw new Error("Board did not create a subcircuit")
+
+  const pad = circuit.db.pcb_smtpad.insert({
+    subcircuit_id: subcircuitId,
+    shape: "rect",
+    x: 0,
+    y: 0.2,
+    width: 0.2,
+    height: 0.2,
+    layer: "top",
+  } as Omit<PcbSmtPadRect, "type" | "pcb_smtpad_id">)
+  const via = circuit.db.pcb_via.insert({
+    subcircuit_id: subcircuitId,
+    x: 0.5,
+    y: 0.2,
+    hole_diameter: 0.2,
+    outer_diameter: 0.4,
+    layers: ["top", "bottom"],
+  })
+  const trace = circuit.db.pcb_trace.insert({
+    subcircuit_id: subcircuitId,
+    route: [
+      { route_type: "wire", x: -1, y: 0, width: 0.1, layer: "top" },
+      { route_type: "wire", x: 1, y: 0, width: 0.1, layer: "top" },
+    ],
+  })
+
+  board.doInitialPcbPlacementDesignRuleChecks()
+  board._drcChecksComplete = false
+  board.updatePcbDesignRuleChecks()
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.getCircuitJson()
+  expect(
+    errors.filter((error) => error.type === "pcb_pad_trace_clearance_error"),
+  ).toHaveLength(1)
+  expect(
+    errors.filter((error) => error.type === "pcb_via_trace_clearance_error"),
+  ).toHaveLength(1)
+  expect(
+    errors.filter(
+      (error) =>
+        error.type === "pcb_trace_error" &&
+        (error.pcb_trace_error_id ===
+          `overlap_${trace.pcb_trace_id}_${pad.pcb_smtpad_id}` ||
+          error.pcb_trace_error_id ===
+            `overlap_${trace.pcb_trace_id}_${via.pcb_via_id}`),
+    ),
+  ).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary

- update `@tscircuit/checks` to `0.0.144`
- deduplicate Board DRC results across routing, placement, and custom check phases
- include diagnostics emitted during initial placement DRC when selecting the canonical report
- retain the typed pad/via clearance error and suppress only the equivalent generic trace error

## Root cause

Core runs routing and placement checks separately. A generic trace-pad collision can therefore be returned by the routing phase while the richer typed pad-trace clearance error was returned—or already inserted—by the placement phase. Per-check deduplication cannot see across those aggregation boundaries.

## Impact

Circuit JSON produced through core no longer contains duplicate generic and typed DRC reports for the same trace-pad or trace-via pair. Standalone checker behavior and unrelated trace errors are unchanged.

## Validation

- `bun test --timeout 9999999 tests/drc/board-dedupes-clearance-errors.test.tsx`
- 7 existing Board DRC lifecycle tests across disabled checks, placement gating, and trace-out-of-board reporting
- `bunx tsc --noEmit`
- `bun run build`
- `bunx biome check lib/components/normal-components/Board.ts tests/drc/board-dedupes-clearance-errors.test.tsx package.json`
