### PR TITLE
Reject new string-keyed maps in CI

### DIFF
--- a/.github/workflows/bun-typecheck.yml
+++ b/.github/workflows/bun-typecheck.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
@@ -21,6 +23,11 @@ jobs:
 
       - name: Install dependencies
         run: bun i
+
+      - name: Reject new string-keyed Map types
+        env:
+          LINT_BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || 'HEAD^' }}
+        run: bun run lint:map-keys
 
       - name: Run typecheck
         run: bunx tsc --noEmit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,9 +115,9 @@ circuit.selectOne("resistor") // Find first resistor
 - Do not introduce transport, protocol, or serialization vocabulary into the
   internal domain model. Translate domain identifiers into boundary-specific
   fields only at the serialization or adapter boundary.
-- **`Map<string, ...>` is banned.** Always use an existing named or branded key
-  type, such as `Map<SchematicPortId, ...>`, and name mapping variables to make
-  both key and value meanings clear.
+- Do not use raw `Map<string, ...>` types for domain identifiers. Use an existing
+  named or branded key type, such as `Map<SourceTraceId, ...>`, and name mapping
+  variables to make both key and value meanings clear.
 - Do not widen domain identifiers or keys to `string` in parameters, return
   types, collections, or intermediate values. Use or export the canonical named
   or branded type, such as `SourceTraceId` or `SubcircuitConnectivityMapKey`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,9 +115,9 @@ circuit.selectOne("resistor") // Find first resistor
 - Do not introduce transport, protocol, or serialization vocabulary into the
   internal domain model. Translate domain identifiers into boundary-specific
   fields only at the serialization or adapter boundary.
-- Do not use raw `Map<string, ...>` types for domain identifiers. Use an existing
-  named or branded key type, such as `Map<SourceTraceId, ...>`, and name mapping
-  variables to make both key and value meanings clear.
+- **`Map<string, ...>` is banned.** Always use an existing named or branded key
+  type, such as `Map<SchematicPortId, ...>`, and name mapping variables to make
+  both key and value meanings clear.
 - Do not widen domain identifiers or keys to `string` in parameters, return
   types, collections, or intermediate values. Use or export the canonical named
   or branded type, such as `SourceTraceId` or `SubcircuitConnectivityMapKey`.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "build": "tsup-node",
     "format": "biome format . --write",
+    "lint:map-keys": "bun run scripts/check-for-new-map-string-keys.ts",
     "measure-bundle": "howfat -r table .",
     "pkg-pr-new-release": "bunx pkg-pr-new publish --comment=off --peerDeps",
     "smoke-test:dist": "bun run scripts/smoke-tests/test-dist-simple-circuit.tsx",

