### PR TITLE
fix: carry inductor maxCurrentRating into source_component (#2837)

### DIFF
--- a/lib/components/normal-components/Inductor.ts
+++ b/lib/components/normal-components/Inductor.ts
@@ -6,7 +6,7 @@ import {
 } from "lib/utils/constants"
 import { NormalComponent } from "../base-components/NormalComponent/NormalComponent"
 import { Port } from "../primitive-components/Port"
-import { formatSiUnit } from "format-si-unit"
+import { formatSiUnit, parseAndConvertSiUnit } from "format-si-unit"
 import type { SourceSimpleInductor } from "circuit-json"
 
 export class Inductor extends NormalComponent<
@@ -41,11 +41,28 @@ export class Inductor extends NormalComponent<
   doInitialSourceRender() {
     const { db } = this.root!
     const { _parsedProps: props } = this
+    // `maxCurrentRating` is declared on InductorProps and `max_current_rating`
+    // exists on the simple_inductor schema, but the value was never carried
+    // across. Unlike capacitor's `maxVoltageRating`, this prop has no zod
+    // transform, so the raw string arrives here. `parseAndConvertSiUnit`
+    // handles the unit suffix, so "500mA" becomes 0.5 rather than 500.
+    const rawMaxCurrentRating = props.maxCurrentRating
+    const maxCurrentRating =
+      typeof rawMaxCurrentRating === "string"
+        ? parseAndConvertSiUnit(rawMaxCurrentRating).value
+        : rawMaxCurrentRating
+
     const source_component = db.source_component.insert({
       name: this.name,
       ftype: FTYPE.simple_inductor,
       inductance: this.props.inductance,
       display_inductance: this._getSchematicSymbolDisplayValue(),
+      max_current_rating:
+        maxCurrentRating === undefined ||
+        maxCurrentRating === null ||
+        Number.isNaN(maxCurrentRating as number)
+          ? undefined
+          : maxCurrentRating,
       supplier_part_numbers: props.supplierPartNumbers,
       manufacturer_part_number: props.manufacturerPartNumber ?? props.mfn,
       are_pins_interchangeable: true,

--- a/tests/components/normal-components/inductor.test.tsx
+++ b/tests/components/normal-components/inductor.test.tsx
@@ -21,3 +21,51 @@ test("<inductor /> component", async () => {
   expect(circuit).toMatchPcbSnapshot(import.meta.path)
   expect(circuit).toMatchSchematicSnapshot(import.meta.path)
 })
+
+test("<inductor /> carries maxCurrentRating into source_component", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="40mm" height="10mm" routingDisabled>
+      <inductor name="L1" inductance="10uH" footprint="0402" schX={-6} />
+      <inductor
+        name="L2"
+        inductance="10uH"
+        maxCurrentRating="2A"
+        footprint="0402"
+        schX={-2}
+      />
+      <inductor
+        name="L3"
+        inductance="10uH"
+        maxCurrentRating={0.5}
+        footprint="0402"
+        schX={2}
+      />
+      <inductor
+        name="L4"
+        inductance="10uH"
+        maxCurrentRating="500mA"
+        footprint="0402"
+        schX={6}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const ratingByName = Object.fromEntries(
+    circuit
+      .getCircuitJson()
+      .filter((e: any) => e.type === "source_component")
+      .map((e: any) => [e.name, e.max_current_rating]),
+  )
+
+  // `max_current_rating` exists on the simple_inductor schema; the prop used to
+  // be dropped entirely.
+  expect(ratingByName.L1).toBeUndefined()
+  expect(ratingByName.L2).toBe(2)
+  expect(ratingByName.L3).toBe(0.5)
+  // The unit prefix has to be honoured — "500mA" is 0.5A, not 500A.
+  expect(ratingByName.L4).toBe(0.5)
+})


### PR DESCRIPTION
Closes #2837.

`maxCurrentRating` is declared on `InductorProps` and `max_current_rating` exists on the `simple_inductor` schema, but `doInitialSourceRender()` never wrote it — the value was dropped with no warning.

```
                                  before      after
L1  (no rating)                   undefined   undefined
L2  maxCurrentRating="2A"         undefined   2
L3  maxCurrentRating={0.5}        undefined   0.5
L4  maxCurrentRating="500mA"      undefined   0.5
```

### The part that isn't obvious

My first attempt used `parseFloat`, copying `Fuse`'s approach, and the checker caught it: **`parseFloat("500mA")` returns 500** — a 1000× error that would have written a plainly wrong value into circuit JSON rather than leaving it absent.

The reason `Fuse` gets away with `parseFloat` is that its ratings are conventionally written without SI prefixes. `maxCurrentRating` has no zod transform either, unlike capacitor's `maxVoltageRating`:

```
capacitor: maxVoltageRating: z.ZodOptional<z.ZodEffects<..., number, string | number>>  ← converted for you
inductor:  maxCurrentRating: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNumber]>>       ← raw string arrives
```

I then tried `parseSiUnit`, which returns **`NaN` for `"2A"`** — it doesn't expect a unit suffix. `parseAndConvertSiUnit(...).value` is the one that handles both, which I verified directly before using it:

```
"2A" → 2    "500mA" → 0.5    "1.5A" → 1.5    "2" → 2    "abc" → NaN
```

`NaN`/`null`/`undefined` all resolve to `undefined` so a malformed rating leaves the field absent rather than poisoning it.

### Verification

**The test bites.** Reverting only `Inductor.ts`:

```
expect(ratingByName.L2).toBe(2)
Received: undefined
(fail) <inductor /> carries maxCurrentRating into source_component
```

It covers all four cases in one board — omitted, string with unit, plain number, and prefixed unit — so the 1000× bug specifically is pinned by `expect(ratingByName.L4).toBe(0.5)`.

**Suite:** `1260 pass / 0 fail`, **no snapshots changed** (this only adds a source field). `biome format` and `tsc --noEmit` clean.

### Other props from the same sweep

I cross-referenced every `*Props` interface against the props each component reads. Several others appear unread — `Capacitor.bypassFor`/`bypassTo`/`schSize`, `Resistor.schSize`/`tolerance`, `Board.topSolderMaskColor`/`bottomSolderMaskColor`, `Chip.internalCircuit`/`pinCompatibleVariants`. I deliberately didn't touch those: unlike this one they have no obvious destination field, so "fixing" them would mean inventing schema semantics. Listed in #2837 in case they're worth triaging.
