### PR TITLE
fix: honor the mfn shorthand in chip, jumper, solderjumper and pinout

### DIFF
--- a/lib/components/normal-components/Chip.ts
+++ b/lib/components/normal-components/Chip.ts
@@ -1,9 +1,9 @@
 import { chipProps } from "@tscircuit/props"
 import { pcb_component_invalid_layer_error } from "circuit-json"
 import { NormalComponent } from "lib/components/base-components/NormalComponent"
-import { type SchematicBoxDimensions } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
-import { Trace } from "lib/components/primitive-components/Trace/Trace"
 import { Port } from "lib/components/primitive-components/Port"
+import { Trace } from "lib/components/primitive-components/Trace/Trace"
+import { type SchematicBoxDimensions } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
 import type { z } from "zod"
 
 export class Chip<PinLabels extends string = never> extends NormalComponent<
@@ -88,7 +88,7 @@ export class Chip<PinLabels extends string = never> extends NormalComponent<
     const source_component = db.source_component.insert({
       ftype: "simple_chip",
       name: this.name,
-      manufacturer_part_number: props.manufacturerPartNumber,
+      manufacturer_part_number: props.manufacturerPartNumber ?? props.mfn,
       supplier_part_numbers: props.supplierPartNumbers,
       display_name: props.displayName,
     })

--- a/lib/components/normal-components/Jumper.ts
+++ b/lib/components/normal-components/Jumper.ts
@@ -1,13 +1,13 @@
-import { NormalComponent } from "lib/components/base-components/NormalComponent"
 import { jumperProps } from "@tscircuit/props"
-import { Port } from "../primitive-components/Port"
+import { NormalComponent } from "lib/components/base-components/NormalComponent"
+import { underscorifyPinStyles } from "lib/soup/underscorifyPinStyles"
+import { underscorifyPortArrangement } from "lib/soup/underscorifyPortArrangement"
 import type { BaseSymbolName } from "lib/utils/constants"
 import {
-  getAllDimensionsForSchematicBox,
   type SchematicBoxDimensions,
+  getAllDimensionsForSchematicBox,
 } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
-import { underscorifyPortArrangement } from "lib/soup/underscorifyPortArrangement"
-import { underscorifyPinStyles } from "lib/soup/underscorifyPinStyles"
+import { Port } from "../primitive-components/Port"
 
 export class Jumper<PinLabels extends string = never> extends NormalComponent<
   typeof jumperProps,
