### PR TITLE
fix: manualEdits in a positioned group no longer double-counts the group anchor

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -505,12 +505,12 @@ export abstract class PrimitiveComponent<
       this.props.pcbY === undefined
     ) {
       const rotation = this._getPcbRotationBeforeLayout() ?? 0
+      // manualPlacement is already in board-absolute coordinates (computed via
+      // the subcircuit's own global transform), so do NOT compose with the
+      // parent transform again — that would double-count group anchors.
       return compose(
-        this.parent?._computePcbGlobalTransformBeforeLayout() ?? identity(),
-        compose(
-          translate(manualPlacement.x, manualPlacement.y),
-          rotate((rotation * Math.PI) / 180),
-        ),
+        translate(manualPlacement.x, manualPlacement.y),
+        rotate((rotation * Math.PI) / 180),
       )
     }
 

--- a/tests/components/primitive-components/manual-edits-layout.test.tsx
+++ b/tests/components/primitive-components/manual-edits-layout.test.tsx
@@ -15,3 +15,43 @@ test("Manual edits prop usage", () => {
 
   expect(project).toMatchPcbSnapshot(import.meta.path)
 })
+
+test("manualEdits inside a positioned group does not double-count the group anchor", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board
+      width="40mm"
+      height="20mm"
+      manualEdits={{
+        pcb_placements: [
+          {
+            selector: "C1",
+            center: { x: 11.4, y: 4.3 },
+            relative_to: "group_center",
+          },
+        ],
+      }}
+    >
+      <group name="region" pcbX={16} pcbY={0}>
+        <capacitor
+          name="C1"
+          capacitance="100nF"
+          footprint="0402"
+          schX={0}
+          schY={0}
+        />
+      </group>
+    </board>,
+  )
+
+  circuit.render()
+
+  const pcbComponents = circuit.db.pcb_component.list()
+  const c1 = pcbComponents.find((c) => c.source_component_id !== undefined)
+
+  // manualEdits center = (11.4, 4.3) board-absolute
+  // group anchor is at pcbX=16, group must NOT be added again
+  expect(c1?.center.x).toBeCloseTo(11.4, 1)
+  expect(c1?.center.y).toBeCloseTo(4.3, 1)
+})


### PR DESCRIPTION
## Problem

`manualEdits.pcb_placements` places a component at the wrong absolute position when its enclosing `<group>` has a non-zero `pcbX/pcbY`. The group anchor is applied twice: once inside `_getPcbManualPlacementForComponent` (via the subcircuit transform), and again in `_computePcbGlobalTransformBeforeLayout` (via the parent compose).

Closes #2281

## Root Cause

`_getPcbManualPlacementForComponent` computes `center = applyToPoint(subcircuit._computePcbGlobalTransformBeforeLayout(), position.center)`. Since the board is at (0,0), `center` equals `position.center` — already in board-absolute coordinates.

But `_computePcbGlobalTransformBeforeLayout` on the child then does:
```ts
return compose(
  this.parent?._computePcbGlobalTransformBeforeLayout() ?? identity(), // group: translate(16, 0)
  compose(translate(11.4, 4.3), rotate(0)),
)
// Result: translate(27.4, 4.3) — group anchor counted twice
```

## Fix

Remove the parent compose from the manual-placement branch. The manual placement center is already board-absolute and needs no further transformation:
```ts
// Before:
return compose(
  this.parent?._computePcbGlobalTransformBeforeLayout() ?? identity(),
  compose(translate(manualPlacement.x, manualPlacement.y), rotate(...)),
)
// After:
return compose(
  translate(manualPlacement.x, manualPlacement.y),
  rotate((rotation * Math.PI) / 180),
)
```

## Test

Added new test in `manual-edits-layout.test.tsx`: a capacitor dragged to `(11.4, 4.3)` inside a group at `pcbX=16` must land at `(11.4, 4.3)`, not at `(27.4, 4.3)`.