### PR TITLE
fix: honour schShowRatings={false} on fuse (#2835)

### DIFF
--- a/lib/components/normal-components/Fuse.ts
+++ b/lib/components/normal-components/Fuse.ts
@@ -28,6 +28,12 @@ export class Fuse extends NormalComponent<typeof fuseProps, PassivePorts> {
     const voltage =
       typeof rawVoltage === "string" ? parseFloat(rawVoltage) : rawVoltage
 
+    // `schShowRatings` is declared on FuseProps but was never read, so
+    // `schShowRatings={false}` had no effect. Unlike capacitor's, this prop has
+    // no schema default, so `undefined` keeps the existing "always show"
+    // behaviour and only an explicit `false` suppresses the ratings.
+    if (this._parsedProps.schShowRatings === false) return undefined
+
     return `${formatSiUnit(current)}A / ${formatSiUnit(voltage)}V`
   }
 

--- a/tests/components/normal-components/fuse.test.tsx
+++ b/tests/components/normal-components/fuse.test.tsx
@@ -20,3 +20,60 @@ test("<fuse /> component", async () => {
 
   expect(circuit).toMatchSchematicSnapshot(import.meta.path)
 })
+
+test("<fuse /> honours schShowRatings={false}", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="10mm" routingDisabled>
+      <fuse
+        name="F1"
+        currentRating="1A"
+        voltageRating="32V"
+        footprint="0402"
+        schX={-4}
+      />
+      <fuse
+        name="F2"
+        currentRating="1A"
+        voltageRating="32V"
+        schShowRatings
+        footprint="0402"
+        schX={0}
+      />
+      <fuse
+        name="F3"
+        currentRating="1A"
+        voltageRating="32V"
+        schShowRatings={false}
+        footprint="0402"
+        schX={4}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const nameBySourceId = Object.fromEntries(
+    circuitJson
+      .filter((e: any) => e.type === "source_component")
+      .map((e: any) => [e.source_component_id, e.name]),
+  )
+  const symbolValueByName = Object.fromEntries(
+    circuitJson
+      .filter((e: any) => e.type === "schematic_component")
+      .map((e: any) => [
+        nameBySourceId[e.source_component_id],
+        e.symbol_display_value,
+      ]),
+  )
+
+  // `schShowRatings` has no schema default on fuse, so omitting it keeps the
+  // existing "always show" behaviour...
+  expect(symbolValueByName.F1).toBe("1A / 32V")
+  expect(symbolValueByName.F2).toBe("1A / 32V")
+  // ...and only an explicit `false` suppresses the ratings. This prop is
+  // declared on FuseProps but used to be ignored entirely.
+  expect(symbolValueByName.F3).toBeUndefined()
+})


### PR DESCRIPTION
Closes #2835.

`schShowRatings` is declared on `FuseProps` ("Whether to show ratings on schematic") but `Fuse` never read it, so `schShowRatings={false}` rendered the ratings anyway.

```
                                              before      after
F1  (prop omitted)                            "1A / 32V"  "1A / 32V"   unchanged
F2  schShowRatings                            "1A / 32V"  "1A / 32V"   unchanged
F3  schShowRatings={false}                    "1A / 32V"  undefined    fixed
```

### Deliberately narrow, and here's why

The obvious "fix" would be to mirror `Capacitor`, which shows ratings **only** on opt-in. I checked the schemas before assuming they're equivalent, and they aren't:

```
capacitor:  schShowRatings: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>   ← has a default
fuse:       schShowRatings: z.ZodOptional<z.ZodBoolean>                 ← no default
```

Capacitor's default is part of its schema; fuse has no default to read off, and it has always shown ratings unconditionally. Switching fuse to opt-in would **silently blank the ratings on every existing fuse schematic** — a behaviour change dressed up as a bug fix. So this PR only makes the explicit `false` work:

```ts
if (this._parsedProps.schShowRatings === false) return undefined
```

`undefined` (prop omitted) and `true` both keep today's output byte-for-byte. If you'd rather fuse match capacitor's opt-in default, I'm happy to send that as a follow-up — it's a product decision, not a defect, and it deserves its own review.

### Verification

**The test bites.** Reverting only `Fuse.ts`:

```
expect(symbolValueByName.F3).toBeUndefined()
Received: "1A / 32V"
(fail) <fuse /> honours schShowRatings={false}
```

It asserts all three states in one board, so a regression in either direction — breaking the default or failing to suppress — is caught.

**Suite:** `1260 pass / 0 fail`, and **no snapshots changed**, which is the evidence that the default path is untouched. `biome format` and `tsc --noEmit` clean.

### Relationship to #2834

Independent — that one fixes the `"1A / V"` bare-unit output when `voltageRating` is omitted; this one fixes the ignored prop. They touch the same method, so whichever lands first will need a trivial rebase of the other. Happy to combine them into one PR if you'd prefer a single review.
