### PR TITLE
Remove obsolete core PCB DRC deduplication

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -1,5 +1,4 @@
 import {
-  dedupePcbDrcErrors,
   runAllNetlistChecks,
   runAllPinSpecificationChecks,
   runAllPlacementChecks,
@@ -691,7 +690,7 @@ export class Board
       }
 
       const checkResults = await Promise.all(checksToRun)
-      db.insertAll(dedupePcbDrcErrors(checkResults.flat()))
+      db.insertAll(checkResults.flat())
     }
 
     const subcircuit = db.subtree({ subcircuit_id: this.subcircuit_id })

--- a/tests/drc/preserve-pcb-drc-errors.test.tsx
+++ b/tests/drc/preserve-pcb-drc-errors.test.tsx
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import type { PcbPadTraceClearanceError, PcbTraceError } from "circuit-json"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test("deduplicates generic PCB trace errors reported by separate DRC checks", async () => {
+test("preserves distinct PCB DRC errors returned by custom checks", async () => {
   const { circuit } = getTestFixture()
 
   circuit.add(
@@ -50,10 +50,9 @@ test("deduplicates generic PCB trace errors reported by separate DRC checks", as
       ["pcb_trace_error", "pcb_pad_trace_clearance_error"].includes(elm.type),
     )
 
-  expect(errors).toHaveLength(1)
-  expect(errors[0]).toMatchObject({
-    type: "pcb_pad_trace_clearance_error",
-    pcb_trace_id: "trace1",
-    pcb_pad_id: "pad1",
-  })
+  expect(errors).toHaveLength(2)
+  expect(errors.map((error) => error.type)).toEqual([
+    "pcb_trace_error",
+    "pcb_pad_trace_clearance_error",
+  ])
 })


### PR DESCRIPTION
## Summary

- stop applying `dedupePcbDrcErrors` when `Board` aggregates DRC results
- insert all routing, placement, netlist, pin-specification, and custom DRC results directly
- update the integration test to verify distinct custom DRC records are preserved

## Why

`@tscircuit/checks@0.0.145` now classifies a trace/obstacle pair as either a physical overlap or a clearance violation. Core no longer needs to remove one result after aggregation, and doing so can incorrectly discard intentionally distinct results from custom checks.

The checks dependency update to `0.0.145` is already present on `main` from #2709; this PR completes the core integration.

## Validation

- `bun test tests/drc/preserve-pcb-drc-errors.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`
- `bunx biome check lib/components/normal-components/Board.ts tests/drc/preserve-pcb-drc-errors.test.tsx`
- `bun test`: 1,183 pass, 31 skip, with one existing `differential-pair/port-selector` snapshot mismatch; the same mismatch reproduces when the old dedupe call is restored and contains routing geometry rather than DRC output
