### PR TITLE
deduplicate Core PCB DRC errors

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -1,4 +1,5 @@
 import {
+  dedupePcbDrcErrors,
   runAllNetlistChecks,
   runAllPinSpecificationChecks,
   runAllPlacementChecks,
@@ -690,7 +691,7 @@ export class Board
       }
 
       const checkResults = await Promise.all(checksToRun)
-      db.insertAll(checkResults.flat())
+      db.insertAll(dedupePcbDrcErrors(checkResults.flat()))
     }
 
     const subcircuit = db.subtree({ subcircuit_id: this.subcircuit_id })

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
     "@tscircuit/capacity-autorouter": "^0.0.670",
-    "@tscircuit/checks": "0.0.143",
+    "@tscircuit/checks": "0.0.144",
     "@tscircuit/circuit-json-util": "^0.0.97",
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "0.0.39",

--- a/tests/breakout/breakout-sot23-regulator-power-rail.test.tsx
+++ b/tests/breakout/breakout-sot23-regulator-power-rail.test.tsx
@@ -90,21 +90,25 @@ test("breakout routes sot23 regulator power rail parts without breakoutpoints", 
     circuit,
   )
 
-  const drcErrors = circuit.db.pcb_trace_error.list()
+  const traceErrors = circuit.db.pcb_trace_error.list()
+  const clearanceErrors = circuit.db.pcb_pad_trace_clearance_error.list()
 
-  expect(drcErrors).toHaveLength(2)
+  expect(traceErrors).toHaveLength(0)
+  expect(clearanceErrors).toHaveLength(2)
   expect(
-    drcErrors.filter((error) => error.message.includes("overlaps with")),
+    clearanceErrors.filter((error) => error.message.includes("overlaps with")),
   ).toHaveLength(0)
   expect(
-    drcErrors.filter((error) => error.message.includes("too close")),
+    clearanceErrors.filter((error) => error.message.includes("too close")),
   ).toHaveLength(2)
   expect(
-    drcErrors.filter((error) =>
+    clearanceErrors.filter((error) =>
       error.message.includes("disconnected endpoint"),
     ),
   ).toHaveLength(0)
   expect(
-    drcErrors.filter((error) => error.message.includes("missing a connection")),
+    clearanceErrors.filter((error) =>
+      error.message.includes("missing a connection"),
+    ),
   ).toHaveLength(0)
 })

