### PR TITLE
fix: <switch /> drops supplierPartNumbers/manufacturerPartNumber, part missing from BOM

### DIFF
--- a/lib/components/normal-components/Switch.ts
+++ b/lib/components/normal-components/Switch.ts
@@ -55,6 +55,8 @@ export class Switch extends NormalComponent<typeof switchProps> {
     const source_component = db.source_component.insert({
       ftype: "simple_switch",
       name: this.name,
+      manufacturer_part_number: props.manufacturerPartNumber ?? props.mfn,
+      supplier_part_numbers: props.supplierPartNumbers,
       are_pins_interchangeable: this._getSwitchType() === "spst",
       display_name: props?.displayName,
     })

--- a/tests/components/normal-components/switch-supplier-part-numbers.test.tsx
+++ b/tests/components/normal-components/switch-supplier-part-numbers.test.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("<switch /> propagates supplierPartNumbers and manufacturerPartNumber to source_component", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <switch
+        name="SW1"
+        type="spdt"
+        supplierPartNumbers={{ jlcpcb: ["C2681570"] }}
+        manufacturerPartNumber="SS-12D00G3"
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const sourceComponent = circuit.db.source_component.getWhere({
+    name: "SW1",
+  })
+
+  expect(sourceComponent?.supplier_part_numbers).toEqual({
+    jlcpcb: ["C2681570"],
+  })
+  expect(sourceComponent?.manufacturer_part_number).toBe("SS-12D00G3")
+})


### PR DESCRIPTION
Fixes tscircuit/tscircuit#4056

## Problem

`<switch />` accepts `supplierPartNumbers` (valid per `SwitchProps extends CommonComponentProps`), but `Switch.doInitialSourceRender()` builds the `source_component` with a fixed field list that omits `supplier_part_numbers` and `manufacturer_part_number`. The value silently disappears and the part never reaches the BOM — no type error, no warning.

Every other component type (`<chip />`, `<pushbutton />`, `<led />`, `<resistor />`, …) passes these through, e.g. PushButton:

```ts
supplier_part_numbers: props.supplierPartNumbers,
```

## Fix

Pass both fields through in `Switch.doInitialSourceRender()`, matching the pattern used by the other normal components (`manufacturerPartNumber ?? mfn` alias handling as in Resistor/Capacitor):

```ts
manufacturer_part_number: props.manufacturerPartNumber ?? props.mfn,
supplier_part_numbers: props.supplierPartNumbers,
```

## Test

Red→green test `tests/components/normal-components/switch-supplier-part-numbers.test.tsx`: renders a `<switch />` with `supplierPartNumbers={{ jlcpcb: ["C2681570"] }}` and `manufacturerPartNumber`, asserts both land on the `source_component`. Fails on main (`supplier_part_numbers` empty), passes with this change. Existing switch tests still pass; `tsc --noEmit` clean.
