### PR TITLE
perf: share the base PrimitiveComponent config instead of rebuilding per access (#2810)

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -63,6 +63,17 @@ export interface BaseComponentConfig {
  * React subtrees or explicit handling of the "footprint" prop. But otherwise
  * has most of the features of a NormalComponent.
  */
+/**
+ * Shared base config: `get config()` is a plain getter accessed thousands of
+ * times per build, and constructing a fresh `z.object({}).passthrough()` per
+ * access retains ~15 eagerly-bound Zod v3 methods per instance — a major
+ * contributor to the heap growth in #2810.
+ */
+const basePrimitiveComponentConfig: BaseComponentConfig = {
+  componentName: "",
+  zodProps: z.object({}).passthrough(),
+}
+
 export abstract class PrimitiveComponent<
   ZodProps extends ZodType = any,
 > extends Renderable {
@@ -71,10 +82,7 @@ export abstract class PrimitiveComponent<
   childrenPendingRemoval: PrimitiveComponent[]
 
   get config(): BaseComponentConfig {
-    return {
-      componentName: "",
-      zodProps: z.object({}).passthrough(),
-    }
+    return basePrimitiveComponentConfig
   }
 
   props: z.input<ZodProps>


### PR DESCRIPTION
Progress on #2810 — the low-risk first slice of the suggested pure-TS fix.

## Change

The base `PrimitiveComponent.get config()` constructed a **fresh** `z.object({}).passthrough()` on every access:

```ts
get config(): BaseComponentConfig {
  return { componentName: "", zodProps: z.object({}).passthrough() }
}
```

`config` is a plain getter with no memo cache, accessed thousands of times per build, and each Zod v3 schema instance eagerly binds ~15 methods (`.parse`, `.safeParse`, `.refine`, …). The heap snapshot in tscircuit/tscircuit#4077 shows ~714k `native_bind` closures retained across ~47k schema instances, with the non-memoized base `get config()` called out as one of the two code-level causes.

The base config is now a module-level shared const — components that don't override `config` no longer allocate a schema (plus its ~15 bound closures) per access. Subclass configs already return module-level `zodProps` (`netProps`, `traceProps`, …) and are unchanged.

## Scope

This intentionally does **not** attempt the Zod v4 migration or a general per-class config memo (both larger, riskier follow-ups listed in the issue). It removes the one unambiguous per-access allocation.

## Verification

- Full `tests/components` suite: 562 pass, 1 fail — the failing `registers a differential pair using port selectors` test fails identically on `main` (pre-existing, unrelated)
- `bunx tsc --noEmit` / `biome check` — clean
