### PR TITLE
fix: schTraceAutoLabelEnabled={false} now suppresses auto net labels

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/Group_doInitialSchematicTraceRender.ts
@@ -38,13 +38,21 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
     inputProblem.directConnections.length > 0 ||
     inputProblem.netConnections.length > 0
 
+  // When the user explicitly disables auto-labels, skip all automatic net
+  // label emission. Wires for direct connections still appear via
+  // applyTracesFromSolverOutput; named-net connections become wire-only.
+  const autoLabelEnabled =
+    group._parsedProps.schTraceAutoLabelEnabled !== false
+
   if (!hasRouteableSchematicConnections) {
-    insertNetLabelsForPortsMissingTrace({
-      group,
-      allSourceAndSchematicPortIdsInScope,
-      schPortIdToSourcePortId,
-      connKeyToSourceNet,
-    })
+    if (autoLabelEnabled) {
+      insertNetLabelsForPortsMissingTrace({
+        group,
+        allSourceAndSchematicPortIdsInScope,
+        schPortIdToSourcePortId,
+        connKeyToSourceNet,
+      })
+    }
     return
   }
 
@@ -84,21 +92,23 @@ export const Group_doInitialSchematicTraceRender = (group: Group<any>) => {
   })
 
   // Apply net labels (from solver placements and net-only ports)
-  applyNetLabelPlacements({
-    group,
-    solver,
-    connKeyToSourceNet,
-    pinIdToSchematicPortId,
-    userNetIdToConnKey,
-    connKeysWithExplicitPortNetTraces,
-    schematicPortIdsWithPreExistingNetLabels,
-    schematicPortIdsWithRoutedTraces,
-  })
+  if (autoLabelEnabled) {
+    applyNetLabelPlacements({
+      group,
+      solver,
+      connKeyToSourceNet,
+      pinIdToSchematicPortId,
+      userNetIdToConnKey,
+      connKeysWithExplicitPortNetTraces,
+      schematicPortIdsWithPreExistingNetLabels,
+      schematicPortIdsWithRoutedTraces,
+    })
 
-  insertNetLabelsForPortsMissingTrace({
-    group,
-    allSourceAndSchematicPortIdsInScope,
-    schPortIdToSourcePortId,
-    connKeyToSourceNet,
-  })
+    insertNetLabelsForPortsMissingTrace({
+      group,
+      allSourceAndSchematicPortIdsInScope,
+      schPortIdToSourcePortId,
+      connKeyToSourceNet,
+    })
+  }
 }

--- a/tests/components/normal-components/sch-trace-auto-label-disabled.test.tsx
+++ b/tests/components/normal-components/sch-trace-auto-label-disabled.test.tsx
@@ -1,0 +1,54 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("schTraceAutoLabelEnabled={false} suppresses automatic schematic_net_label elements", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" schTraceAutoLabelEnabled={false}>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin2: "GND" }}
+        connections={{ VCC: "net.V3_3", GND: "net.GND" }}
+      />
+      <resistor
+        name="R1"
+        resistance="10k"
+        footprint="0402"
+        connections={{ pin1: "net.V3_3", pin2: "net.GND" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  // With auto-labels disabled no schematic_net_label should be emitted
+  expect(circuit.db.schematic_net_label.list()).toHaveLength(0)
+})
+
+test("schTraceAutoLabelEnabled unset (default) does emit schematic_net_label elements", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin2: "GND" }}
+        connections={{ VCC: "net.V3_3", GND: "net.GND" }}
+      />
+      <resistor
+        name="R1"
+        resistance="10k"
+        footprint="0402"
+        connections={{ pin1: "net.V3_3", pin2: "net.GND" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  // Without explicitly disabling auto-labels, they should appear
+  expect(circuit.db.schematic_net_label.list().length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
﻿## Summary

schTraceAutoLabelEnabled={false} on a board or group had no observable effect: the MSP schematic renderer always called applyNetLabelPlacements() and insertNetLabelsForPortsMissingTrace(), emitting schematic_net_label elements regardless.

## Root Cause

The schTraceAutoLabelEnabled check in Trace_doInitialSchematicTraceRender.ts only guards the complex-trace display-label path. The group-level MSP renderer had no guard at all.

## Fix

Read group._parsedProps.schTraceAutoLabelEnabled !== false once (autoLabelEnabled). Guard both net-label insertion calls behind it. The solver still runs and applyTracesFromSolverOutput still fires, so wire-based connections remain visible; only the automatic net-name label boxes (schematic_net_label) are suppressed.

## Changes

- Group_doInitialSchematicTraceRender.ts: 2 call-sites guarded
- tests/components/normal-components/sch-trace-auto-label-disabled.test.tsx: 2 tests

## Test plan

- bun test tests/components/normal-components/sch-trace-auto-label-disabled.test.tsx passes on CI
- Existing schematic label tests still pass

Fixes #2243
