### PR TITLE
fix: support pcbStyle.silkscreenTextPosition for footprint designators

### DIFF
--- a/lib/utils/pcbSx/convert-pcb-style-to-pcb-sx.ts
+++ b/lib/utils/pcbSx/convert-pcb-style-to-pcb-sx.ts
@@ -7,6 +7,11 @@ import type { PcbStyle, PcbSx } from "@tscircuit/props"
  * Mapping:
  *   silkscreenFontSize        -> "& silkscreentext": { fontSize }
  *   silkscreenTextVisibility  -> "& silkscreentext": { visibility }
+ *   silkscreenTextPosition    -> "& silkscreentext": { pcbX, pcbY, visibility }
+ *     - { offsetX, offsetY }  -> pcbX, pcbY
+ *     - "centered"            -> pcbX: 0, pcbY: 0
+ *     - "outside"             -> no-op (footprinter default)
+ *     - "none"                -> visibility: "hidden"
  */
 export function convertPcbStyleToPcbSx(
   pcbStyle: PcbStyle | undefined,
@@ -22,6 +27,27 @@ export function convertPcbStyleToPcbSx(
 
   if (pcbStyle.silkscreenTextVisibility !== undefined) {
     silkscreenTextSx.visibility = pcbStyle.silkscreenTextVisibility
+  }
+
+  if (pcbStyle.silkscreenTextPosition !== undefined) {
+    if (
+      typeof pcbStyle.silkscreenTextPosition === "object" &&
+      pcbStyle.silkscreenTextPosition !== null
+    ) {
+      if (pcbStyle.silkscreenTextPosition.offsetX !== undefined) {
+        silkscreenTextSx.pcbX = pcbStyle.silkscreenTextPosition.offsetX
+      }
+      if (pcbStyle.silkscreenTextPosition.offsetY !== undefined) {
+        silkscreenTextSx.pcbY = pcbStyle.silkscreenTextPosition.offsetY
+      }
+    } else if (pcbStyle.silkscreenTextPosition === "centered") {
+      silkscreenTextSx.pcbX = 0
+      silkscreenTextSx.pcbY = 0
+    } else if (pcbStyle.silkscreenTextPosition === "outside") {
+      // "outside" is the footprinter default — no explicit position override needed
+    } else if (pcbStyle.silkscreenTextPosition === "none") {
+      silkscreenTextSx.visibility = "hidden"
+    }
   }
 
   if (Object.keys(silkscreenTextSx).length > 0) {

--- a/tests/features/pcb-style-silkscreen-text-visibility.test.tsx
+++ b/tests/features/pcb-style-silkscreen-text-visibility.test.tsx
@@ -21,3 +21,128 @@ test("pcbStyle.silkscreenTextVisibility hides footprinter-generated designators"
   expect(circuit.db.pcb_smtpad.list().length).toBeGreaterThan(0)
   expect(circuit).toMatchPcbSnapshot(import.meta.path)
 })
+
+test("pcbStyle.silkscreenTextVisibility on component hides only that component's designator", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm">
+      <resistor
+        name="R1"
+        resistance="330"
+        footprint="0402"
+        pcbX={-5}
+        pcbY={0}
+        pcbStyle={{ silkscreenTextVisibility: "hidden" }}
+      />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={5} pcbY={0} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const silkscreenTexts = circuit.db.pcb_silkscreen_text.list()
+  // R1 designator hidden, R2 designator visible
+  expect(silkscreenTexts.map((t) => t.text)).toEqual(["R2"])
+})
+
+test("pcbStyle.silkscreenTextPosition offsets footprint designator text", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm">
+      <resistor
+        name="R1"
+        resistance="330"
+        footprint="0402"
+        pcbX={0}
+        pcbY={0}
+        pcbStyle={{
+          silkscreenTextPosition: { offsetX: 2, offsetY: 3 },
+        }}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const text = circuit.db.pcb_silkscreen_text.getWhere({ text: "R1" })
+  expect(text).toBeDefined()
+  expect(text?.anchor_position.x).toBe(2)
+  expect(text?.anchor_position.y).toBe(3)
+})
+
+test("pcbStyle.silkscreenTextPosition 'none' hides footprint designator text", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm">
+      <resistor
+        name="R1"
+        resistance="330"
+        footprint="0402"
+        pcbX={0}
+        pcbY={0}
+        pcbStyle={{
+          silkscreenTextPosition: "none",
+        }}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const text = circuit.db.pcb_silkscreen_text.getWhere({ text: "R1" })
+  expect(text).toBeUndefined()
+})
+
+test("pcbStyle.silkscreenTextPosition 'centered' centers footprint designator text at component origin", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm">
+      <resistor
+        name="R1"
+        resistance="330"
+        footprint="0402"
+        pcbX={5}
+        pcbY={5}
+        pcbStyle={{
+          silkscreenTextPosition: "centered",
+        }}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const text = circuit.db.pcb_silkscreen_text.getWhere({ text: "R1" })
+  expect(text).toBeDefined()
+  expect(text?.anchor_position.x).toBe(5)
+  expect(text?.anchor_position.y).toBe(5)
+})
+
+test("pcbStyle.silkscreenTextPosition 'outside' renders footprint designator at default position", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm">
+      <resistor
+        name="R1"
+        resistance="330"
+        footprint="0402"
+        pcbX={5}
+        pcbY={5}
+        pcbStyle={{
+          silkscreenTextPosition: "outside",
+        }}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const text = circuit.db.pcb_silkscreen_text.getWhere({ text: "R1" })
+  // "outside" should render text (unlike "none" which hides it)
+  expect(text).toBeDefined()
+})


### PR DESCRIPTION
Support `silkscreenTextPosition` (`centered`, `none`, `{ offsetX, offsetY }`) and `silkscreenTextVisibility` in `convertPcbStyleToPcbSx` for footprint-driven designators.

Fixes tscircuit/tscircuit#3296