### PR TITLE
fix: propagate manufacturerPartNumber and supplierPartNumbers in mosfet

### DIFF
--- a/lib/components/normal-components/Mosfet.ts
+++ b/lib/components/normal-components/Mosfet.ts
@@ -20,6 +20,8 @@ export class Mosfet extends NormalComponent<typeof mosfetProps> {
     const source_component = db.source_component.insert({
       ftype: "simple_mosfet",
       name: this.name,
+      manufacturer_part_number: props.manufacturerPartNumber ?? props.mfn,
+      supplier_part_numbers: props.supplierPartNumbers,
       mosfet_mode: props.mosfetMode,
       channel_type: props.channelType,
       display_name: props.displayName,

--- a/tests/components/normal-components/mosfet-supplier-part-numbers.test.tsx
+++ b/tests/components/normal-components/mosfet-supplier-part-numbers.test.tsx
@@ -4,36 +4,33 @@
 import { expect, test } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test.failing(
-  "<mosfet /> propagates supplierPartNumbers and manufacturerPartNumber to source_component",
-  async () => {
-    const { circuit } = getTestFixture()
+test("<mosfet /> propagates supplierPartNumbers and manufacturerPartNumber to source_component", async () => {
+  const { circuit } = getTestFixture()
 
-    circuit.add(
-      <board width="20mm" height="20mm">
-        <mosfet
-          name="Q1"
-          channelType="n"
-          mosfetMode="enhancement"
-          footprint="to220_3"
-          manufacturerPartNumber="IRF520N"
-          supplierPartNumbers={{ jlcpcb: ["C2681570"] }}
-        />
-      </board>,
-    )
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <mosfet
+        name="Q1"
+        channelType="n"
+        mosfetMode="enhancement"
+        footprint="to220_3"
+        manufacturerPartNumber="IRF520N"
+        supplierPartNumbers={{ jlcpcb: ["C2681570"] }}
+      />
+    </board>,
+  )
 
-    await circuit.renderUntilSettled()
+  await circuit.renderUntilSettled()
 
-    expect(circuit).toMatchPcbSnapshot(import.meta.path)
-    expect(circuit).toMatchSchematicSnapshot(import.meta.path)
+  expect(circuit).toMatchPcbSnapshot(import.meta.path)
+  expect(circuit).toMatchSchematicSnapshot(import.meta.path)
 
-    const sourceComponent = circuit.db.source_component.getWhere({
-      name: "Q1",
-    })
+  const sourceComponent = circuit.db.source_component.getWhere({
+    name: "Q1",
+  })
 
-    expect(sourceComponent?.supplier_part_numbers).toEqual({
-      jlcpcb: ["C2681570"],
-    })
-    expect(sourceComponent?.manufacturer_part_number).toBe("IRF520N")
-  },
-)
+  expect(sourceComponent?.supplier_part_numbers).toEqual({
+    jlcpcb: ["C2681570"],
+  })
+  expect(sourceComponent?.manufacturer_part_number).toBe("IRF520N")
+})


### PR DESCRIPTION
Fixes #2776.

## Summary

`<mosfet />` did not propagate `manufacturerPartNumber` and
`supplierPartNumbers` to the generated `source_component`.

This change serializes the missing fields in `Mosfet#doInitialSourceRender()`.