### PR TITLE
fix: pcbPositionMode=relative_to_board_anchor now uses board-absolute coordinates

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -514,6 +514,16 @@ export abstract class PrimitiveComponent<
       )
     }
 
+    // When pcbPositionMode is relative_to_board_anchor, the declared pcbX/pcbY
+    // are board-absolute coordinates — don't compose with parent transform.
+    const pcbPositionMode = (this._parsedProps as any)?.pcbPositionMode
+    if (pcbPositionMode === "relative_to_board_anchor") {
+      const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
+      if (pcbX !== undefined || pcbY !== undefined) {
+        return this.computePcbPropsTransform()
+      }
+    }
+
     // If this is a primitive, and the parent primitive container is flipped,
     // we flip it's position
     if (this.isPcbPrimitive) {

--- a/tests/components/normal-components/pcb-position-mode.test.tsx
+++ b/tests/components/normal-components/pcb-position-mode.test.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("pcbPositionMode=relative_to_board_anchor uses board-absolute coordinates inside a group", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="40mm" height="20mm">
+      <group name="region" pcbX={16} pcbY={0}>
+        <chip
+          name="U1"
+          footprint="dip8"
+          pcbX={5}
+          pcbY={3}
+          pcbPositionMode="relative_to_board_anchor"
+        />
+      </group>
+    </board>,
+  )
+
+  circuit.render()
+
+  const pcbComponents = circuit.db.pcb_component.list()
+  const u1 = pcbComponents.find((c) => c.source_component_id !== undefined)
+
+  // pcbPositionMode=relative_to_board_anchor means pcbX=5, pcbY=3 are board-absolute
+  // so group anchor (pcbX=16) must NOT be added on top
+  expect(u1?.center.x).toBeCloseTo(5, 1)
+  expect(u1?.center.y).toBeCloseTo(3, 1)
+})
+
+test("pcbPositionMode=relative_to_group_anchor (default) adds parent group offset", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="40mm" height="20mm">
+      <group name="region" pcbX={16} pcbY={0}>
+        <chip
+          name="U1"
+          footprint="dip8"
+          pcbX={5}
+          pcbY={3}
+          pcbPositionMode="relative_to_group_anchor"
+        />
+      </group>
+    </board>,
+  )
+
+  circuit.render()
+
+  const pcbComponents = circuit.db.pcb_component.list()
+  const u1 = pcbComponents.find((c) => c.source_component_id !== undefined)
+
+  // relative_to_group_anchor: board position = group anchor (16,0) + local offset (5,3) = (21,3)
+  expect(u1?.center.x).toBeCloseTo(21, 1)
+  expect(u1?.center.y).toBeCloseTo(3, 1)
+})


### PR DESCRIPTION
## Problem

`pcbPositionMode=relative_to_board_anchor` typed correctly but had no runtime effect. A chip at `pcbX={5}` inside a `<group>` at `pcbX={16}` always landed at x=21, regardless of `pcbPositionMode`.

Closes #2242

## Root Cause

`_computePcbGlobalTransformBeforeLayout` always composed `pcbX/pcbY` on top of the parent group's transform. The `pcbPositionMode` prop was parsed by zod but never read anywhere in the position-resolution code.

## Fix

Added a branch in `_computePcbGlobalTransformBeforeLayout`: when `pcbPositionMode === relative_to_board_anchor` and explicit `pcbX/pcbY` are set, return just `computePcbPropsTransform()` without composing the parent transform:

```ts
const pcbPositionMode = (this._parsedProps as any)?.pcbPositionMode
if (pcbPositionMode === relative_to_board_anchor) {
  const { pcbX, pcbY } = this.getResolvedPcbPositionProp()
  if (pcbX !== undefined || pcbY !== undefined) {
    return this.computePcbPropsTransform()  // board-absolute, no parent offset
  }
}
```

## Tests

Two new tests in `pcb-position-mode.test.tsx`:
- `relative_to_board_anchor`: chip at pcbX=5 inside group at pcbX=16 must land at x=5 (not x=21)
- `relative_to_group_anchor` (default): chip at pcbX=5 inside group at pcbX=16 must land at x=21 (unchanged behavior)