### PR TITLE
perf: back renderPhaseStates with typed arrays instead of 63 objects per component

### DIFF
--- a/lib/components/base-components/Renderable.ts
+++ b/lib/components/base-components/Renderable.ts
@@ -167,6 +167,113 @@ export type RenderPhaseStates = Record<
   }
 >
 
+/**
+ * Backing store for `renderPhaseStates`.
+ *
+ * Every Renderable used to allocate one `{ initialized, dirty }` object per
+ * render phase in its constructor. With 63 phases that is 63 objects plus the
+ * containing record for every component in the tree, which made the Renderable
+ * constructor the single largest allocation site during generation.
+ *
+ * The flags now live in two `Uint8Array`s (one byte per phase each), and the
+ * per-phase objects are materialized lazily and cached only for the phases a
+ * caller actually touches. The public shape of `renderPhaseStates` is
+ * unchanged: it still reads and writes as
+ * `renderPhaseStates[phase].initialized` / `.dirty`, still enumerates every
+ * phase, and still serializes identically in `getRenderGraph()`.
+ */
+class RenderPhaseStateStore {
+  readonly initializedFlags: Uint8Array
+  readonly dirtyFlags: Uint8Array
+  private _views: Array<RenderPhaseStateView | undefined>
+
+  constructor() {
+    this.initializedFlags = new Uint8Array(orderedRenderPhases.length)
+    this.dirtyFlags = new Uint8Array(orderedRenderPhases.length)
+    this._views = new Array(orderedRenderPhases.length)
+  }
+
+  getView(phaseIndex: number): RenderPhaseStateView {
+    let view = this._views[phaseIndex]
+    if (view === undefined) {
+      view = new RenderPhaseStateView(this, phaseIndex)
+      this._views[phaseIndex] = view
+    }
+    return view
+  }
+}
+
+/**
+ * A live view onto one phase's flags. Reads and writes go straight to the
+ * shared typed arrays, so this stays in sync with `_markDirty` and with any
+ * other view of the same phase.
+ */
+class RenderPhaseStateView {
+  constructor(
+    private readonly _store: RenderPhaseStateStore,
+    private readonly _phaseIndex: number,
+  ) {}
+
+  get initialized(): boolean {
+    return this._store.initializedFlags[this._phaseIndex] === 1
+  }
+
+  set initialized(value: boolean) {
+    this._store.initializedFlags[this._phaseIndex] = value ? 1 : 0
+  }
+
+  get dirty(): boolean {
+    return this._store.dirtyFlags[this._phaseIndex] === 1
+  }
+
+  set dirty(value: boolean) {
+    this._store.dirtyFlags[this._phaseIndex] = value ? 1 : 0
+  }
+
+  /** Keeps `JSON.stringify(getRenderGraph())` byte-identical to before. */
+  toJSON() {
+    return { initialized: this.initialized, dirty: this.dirty }
+  }
+}
+
+/**
+ * Compatibility view over the flag arrays, built only if something actually
+ * reads `renderPhaseStates`. The hot paths (`runRenderPhase`, `_markDirty`)
+ * read and write the typed arrays directly and never construct this.
+ */
+const createRenderPhaseStates = (
+  store: RenderPhaseStateStore,
+): RenderPhaseStates =>
+  new Proxy({} as RenderPhaseStates, {
+    get(_target, prop) {
+      if (typeof prop !== "string") return undefined
+      const phaseIndex = renderPhaseIndexMap.get(prop as RenderPhase)
+      if (phaseIndex === undefined) return undefined
+      return store.getView(phaseIndex)
+    },
+    has(_target, prop) {
+      return (
+        typeof prop === "string" && renderPhaseIndexMap.has(prop as RenderPhase)
+      )
+    },
+    ownKeys() {
+      return [...orderedRenderPhases]
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      if (
+        typeof prop !== "string" ||
+        !renderPhaseIndexMap.has(prop as RenderPhase)
+      ) {
+        return undefined
+      }
+      return {
+        enumerable: true,
+        configurable: true,
+        value: store.getView(renderPhaseIndexMap.get(prop as RenderPhase)!),
+      }
+    },
+  })
+
 export type AsyncEffect = {
   asyncEffectId: string
   effectName: string
@@ -191,7 +298,6 @@ export type IRenderable = RenderPhaseFunctions & {
 let globalRenderCounter = 0
 let globalAsyncEffectCounter = 0
 export abstract class Renderable implements IRenderable {
-  renderPhaseStates: RenderPhaseStates
   shouldBeRemoved = false
   children: IRenderable[]
 
@@ -210,22 +316,25 @@ export abstract class Renderable implements IRenderable {
   constructor(props: any) {
     this._renderId = `${globalRenderCounter++}`
     this.children = []
-    this.renderPhaseStates = {} as RenderPhaseStates
-    for (const phase of orderedRenderPhases) {
-      this.renderPhaseStates[phase] = {
-        initialized: false,
-        dirty: false,
-      }
+    this._renderPhaseStateStore = new RenderPhaseStateStore()
+  }
+
+  private _renderPhaseStateStore: RenderPhaseStateStore
+  private _renderPhaseStatesView: RenderPhaseStates | null = null
+
+  get renderPhaseStates(): RenderPhaseStates {
+    if (this._renderPhaseStatesView === null) {
+      this._renderPhaseStatesView = createRenderPhaseStates(
+        this._renderPhaseStateStore,
+      )
     }
+    return this._renderPhaseStatesView
   }
 
   _markDirty(phase: RenderPhase) {
-    this.renderPhaseStates[phase].dirty = true
     // Mark all subsequent phases as dirty
     const phaseIndex = renderPhaseIndexMap.get(phase)!
-    for (let i = phaseIndex + 1; i < orderedRenderPhases.length; i++) {
-      this.renderPhaseStates[orderedRenderPhases[i]].dirty = true
-    }
+    this._renderPhaseStateStore.dirtyFlags.fill(1, phaseIndex)
 
     if (this.parent?._markDirty) {
       this.parent._markDirty(phase)
@@ -385,9 +494,10 @@ export abstract class Renderable implements IRenderable {
    */
   runRenderPhase(phase: RenderPhase) {
     this._currentRenderPhase = phase
-    const phaseState = this.renderPhaseStates[phase]
-    const isInitialized = phaseState.initialized
-    const isDirty = phaseState.dirty
+    const store = this._renderPhaseStateStore
+    const phaseIndex = renderPhaseIndexMap.get(phase)!
+    const isInitialized = store.initializedFlags[phaseIndex] === 1
+    const isDirty = store.dirtyFlags[phaseIndex] === 1
 
     // Skip if component is being removed and not initialized
     if (!isInitialized && this.shouldBeRemoved) return
@@ -395,14 +505,14 @@ export abstract class Renderable implements IRenderable {
     if (this.shouldBeRemoved && isInitialized) {
       this._emitRenderLifecycleEvent(phase, "start")
       ;(this as any)?.[`remove${phase}`]?.()
-      phaseState.initialized = false
-      phaseState.dirty = false
+      store.initializedFlags[phaseIndex] = 0
+      store.dirtyFlags[phaseIndex] = 0
       this._emitRenderLifecycleEvent(phase, "end")
       return
     }
 
     // Check for incomplete async effects from previous phases
-    const prevPhaseIndex = renderPhaseIndexMap.get(phase)! - 1
+    const prevPhaseIndex = phaseIndex - 1
     if (prevPhaseIndex >= 0) {
       const prevPhase = orderedRenderPhases[prevPhaseIndex]
       const hasIncompleteEffects = this._asyncEffects
@@ -427,15 +537,15 @@ export abstract class Renderable implements IRenderable {
     if (isInitialized) {
       if (isDirty) {
         ;(this as any)?.[`update${phase}`]?.()
-        phaseState.dirty = false
+        store.dirtyFlags[phaseIndex] = 0
       }
       this._emitRenderLifecycleEvent(phase, "end")
       return
     }
     // Initial render
-    phaseState.dirty = false
+    store.dirtyFlags[phaseIndex] = 0
     ;(this as any)?.[`doInitial${phase}`]?.()
-    phaseState.initialized = true
+    store.initializedFlags[phaseIndex] = 1
     this._emitRenderLifecycleEvent(phase, "end")
   }
 

--- a/tests/components/base-components/render-phase-states-shape.test.tsx
+++ b/tests/components/base-components/render-phase-states-shape.test.tsx
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { orderedRenderPhases } from "lib/components/base-components/Renderable"
+
+// renderPhaseStates is read by lib code, by tests, and is serialized through
+// getRenderGraph(). Its backing store is now two Uint8Arrays rather than one
+// object per phase, so these pin the observable shape.
+
+test("renderPhaseStates keeps its enumerable per-phase shape", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  const component = circuit.selectOne("resistor")!
+  const states = component.renderPhaseStates
+
+  expect(Object.keys(states)).toEqual([...orderedRenderPhases])
+  expect("SourceRender" in states).toBe(true)
+  expect(Object.keys({ ...states }).length).toBe(orderedRenderPhases.length)
+  expect(states.SourceRender.initialized).toBe(true)
+})
+
+test("renderPhaseStates writes are visible through a fresh read", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  const component = circuit.selectOne("resistor")!
+  component.renderPhaseStates.SchematicLayout.dirty = true
+  expect(component.renderPhaseStates.SchematicLayout.dirty).toBe(true)
+
+  component.renderPhaseStates.SchematicLayout.dirty = false
+  expect(component.renderPhaseStates.SchematicLayout.dirty).toBe(false)
+})
+
+test("getRenderGraph serializes phase states as plain objects", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  const component = circuit.selectOne("resistor")! as any
+  const graph = component.getRenderGraph()
+  const roundTripped = JSON.parse(JSON.stringify(graph.renderPhaseStates))
+
+  expect(Object.keys(roundTripped)).toEqual([...orderedRenderPhases])
+  expect(roundTripped.SourceRender).toEqual({
+    initialized: true,
+    dirty: false,
+  })
+})
+
+test("_markDirty marks the phase and every phase after it", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  const component = circuit.selectOne("resistor")! as any
+  component._markDirty("SchematicComponentRender")
+
+  const markedIndex = orderedRenderPhases.indexOf("SchematicComponentRender")
+  for (let i = 0; i < orderedRenderPhases.length; i++) {
+    expect(component.renderPhaseStates[orderedRenderPhases[i]].dirty).toBe(
+      i >= markedIndex,
+    )
+  }
+})


### PR DESCRIPTION
Follow-up to #2814, and it also carries a measurement that I think redirects #2830.

## What I measured

Node's sampling heap profiler (`HeapProfiler.startSampling`, 2048-byte interval) over `Benchmark1LedMatrix` with `routingDisabled` — 4,734 circuit-json elements, 2,114 components in the tree. Same script, same board, run against `origin/main` in a clean worktree and against this branch:

| | `origin/main` | this PR |
|---|---:|---:|
| total sampled allocation | 29.46 MB | **19.49 MB** |
| `Renderable` constructor (self) | 12.41 MB | **0.30 MB** |

**-33.8% total allocation**, and the `Renderable` constructor drops from **42% of all sampled allocation to 1.8%**.

## Cause

`Renderable`'s constructor eagerly built one `{ initialized, dirty }` object per render phase:

```ts
this.renderPhaseStates = {} as RenderPhaseStates
for (const phase of orderedRenderPhases) {
  this.renderPhaseStates[phase] = { initialized: false, dirty: false }
}
```

There are 63 phases, so every component in the tree allocated 63 objects plus the containing record. On this board that is **133,182 state objects** for 2,114 components — and the count scales with `orderedRenderPhases.length`, so it grows every time a phase is added.

## Change

The flags move into two `Uint8Array`s (one byte per phase each). The hot paths — `runRenderPhase` and `_markDirty` — index those arrays directly, and `_markDirty`'s "mark this phase and everything after it" loop becomes a single `dirtyFlags.fill(1, phaseIndex)`.

`renderPhaseStates` itself is still there and still behaves identically; it is now a lazily-created view that is only built if something reads it.

## Compatibility

`renderPhaseStates` is read by `lib` (`Trace_doInitialPcbTraceRender`, `NormalComponent`), by tests, and is serialized through `getRenderGraph()`, so I pinned the observable shape rather than assuming it:

- `Object.keys(states)` is still all 63 phases **in order**
- `"SourceRender" in states`, spreading, and enumeration all work
- writes through `states[phase].dirty = true` are visible on a fresh read
- `JSON.stringify(getRenderGraph())` still emits `{"initialized":...,"dirty":...}` per phase

Those four properties are the new test file.

## About #2830

While verifying this I could not reproduce the premise of #2830 on this board. Walking the live object graph from the circuit root after render finds **1,492** retained `{x, y}` objects (1,488 of them behind `.route`), not millions, and `anchorPoint` does not appear in `core`'s retained graph at all — `core` has exactly one `anchorPoint` reference, in `applyNetLabelPlacements`, reading solver output.

By allocation, transform helpers (`applyToPoint`/`applyMatrix`/`transformPoint`/`compose`/`decomposeTSR`) account for **0.13 MB of 29.46 MB — 0.46%**. So on this board the 597 `applyToPoint` call sites are not the bottleneck; the per-phase state objects were, by two orders of magnitude. If the reporter's board behaves differently I'd like the input JSON, since that would mean the retention is coming from a path this benchmark doesn't exercise. I'll follow up on #2830 with these numbers.

## Verification

Full suite **1259 pass / 0 fail / 31 skip**, `tsc --noEmit` clean, `biome format .` clean.

**Diff: 1 source file + 1 test file.** No snapshots touched.

cc @seveibar @imrishabh18 @mohan-bee
