### PR TITLE
Update capacity autorouter to 0.0.710

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@resvg/resvg-js": "^2.6.2",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
-    "@tscircuit/capacity-autorouter": "^0.0.696",
+    "@tscircuit/capacity-autorouter": "^0.0.710",
     "@tscircuit/checks": "0.0.145",
     "@tscircuit/circuit-json-util": "^0.0.97",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

Updates `@tscircuit/capacity-autorouter` from `^0.0.696` to `^0.0.710` so core uses the latest autorouting fixes and behavior.

## Impact

No core implementation changes are included. Snapshot and DRC baselines will only be updated if this dependency change causes corresponding CI failures.

## Validation

- `bun run build`
- `bunx tsc --noEmit`
