### PR TITLE
Update @tscircuit/props to 0.0.585

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.19",
-    "@tscircuit/props": "^0.0.584",
+    "@tscircuit/props": "^0.0.585",
     "@tscircuit/schematic-match-adapt": "^0.0.18",
     "@tscircuit/schematic-trace-solver": "^0.0.104",
     "@tscircuit/solver-utils": "^0.0.16",


### PR DESCRIPTION
## Summary

- update @tscircuit/props from ^0.0.584 to ^0.0.585
- consume the maxLengthSkew validation fix from tscircuit/props#742

## Validation

- bun test tests/components/primitive-components/differential-pair (9 passed)
- bunx tsc --noEmit
- bunx biome format .
- bun run build