### PR TITLE
Update Node-compatible FDM enclosure package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@tscircuit/circuit-json-util": "^0.0.97",
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "0.0.39",
-    "@tscircuit/create-fdm-enclosure": "0.0.2",
+    "@tscircuit/create-fdm-enclosure": "0.0.3",
     "@tscircuit/footprinter": "^0.0.380",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/infer-cable-insertion-point": "^0.0.2",


### PR DESCRIPTION
## Summary

Update `@tscircuit/create-fdm-enclosure` from `0.0.2` to `0.0.3`.

## Why

Version `0.0.2` published its runtime entrypoint as raw TypeScript (`lib/index.ts`). Plain Node consumers fail to import core with `ERR_UNKNOWN_FILE_EXTENSION`, which caused `svg.tscircuit.com` render requests to return HTTP 500 after the FDM enclosure dependency was introduced.

Version `0.0.3`, published from tscircuit/create-fdm-enclosure#3, ships compiled JavaScript and declarations from `dist` with Node-compatible package exports.

## Validation

- `bun test tests/fiber/namespaced-enclosure-fdm-box.test.tsx tests/fiber/namespaced-enclosure-fdm-box-type.test.tsx tests/enclosure/enclosure-fdm-box-usb-cutout.test.tsx --timeout 120000` — 3 passed
- `bunx tsc --noEmit`
- `bun run build`
- imported the built `@tscircuit/core` package under plain Node and verified `RootCircuit` is available