@@ -54,7 +54,7 @@ export class Jumper<PinLabels extends string = never> extends NormalComponent<
     const source_component = db.source_component.insert({
       ftype: "simple_chip", // TODO unknown or jumper
       name: this.name,
-      manufacturer_part_number: props.manufacturerPartNumber,
+      manufacturer_part_number: props.manufacturerPartNumber ?? props.mfn,
       supplier_part_numbers: props.supplierPartNumbers,
       are_pins_interchangeable: true,
       display_name: props.displayName,
@@ -106,7 +106,7 @@ export class Jumper<PinLabels extends string = never> extends NormalComponent<
       if (typeof sourcePort?.pin_number === "number") {
         pinLabel = sourcePort.pin_number.toString()
       } else if (Array.isArray(sourcePort?.port_hints)) {
-        let matchedHint = sourcePort.port_hints.find((h: string) =>
+        const matchedHint = sourcePort.port_hints.find((h: string) =>
           /^(pin)?\d+$/.test(h),
         )
         if (matchedHint) {

--- a/lib/components/normal-components/Pinout.ts
+++ b/lib/components/normal-components/Pinout.ts
@@ -1,6 +1,6 @@
 import { pinoutProps } from "@tscircuit/props"
-import { Chip } from "./Chip"
 import type { z } from "zod"
+import { Chip } from "./Chip"
 
 export class Pinout<PinLabels extends string = never> extends Chip<PinLabels> {
   constructor(props: z.input<typeof pinoutProps>) {
@@ -22,7 +22,7 @@ export class Pinout<PinLabels extends string = never> extends Chip<PinLabels> {
     const source_component = db.source_component.insert({
       ftype: "simple_pinout",
       name: this.name,
-      manufacturer_part_number: props.manufacturerPartNumber,
+      manufacturer_part_number: props.manufacturerPartNumber ?? props.mfn,
       supplier_part_numbers: props.supplierPartNumbers,
       display_name: props.displayName,
     })

--- a/lib/components/normal-components/SolderJumper.ts
+++ b/lib/components/normal-components/SolderJumper.ts
@@ -1,7 +1,7 @@
-import { NormalComponent } from "lib/components/base-components/NormalComponent"
 import { solderjumperProps } from "@tscircuit/props"
-import { Port } from "../primitive-components/Port"
+import { NormalComponent } from "lib/components/base-components/NormalComponent"
 import type { SchematicBoxDimensions } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
+import { Port } from "../primitive-components/Port"
 
 export class SolderJumper<
   PinLabels extends string = never,
@@ -203,7 +203,7 @@ export class SolderJumper<
     const source_component = db.source_component.insert({
       ftype: "simple_chip", // TODO unknown or jumper
       name: this.name,
-      manufacturer_part_number: props.manufacturerPartNumber,
+      manufacturer_part_number: props.manufacturerPartNumber ?? props.mfn,
       supplier_part_numbers: props.supplierPartNumbers,
       are_pins_interchangeable: true,
       display_name: props.displayName,
@@ -255,7 +255,7 @@ export class SolderJumper<
       if (typeof sourcePort?.pin_number === "number") {
         pinLabel = sourcePort.pin_number.toString()
       } else if (Array.isArray(sourcePort?.port_hints)) {
-        let matchedHint = sourcePort.port_hints.find((h: string) =>
+        const matchedHint = sourcePort.port_hints.find((h: string) =>
           /^(pin)?\d+$/.test(h),
         )
         if (matchedHint) {

--- a/tests/components/normal-components/mfn-alias-propagation.test.tsx
+++ b/tests/components/normal-components/mfn-alias-propagation.test.tsx
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// `mfn` is a documented shorthand for `manufacturerPartNumber` on
+// commonComponentProps, and most components honor it via
+// `props.manufacturerPartNumber ?? props.mfn`. These four read
+// `props.manufacturerPartNumber` only, so `mfn` silently parses and is dropped.
+
+test("<chip /> mfn propagation", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip name="U1" mfn="ATTINY85-20SU" footprint="soic8" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+  expect(
+    circuit.db.source_component.getWhere({ name: "U1" })
+      ?.manufacturer_part_number,
+  ).toBe("ATTINY85-20SU")
+})
+
+test("<jumper /> mfn propagation", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <jumper name="J1" mfn="61300211121" footprint="pinrow2" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+  expect(
+    circuit.db.source_component.getWhere({ name: "J1" })
+      ?.manufacturer_part_number,
+  ).toBe("61300211121")
+})
+
+test("<solderjumper /> mfn propagation", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <solderjumper name="SJ1" mfn="SJ-2A" footprint="solderjumper2" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+  expect(
+    circuit.db.source_component.getWhere({ name: "SJ1" })
+      ?.manufacturer_part_number,
+  ).toBe("SJ-2A")
+})
+
+test("<pinout /> mfn propagation", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <pinout name="PO1" mfn="PINOUT-1234" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+  expect(
+    circuit.db.source_component.getWhere({ name: "PO1" })
+      ?.manufacturer_part_number,
+  ).toBe("PINOUT-1234")
+})
+
+test("explicit manufacturerPartNumber still wins over mfn", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip
+        name="U2"
+        manufacturerPartNumber="EXPLICIT-1"
+        mfn="SHORTHAND-2"
+        footprint="soic8"
+      />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+  expect(
+    circuit.db.source_component.getWhere({ name: "U2" })
+      ?.manufacturer_part_number,
+  ).toBe("EXPLICIT-1")
+})


### PR DESCRIPTION
`mfn` is a documented shorthand for `manufacturerPartNumber` on `commonComponentProps`, and 20+ normal components resolve it as `props.manufacturerPartNumber ?? props.mfn`. Four do not: `<chip />`, `<jumper />`, `<solderjumper />` and `<pinout />` read `props.manufacturerPartNumber` only.

Because the prop is valid on their zod schemas, `mfn` parses without any warning and is then silently discarded, so `source_component.manufacturer_part_number` comes out `undefined`. That is the field BOM/JLCPCB output reads, so a board written with the shorthand loses its part numbers with no diagnostic.

Reproduced on `main` before the fix (new test file, run against unmodified `lib/`):

```
(fail) <chip /> mfn propagation          Expected: "ATTINY85-20SU"  Received: undefined
(fail) <jumper /> mfn propagation        Expected: "61300211121"    Received: undefined
(fail) <solderjumper /> mfn propagation  Expected: "SJ-2A"          Received: undefined
(fail) <pinout /> mfn propagation        Expected: "PINOUT-1234"    Received: undefined
(pass) explicit manufacturerPartNumber still wins over mfn
```

After: 5 pass / 0 fail.

The fifth test is a control — it pins the precedence so `manufacturerPartNumber` keeps winning when both are given, matching the behavior of the components that already had this.

This continues the series of propagation fixes merged over the past few days (#2765, #2778, #2788, #2789) and closes out the last components that were dropping the field.

**Diff: 4 one-line source changes (`props.manufacturerPartNumber` → `props.manufacturerPartNumber ?? props.mfn`) + 1 test file.** No snapshots touched.

Full suite: **1264 pass / 0 fail / 31 skip**, `biome format .` clean.

cc @seveibar @imrishabh18 @mohan-bee
