### PR TITLE
Update circuit-to-svg to 0.0.391

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "circuit-json-to-connectivity-map": "^0.0.23",
     "circuit-json-to-gltf": "^0.0.105",
     "circuit-json-to-spice": "^0.0.43",
-    "circuit-to-svg": "^0.0.390",
+    "circuit-to-svg": "^0.0.391",
     "concurrently": "^9.1.2",
     "connectivity-map": "^1.0.0",
     "debug": "^4.3.6",


### PR DESCRIPTION
## Summary

- bump the existing `circuit-to-svg` dev dependency from `^0.0.390` to `^0.0.391`

## Why

`circuit-to-svg@0.0.391` makes standalone simulation graph SVGs expose the schematic background color on the root SVG. This allows graph-only analog simulation viewers to use the same surrounding background as schematic and combined simulation views.

## Impact

Once this core release propagates into `tscircuit`, downstream packages can consume the graph-only background fix without changing their existing dependency structure.

## Validation

- confirmed the install resolves `circuit-to-svg@0.0.391`
- `bunx tsc --noEmit`
- `bun run build`
- `bun test tests/features/spice-analysis tests/components/normal-components/ammeter-current-voltage-graph.test.tsx` (29 passing)