--- a/scripts/check-for-new-map-string-keys.ts
+++ b/scripts/check-for-new-map-string-keys.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import ts from "typescript"
+
+type RepositoryFilePath = string
+
+export interface SourceRange {
+  startLine: number
+  endLine: number
+}
+
+const runGit = (args: string[]): string => {
+  const result = spawnSync("git", args, { encoding: "utf8" })
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `git ${args.join(" ")} failed`)
+  }
+
+  return result.stdout
+}
+
+export const getAddedLineNumbersByFilePath = (
+  diff: string,
+): Map<RepositoryFilePath, Set<number>> => {
+  const addedLineNumbersByFilePath = new Map<RepositoryFilePath, Set<number>>()
+  let currentFilePath: RepositoryFilePath | null = null
+  let currentNewLineNumber: number | null = null
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+++ ")) {
+      const filePath = line.slice(4).replace(/^b\//, "")
+      currentFilePath = filePath === "/dev/null" ? null : filePath
+      currentNewLineNumber = null
+      continue
+    }
+
+    const hunkHeaderMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+    if (hunkHeaderMatch) {
+      currentNewLineNumber = Number(hunkHeaderMatch[1])
+      continue
+    }
+
+    if (currentFilePath === null || currentNewLineNumber === null) continue
+
+    if (line.startsWith("+")) {
+      const addedLineNumbers =
+        addedLineNumbersByFilePath.get(currentFilePath) ?? new Set<number>()
+      addedLineNumbers.add(currentNewLineNumber)
+      addedLineNumbersByFilePath.set(currentFilePath, addedLineNumbers)
+      currentNewLineNumber++
+    } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+      currentNewLineNumber++
+    }
+  }
+
+  return addedLineNumbersByFilePath
+}
+
+export const findRawStringMapKeyRanges = (source: string): SourceRange[] => {
+  const sourceFile = ts.createSourceFile(
+    "source.tsx",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  )
+  const ranges: SourceRange[] = []
+
+  const visit = (node: ts.Node) => {
+    const isMapTypeReference =
+      ts.isTypeReferenceNode(node) &&
+      ts.isIdentifier(node.typeName) &&
+      node.typeName.text === "Map"
+    const isMapConstructor =
+      ts.isNewExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "Map"
+    const typeArguments =
+      isMapTypeReference || isMapConstructor ? node.typeArguments : undefined
+
+    if (typeArguments?.[0]?.kind === ts.SyntaxKind.StringKeyword) {
+      const start = sourceFile.getLineAndCharacterOfPosition(
+        node.getStart(sourceFile),
+      )
+      const end = sourceFile.getLineAndCharacterOfPosition(node.getEnd())
+      ranges.push({ startLine: start.line + 1, endLine: end.line + 1 })
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return ranges
+}
+
+export const findNewRawStringMapKeyLines = (
+  source: string,
+  addedLineNumbers: Set<number>,
+): number[] =>
+  findRawStringMapKeyRanges(source)
+    .filter(({ startLine, endLine }) => {
+      for (let lineNumber = startLine; lineNumber <= endLine; lineNumber++) {
+        if (addedLineNumbers.has(lineNumber)) return true
+      }
+      return false
+    })
+    .map(({ startLine }) => startLine)
+
+const main = () => {
+  const baseRef = process.env.LINT_BASE_REF || "origin/main"
+  const mergeBase = runGit(["merge-base", baseRef, "HEAD"]).trim()
+  const diff = runGit([
+    "diff",
+    "--unified=0",
+    "--no-color",
+    "--diff-filter=ACMR",
+    mergeBase,
+    "--",
+    "*.ts",
+    "*.tsx",
+    "*.mts",
+    "*.cts",
+  ])
+  const addedLineNumbersByFilePath = getAddedLineNumbersByFilePath(diff)
+  const violations: Array<{
+    filePath: RepositoryFilePath
+    lineNumber: number
+  }> = []
+
+  for (const [filePath, addedLineNumbers] of addedLineNumbersByFilePath) {
+    const source = readFileSync(filePath, "utf8")
+    for (const lineNumber of findNewRawStringMapKeyLines(
+      source,
+      addedLineNumbers,
+    )) {
+      violations.push({ filePath, lineNumber })
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log("No new Map<string, ...> key types found.")
+    return
+  }
+
+  for (const { filePath, lineNumber } of violations) {
+    console.error(
+      `${filePath}:${lineNumber}: Map<string, ...> is banned. Use a named or branded key type, such as Map<SchematicPortId, ...>.`,
+    )
+  }
+  process.exitCode = 1
+}
+
+if (import.meta.main) main()

--- a/tests/lint/check-for-new-map-string-keys.test.ts
+++ b/tests/lint/check-for-new-map-string-keys.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import {
+  findNewRawStringMapKeyLines,
+  findRawStringMapKeyRanges,
+  getAddedLineNumbersByFilePath,
+} from "../../scripts/check-for-new-map-string-keys"
+
+test("finds raw string Map keys but ignores comments and strings", () => {
+  const source = [
+    "const good = new Map<SchematicPortId, Port>()",
+    "const bad = new " + "Map<string, Port>()",
+    "// " + "Map<string, Port>() is only documentation",
+    'const example = "' + "Map<string, Port>()" + '"',
+  ].join("\n")
+
+  expect(findRawStringMapKeyRanges(source)).toEqual([
+    { startLine: 2, endLine: 2 },
+  ])
+})
+
+test("finds a multiline raw string Map key when any of its lines are added", () => {
+  const source = ["const ports = new Map<", "  string,", "  Port", ">()"].join(
+    "\n",
+  )
+
+  expect(findNewRawStringMapKeyLines(source, new Set([2]))).toEqual([1])
+})
+
+test("parses added line numbers from a zero-context git diff", () => {
+  const diff = [
+    "diff --git a/lib/example.ts b/lib/example.ts",
+    "--- a/lib/example.ts",
+    "+++ b/lib/example.ts",
+    "@@ -1,0 +2,2 @@",
+    "+const ports = new " + "Map<string, Port>()",
+    "+usePorts(ports)",
+  ].join("\n")
+
+  expect([
+    ...getAddedLineNumbersByFilePath(diff).get("lib/example.ts")!,
+  ]).toEqual([2, 3])
+})


### PR DESCRIPTION
## Summary

- add a `lint:map-keys` ratchet that rejects new `Map<string, ...>` type references and constructors
- compare added TypeScript lines with the PR base so existing violations can be migrated incrementally
- run the check in the typecheck workflow and cover its diff parsing and TypeScript AST detection with focused tests

## Why

Named key types make the meaning of map keys visible at every declaration and call site, improving readability and preventing unrelated string identifiers from being mixed.

The repository currently has 80 legacy `Map<string, ...>` occurrences across 32 files. A whole-repository check would fail immediately, so this change prevents new violations without coupling the lint rule to a risky mass refactor.

## Impact

New single-line or multiline `Map<string, ...>` syntax fails CI when it is introduced on an added line. Comments and string literals are ignored.

## Validation

- `bun run lint:map-keys`
- focused lint tests: 3 passed
- `bunx biome check scripts/check-for-new-map-string-keys.ts tests/lint/check-for-new-map-string-keys.test.ts`
- `bunx tsc --noEmit`
- `git diff --check main...HEAD`