--- a/tests/breakout/breakoutpoint-route.test.tsx
+++ b/tests/breakout/breakoutpoint-route.test.tsx
@@ -46,21 +46,23 @@ test("autorouter uses breakout point", async () => {
   expect(hasPointNear).toBe(true)
   expect(circuit).toMatchPcbSnapshot(import.meta.path)
 
-  const drcErrors = circuit.db.pcb_trace_error.list()
+  const traceErrors = circuit.db.pcb_trace_error.list()
+  const clearanceErrors = circuit.db.pcb_pad_trace_clearance_error.list()
 
-  expect(drcErrors).toHaveLength(2)
+  expect(traceErrors).toHaveLength(1)
   expect(
-    drcErrors.filter((error) => error.message.includes("overlaps with")),
-  ).toHaveLength(1)
-  expect(
-    drcErrors.filter((error) => error.message.includes("too close")),
+    traceErrors.filter((error) => error.message.includes("overlaps with")),
   ).toHaveLength(0)
   expect(
-    drcErrors.filter((error) =>
+    traceErrors.filter((error) =>
       error.message.includes("disconnected endpoint"),
     ),
   ).toHaveLength(1)
   expect(
-    drcErrors.filter((error) => error.message.includes("missing a connection")),
+    traceErrors.filter((error) =>
+      error.message.includes("missing a connection"),
+    ),
   ).toHaveLength(0)
+  expect(clearanceErrors).toHaveLength(1)
+  expect(clearanceErrors[0]?.message).toInclude("too close")
 })

--- a/tests/breakout/fanoutpoint-chip-route.test.tsx
+++ b/tests/breakout/fanoutpoint-chip-route.test.tsx
@@ -70,21 +70,23 @@ test("fanout routes a chip pin through a fanoutpoint", async () => {
 
   expect(traceThroughFanoutPoint).toBeDefined()
   await expect(circuit).toMatchPcbSnapshot(import.meta.path)
-  const drcErrors = circuit.db.pcb_trace_error.list()
+  const traceErrors = circuit.db.pcb_trace_error.list()
+  const clearanceErrors = circuit.db.pcb_pad_trace_clearance_error.list()
 
-  expect(drcErrors).toHaveLength(2)
+  expect(traceErrors).toHaveLength(1)
   expect(
-    drcErrors.filter((error) => error.message.includes("overlaps with")),
-  ).toHaveLength(1)
-  expect(
-    drcErrors.filter((error) => error.message.includes("too close")),
+    traceErrors.filter((error) => error.message.includes("overlaps with")),
   ).toHaveLength(0)
   expect(
-    drcErrors.filter((error) =>
+    traceErrors.filter((error) =>
       error.message.includes("disconnected endpoint"),
     ),
   ).toHaveLength(1)
   expect(
-    drcErrors.filter((error) => error.message.includes("missing a connection")),
+    traceErrors.filter((error) =>
+      error.message.includes("missing a connection"),
+    ),
   ).toHaveLength(0)
+  expect(clearanceErrors).toHaveLength(1)
+  expect(clearanceErrors[0]?.message).toInclude("too close")
 })

--- a/tests/drc/dedupe-pcb-drc-errors.test.tsx
+++ b/tests/drc/dedupe-pcb-drc-errors.test.tsx
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import type { PcbPadTraceClearanceError, PcbTraceError } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("deduplicates generic PCB trace errors reported by separate DRC checks", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="12mm" routingDisabled>
+      <drccheck
+        name="generic-trace-overlap-check"
+        checkFn={() =>
+          ({
+            type: "pcb_trace_error",
+            error_type: "pcb_trace_error",
+            pcb_trace_error_id: "overlap_trace1_pad1",
+            message: "Generic trace overlap",
+            pcb_trace_id: "trace1",
+            source_trace_id: "source_trace1",
+            pcb_component_ids: [],
+            pcb_port_ids: [],
+            center: { x: 0, y: 0 },
+          }) satisfies PcbTraceError
+        }
+      />
+      <drccheck
+        name="typed-pad-trace-clearance-check"
+        checkFn={() =>
+          ({
+            type: "pcb_pad_trace_clearance_error",
+            error_type: "pcb_pad_trace_clearance_error",
+            pcb_pad_trace_clearance_error_id: "pad_trace_clearance_trace1_pad1",
+            message: "Typed pad/trace clearance",
+            pcb_trace_id: "trace1",
+            pcb_pad_id: "pad1",
+            actual_clearance: 0,
+            minimum_clearance: 0.1,
+            center: { x: 0, y: 0 },
+          }) satisfies PcbPadTraceClearanceError as never
+        }
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit
+    .getCircuitJson()
+    .filter((elm) =>
+      ["pcb_trace_error", "pcb_pad_trace_clearance_error"].includes(elm.type),
+    )
+
+  expect(errors).toHaveLength(1)
+  expect(errors[0]).toMatchObject({
+    type: "pcb_pad_trace_clearance_error",
+    pcb_trace_id: "trace1",
+    pcb_pad_id: "pad1",
+  })
+})


### PR DESCRIPTION
## Summary

- apply `dedupePcbDrcErrors` once at Core's DRC aggregation boundary
- bump `@tscircuit/checks` to `0.0.144`, the first release exporting the shared deduper
- keep typed pad/trace clearance diagnostics while removing matching legacy `pcb_trace_error` overlap records
- update breakout assertions to target the typed clearance diagnostics

## Root cause

Core inserted the flattened results of routing, placement, netlist, pin-specification, and custom DRC checks directly into circuit JSON. When one check emitted a typed pad/trace or via/trace clearance error and another emitted the legacy generic overlap record for the same pair, both survived and rendered as duplicate markers and labels.

## Impact

Consumers of Core circuit JSON now receive one specific clearance diagnostic for each affected pad/trace or via/trace pair. Unrelated generic trace diagnostics, such as disconnected endpoints, are preserved.

## Validation

- `bunx tsc --noEmit`
- `bun run build`
- focused DRC regression and three affected breakout tests pass
- full suite completed with 1,176 passing and 31 skipped; its only unrelated remaining failure after updating the three dedupe-sensitive assertions is the differential-pair `port-selector` PCB snapshot, which also fails unchanged on a clean `origin/main` worktree with `@tscircuit/checks@0.0.143`
