### PR TITLE
Use schematic port names when constructing solver input

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/createSchematicTraceSolverInputProblem.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSchematicTraceRender/createSchematicTraceSolverInputProblem.ts
@@ -260,7 +260,7 @@ export function createSchematicTraceSolverInputProblem(
 
   // Direct connections derived from explicit source_traces
   const directConnections: Array<{
-    pinIds: [string, string]
+    schematicPortIds: [SchematicPortId, SchematicPortId]
     netId?: string
     netLabelWidth?: number
   }> = []
@@ -328,7 +328,7 @@ export function createSchematicTraceSolverInputProblem(
           )
         }
         directConnections.push({
-          pinIds: [a, b],
+          schematicPortIds: [a, b],
           netId: userNetId,
           netLabelWidth,
         })
@@ -339,7 +339,7 @@ export function createSchematicTraceSolverInputProblem(
   // Net connections derived from named nets (source_net) in-scope
   const netConnections: Array<{
     netId: string
-    pinIds: string[]
+    schematicPortIds: SchematicPortId[]
     netLabelWidth?: number
     netLabelHeight?: number
   }> = []
@@ -356,16 +356,18 @@ export function createSchematicTraceSolverInputProblem(
   /**
    * Subcircuit connectivity map key to schematic port ids
    */
-  const connKeyToPinIds = new Map<string, SchematicPortId[]>()
+  const connKeyToSchematicPortIds = new Map<string, SchematicPortId[]>()
   for (const [schId, srcPortId] of schPortIdToSourcePortId) {
     const sp = db.source_port.get(srcPortId)
     if (!sp?.subcircuit_connectivity_map_key) continue
     const connKey = sp.subcircuit_connectivity_map_key
-    if (!connKeyToPinIds.has(connKey)) connKeyToPinIds.set(connKey, [])
-    connKeyToPinIds.get(connKey)!.push(schId)
+    if (!connKeyToSchematicPortIds.has(connKey)) {
+      connKeyToSchematicPortIds.set(connKey, [])
+    }
+    connKeyToSchematicPortIds.get(connKey)!.push(schId)
   }
 
-  for (const [connKey, schematicPortIds] of connKeyToPinIds) {
+  for (const [connKey, schematicPortIds] of connKeyToSchematicPortIds) {
     const sourceNet = connKeyToSourceNet.get(connKey)
     if (sourceNet && schematicPortIds.length >= 1) {
       const seenRoutedSchematicPortIds = new Set<SchematicPortId>()
@@ -413,7 +415,7 @@ export function createSchematicTraceSolverInputProblem(
 
       netConnections.push({
         netId: userNetId,
-        pinIds: uniqueSchematicPortIds,
+        schematicPortIds: uniqueSchematicPortIds,
         netLabelWidth,
         netLabelHeight,
       })
@@ -445,8 +447,18 @@ export function createSchematicTraceSolverInputProblem(
 
   const inputProblem: InputProblem = {
     chips,
-    directConnections,
-    netConnections,
+    directConnections: directConnections.map(
+      ({ schematicPortIds, ...connection }) => ({
+        ...connection,
+        pinIds: schematicPortIds,
+      }),
+    ),
+    netConnections: netConnections.map(
+      ({ schematicPortIds, ...connection }) => ({
+        ...connection,
+        pinIds: schematicPortIds,
+      }),
+    ),
     textBoxes,
     availableNetLabelOrientations,
     maxMspPairDistance:


### PR DESCRIPTION
## Summary

- rename core's local connection fields from `pinIds` to `schematicPortIds`
- rename `connKeyToPinIds` to `connKeyToSchematicPortIds`
- translate `schematicPortIds` to the trace solver's required `pinIds` field only at the `InputProblem` boundary

## Why

After #2806, these values are canonical `schematic_port_id` values rather than selector-shaped generic pin identifiers. Calling them `pinIds` inside core obscures their domain meaning.

The external `@tscircuit/schematic-trace-solver` API still requires `pinIds`, so this PR keeps that name only in the boundary adapter. There is no routing behavior change.

## Validation

- `bunx tsc --noEmit`
- `bun test tests/repros/repro156-schematicbox-chipref-netlabel.test.tsx tests/repros/repro155-internally-connected-pushbutton-traces.test.tsx tests/components/normal-components/pushbutton-pin-configurations.test.tsx`