### PR TITLE
fix: set pcb_group_id on copper pour records

### DIFF
--- a/lib/components/primitive-components/CopperPour/CopperPour.ts
+++ b/lib/components/primitive-components/CopperPour/CopperPour.ts
@@ -76,6 +76,7 @@ export class CopperPour extends PrimitiveComponent<typeof copperPourProps> {
           layer: props.layer,
           brep_shape,
           source_net_id: net.source_net_id,
+          pcb_group_id: this.getGroup()?.pcb_group_id ?? undefined,
           subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
           covered_with_solder_mask: coveredWithSolderMask,
         } as PcbCopperPour)

--- a/tests/repros/repro-copper-pour-group-id.test.tsx
+++ b/tests/repros/repro-copper-pour-group-id.test.tsx
@@ -1,0 +1,44 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("copper pour records carry the enclosing pcb_group_id", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <group name="G1">
+        <resistor
+          name="R1"
+          resistance="1k"
+          footprint="0402"
+          pcbX={0}
+          pcbY={5}
+        />
+        <trace from=".R1 > .pin1" to="net.GND" />
+        <via
+          connectsTo="net.GND"
+          holeDiameter="0.3mm"
+          outerDiameter="0.6mm"
+          fromLayer="top"
+          toLayer="bottom"
+          pcbX={0}
+          pcbY={-8}
+        />
+        <copperpour connectsTo="net.GND" layer="top" clearance="0.3mm" />
+      </group>
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  const pours = circuit.db.pcb_copper_pour.list()
+  expect(pours.length).toBeGreaterThan(0)
+  const vias = circuit.db.pcb_via.list()
+
+  // The via inside the same group already carries the group id; the copper
+  // pour must be grouped consistently with the other PCB primitives.
+  const groupId = vias[0]?.pcb_group_id
+  expect(groupId).toBeDefined()
+
+  for (const pour of pours) {
+    expect(pour.pcb_group_id).toBe(groupId)
+  }
+})


### PR DESCRIPTION
Related to #2621 (does not close it — see "Scope" below).

`CopperPour` was the only PCB primitive that never populated `pcb_group_id` on the records it emits.

Every other primitive passes the enclosing group through — `PcbVia`, `CourtyardRect`, `SilkscreenPath`, `Hole`, `Port`, and `PcbNoteDimension` all use `this.getGroup()?.pcb_group_id` — so copper pours were inconsistently ungrouped in the emitted Circuit JSON.

### Evidence

With a `<via>` and a `<copperpour>` inside the same `<group name="G1">`, before this change:

```
via group:  [ "pcb_group_0" ]
pour group: [ undefined ]
```

Same group, same board, different answer. After the change both report `pcb_group_0`.

### Change

One line in `doInitialPcbCopperPourRender`, matching the existing convention, plus a regression test that asserts the pour's `pcb_group_id` equals the via's rather than just checking it's non-null.

### Scope

This is a consistency fix and is deliberately narrow. It is **not** a fix for #2621 (one `pcb_copper_pour` record per fill fragment) — a board-level pour still has no group, so that issue needs a circuit-json schema decision, which I've laid out with options in a comment there.

### Verification

- `bunx tsc --noEmit` — clean
- `biome format` — clean
- All 7 copper-pour test files: 15 pass / 0 fail
