### PR TITLE
Report PCB packing failures in Circuit JSON

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialPcbLayoutPack/Group_doInitialPcbLayoutPack.ts
@@ -169,6 +169,23 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
   }
 
   let packOutput: PackOutput
+  let packingFailed = false
+  const reportPackingError = (solverErrorMessage: string) => {
+    const message = `Unable to pack all PCB components within the layout bounds: ${solverErrorMessage}`
+
+    db.pcb_packing_error.insert({
+      error_type: "pcb_packing_error",
+      message,
+      pcb_group_id: group.pcb_group_id ?? undefined,
+      subcircuit_id: group.subcircuit_id ?? undefined,
+    })
+    group.root?.emit("packing:error", {
+      subcircuit_id: group.subcircuit_id,
+      componentDisplayName: group.getString(),
+      error: { message },
+    })
+  }
+
   try {
     const solver = new PackSolver2(packInput)
     group.root?.emit("solver:started", {
@@ -180,18 +197,21 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
 
     solver.solve()
 
+    if (solver.failed) {
+      packingFailed = true
+      const solverErrorMessage =
+        solver.error ??
+        solver.activeSubSolver?.error ??
+        "No valid packing solution found"
+      reportPackingError(solverErrorMessage)
+    }
+
     packOutput = {
       ...packInput,
       components: solver.packedComponents,
     }
   } catch (error) {
-    group.root?.emit("packing:error", {
-      subcircuit_id: group.subcircuit_id,
-      componentDisplayName: group.getString(),
-      error: {
-        message: error instanceof Error ? error.message : String(error),
-      },
-    })
+    reportPackingError(error instanceof Error ? error.message : String(error))
     throw error
   }
 
@@ -202,6 +222,8 @@ export const Group_doInitialPcbLayoutPack = (group: Group) => {
   }
 
   applyPackOutput(group, packOutput, clusterMap, initialPackOutput)
+
+  if (packingFailed) return
 
   // Emit packing:end event
   group.root?.emit("packing:end", {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "bun-match-svg": "0.0.12",
     "calculate-elbow": "^0.0.12",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.454",
+    "circuit-json": "^0.0.455",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.23",
     "circuit-json-to-gltf": "^0.0.107",

--- a/tests/projects/seveibar__rp2040-zero/index.test.tsx
+++ b/tests/projects/seveibar__rp2040-zero/index.test.tsx
@@ -60,6 +60,16 @@ test("seveibar__rp2040-zero matches snapshots", async () => {
   expect(decouplingRailTraces.length).toBeGreaterThan(0)
   expect(railEdgesIntersectingU2).toHaveLength(0)
 
+  const packingErrors = circuit.db.pcb_packing_error.list()
+  expect(packingErrors).toHaveLength(1)
+  expect(packingErrors[0]).toMatchObject({
+    type: "pcb_packing_error",
+    error_type: "pcb_packing_error",
+    message: expect.stringContaining(
+      "Unable to pack all PCB components within the layout bounds",
+    ),
+  })
+
   expect(circuit).toMatchSchematicSnapshot(import.meta.path)
   expect(circuit).toMatchPcbSnapshot(import.meta.path)
 }, 200_000)


### PR DESCRIPTION
## Summary

- emit a `pcb_packing_error` Circuit JSON element when `PackSolver2` cannot find a valid bounded layout
- use the same diagnostic path for solver-state failures and thrown packing exceptions while continuing to emit `packing:error`
- bump `circuit-json` to `0.0.455`, which defines the new error element
- assert the error against the `seveibar__rp2040-zero` regression circuit

## Root cause

`PackSolver2.solve()` reports an unsatisfied bounded packing problem by setting `solver.failed`; it does not throw. Core only handled thrown exceptions, so the failed state fell through to `applyPackOutput`, leaving unpacked components at their original center without a Circuit JSON diagnostic.

## Validation

- `bun test tests/projects/seveibar__rp2040-zero/index.test.tsx`
- `bun test tests/features/pcb-pack-layout tests/repros/repro64-packing-outside-board.test.tsx tests/examples/example36-packing-events.test.tsx` (16 pass)
- `bunx tsc --noEmit`
- `bun run build`
- Biome formatting check on changed files