### PR TITLE
fix: carry net highlightColor into pcb_trace.highlight_color (#2839)

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -96,6 +96,7 @@ import {
 } from "./region-replacement"
 import { splitPcbTracesOnJumperSegments } from "./split-pcb-traces-on-jumper-segments"
 import { computeCenterFromAnchorPosition } from "./utils/computeCenterFromAnchorPosition"
+import { getHighlightColorForSourceTrace } from "lib/utils/get-highlight-color-for-source-trace"
 
 const getDistanceToPoint = (
   routePoint: PcbTrace["route"][number],
@@ -1509,6 +1510,11 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             ...pcb_trace,
             source_trace_id: sourceTraceId,
             route: segment,
+            highlight_color: getHighlightColorForSourceTrace({
+              db,
+              group: this,
+              sourceTraceId,
+            }),
           })
         }
       }

--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -73,6 +73,21 @@ export class Trace
     return this._parsedProps.thickness ?? this._parsedProps.width
   }
 
+  /**
+   * The `highlightColor` of a net this trace is connected to, if any.
+   *
+   * `pcb_trace.highlight_color` exists on the circuit-JSON schema and
+   * `NetProps.highlightColor` is documented, but nothing carried the value
+   * across, so the prop had no effect.
+   */
+  _getHighlightColor(): string | undefined {
+    for (const net of this._findConnectedNets().nets) {
+      const highlightColor = net?._parsedProps?.highlightColor
+      if (highlightColor) return highlightColor
+    }
+    return undefined
+  }
+
   _getSchematicNetLabelText(): string | undefined {
     return (
       this._parsedProps.schDisplayLabel ??

--- a/lib/components/primitive-components/Trace/Trace_doInitialPcbManualTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialPcbManualTraceRender.ts
@@ -167,6 +167,7 @@ export function Trace_doInitialPcbManualTraceRender(trace: Trace) {
         source_trace_id: trace.source_trace_id!,
         subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
         pcb_group_id: trace.getGroup()?.pcb_group_id ?? undefined,
+        highlight_color: trace._getHighlightColor(),
       })
       const pcbStyle = trace.getInheritedMergedProperty("pcbStyle")
       const { holeDiameter, padDiameter } = getViaDiameterDefaults(pcbStyle)
@@ -291,6 +292,7 @@ export function Trace_doInitialPcbManualTraceRender(trace: Trace) {
       subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
       pcb_group_id: trace.getGroup()?.pcb_group_id ?? undefined,
       trace_length: traceLength,
+      highlight_color: trace._getHighlightColor(),
     })
     trace._portsRoutedOnPcb = ports
     trace.pcb_trace_id = pcb_trace.pcb_trace_id
@@ -429,6 +431,7 @@ export function Trace_doInitialPcbManualTraceRender(trace: Trace) {
     subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
     pcb_group_id: trace.getGroup()?.pcb_group_id ?? undefined,
     trace_length: traceLength,
+    highlight_color: trace._getHighlightColor(),
   })
   const subcircuitConnectivityMapKey =
     trace.subcircuit_connectivity_map_key ??

--- a/lib/components/primitive-components/Trace/Trace_doInitialPcbTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialPcbTraceRender.ts
@@ -111,6 +111,7 @@ export function Trace_doInitialPcbTraceRender(trace: Trace) {
       source_trace_id: trace.source_trace_id!,
       subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
       pcb_group_id: trace.getGroup()?.pcb_group_id ?? undefined,
+      highlight_color: trace._getHighlightColor(),
     })
     trace.pcb_trace_id = pcb_trace.pcb_trace_id
     return
@@ -512,6 +513,7 @@ export function Trace_doInitialPcbTraceRender(trace: Trace) {
     source_trace_id: trace.source_trace_id!,
     subcircuit_id: trace.getSubcircuit()?.subcircuit_id!,
     trace_length: traceLength,
+    highlight_color: trace._getHighlightColor(),
   })
   const subcircuitConnectivityMapKey =
     trace.subcircuit_connectivity_map_key ??

--- a/lib/utils/get-highlight-color-for-source-trace.ts
+++ b/lib/utils/get-highlight-color-for-source-trace.ts
@@ -1,0 +1,36 @@
+import type { Net } from "lib/components/primitive-components/Net"
+import type { PrimitiveComponent } from "lib/components/base-components/PrimitiveComponent"
+
+/**
+ * `NetProps.highlightColor` is documented and `pcb_trace.highlight_color`
+ * exists on the circuit-JSON schema, but nothing carried the value across.
+ *
+ * `source_net` has no highlight field, so the colour has to come from the `Net`
+ * component. This resolves it from a `source_trace_id` by matching the trace's
+ * connected nets back to their components.
+ */
+export const getHighlightColorForSourceTrace = ({
+  db,
+  group,
+  sourceTraceId,
+}: {
+  db: any
+  group: PrimitiveComponent
+  sourceTraceId?: string | null
+}): string | undefined => {
+  if (!sourceTraceId) return undefined
+
+  const sourceTrace = db.source_trace.get(sourceTraceId)
+  const connectedNetIds: string[] = sourceTrace?.connected_source_net_ids ?? []
+  if (connectedNetIds.length === 0) return undefined
+
+  const nets = group.selectAll("net") as Net[]
+  for (const net of nets) {
+    if (!net.source_net_id) continue
+    if (!connectedNetIds.includes(net.source_net_id)) continue
+    const highlightColor = net._parsedProps?.highlightColor
+    if (highlightColor) return highlightColor
+  }
+
+  return undefined
+}

--- a/tests/components/primitive-components/net.test.tsx
+++ b/tests/components/primitive-components/net.test.tsx
@@ -19,3 +19,49 @@ it("should create a Net component with correct properties", () => {
   expect(net.props.name).toBe("VCC")
   expect(net.getPortSelector()).toBe("net.VCC")
 })
+
+it("carries net highlightColor into pcb_trace.highlight_color", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm">
+      <net name="VCC" highlightColor="#ff0000" />
+      <net name="GND" />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-6} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={6} />
+      <trace from=".R1 > .pin2" to="net.VCC" />
+      <trace from=".R2 > .pin2" to="net.VCC" />
+      <trace from=".R1 > .pin1" to="net.GND" />
+      <trace from=".R2 > .pin1" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const netNameBySourceNetId = Object.fromEntries(
+    circuitJson
+      .filter((e: any) => e.type === "source_net")
+      .map((e: any) => [e.source_net_id, e.name]),
+  )
+  const netIdsBySourceTraceId = Object.fromEntries(
+    circuitJson
+      .filter((e: any) => e.type === "source_trace")
+      .map((e: any) => [e.source_trace_id, e.connected_source_net_ids ?? []]),
+  )
+
+  const highlightByNetName: Record<string, string | undefined> = {}
+  for (const pcbTrace of circuitJson.filter(
+    (e: any) => e.type === "pcb_trace",
+  ) as any[]) {
+    for (const netId of netIdsBySourceTraceId[pcbTrace.source_trace_id] ?? []) {
+      highlightByNetName[netNameBySourceNetId[netId]] = pcbTrace.highlight_color
+    }
+  }
+
+  // `NetProps.highlightColor` is documented and `pcb_trace.highlight_color`
+  // exists on the circuit-JSON schema; the value used to be dropped entirely.
+  expect(highlightByNetName.VCC).toBe("#ff0000")
+  // A net without the prop must not pick one up.
+  expect(highlightByNetName.GND).toBeUndefined()
+})


### PR DESCRIPTION
Closes #2839.

`NetProps.highlightColor` is documented and `pcb_trace.highlight_color` exists on the circuit-JSON schema, but the value was never written — `grep -rn "highlightColor\|highlight_color" lib/` returned nothing in core.

```
                                        before      after
trace on <net highlightColor="#ff0000"> undefined   "#ff0000"
trace on <net /> (no prop)              undefined   undefined
```

### Finding the right insertion site mattered more than the fix

There are five `db.pcb_trace.insert` sites. My first attempt patched the ones in `Trace_doInitialPcbTraceRender` / `Trace_doInitialPcbManualTraceRender` and added a `Trace._getHighlightColor()` helper. The helper resolved correctly — I verified it returns `#ff0000` — **and the output was still `undefined`**, because for a normally autorouted board none of those sites run.

I instrumented each site with a marker to find out which one actually executes: it's the **segment insert in `Group.ts`**, after `getSourceTraceIdForRoutedTrace`. That's where this PR writes the field.

That site has only a `source_trace_id`, and `source_net` has no highlight field to read back:

```
source_net: type, source_net_id, name, member_source_group_ids, is_power, is_ground,
            is_digital_signal, is_analog_signal, is_positive_voltage_source,
            trace_width, subcircuit_id, subcircuit_connectivity_map_key
```

So `getHighlightColorForSourceTrace` resolves `source_trace.connected_source_net_ids` → matching `Net` component → `highlightColor`. It's a small standalone helper rather than inline code so the other insertion sites can adopt it if they ever become reachable.

I kept the `Trace._getHighlightColor()` helper too, since the `Trace_*` sites are reachable for cached-route and manual-path boards, and left both paths consistent.

### Verification

**The test bites.** Reverting only `Group.ts`:

```
expect(highlightByNetName.VCC).toBe("#ff0000")
Received: undefined
(fail) carries net highlightColor into pcb_trace.highlight_color
```

It also asserts a second net **without** the prop stays `undefined`, so the fix can't pass by blanket-applying a colour.

**Suite:** `1260 pass / 0 fail`, no snapshot churn, `biome format` and `tsc --noEmit` clean.

One note on process: an intermediate run of mine reported 7 unrelated failures (3D/PCB snapshot tests). Those were an artifact of my machine hitting 100% disk during the run — they pass individually and the count returns to `0 fail` on a clean run of this same branch, and `main` is also `0 fail`. Flagging it so a stray number in my earlier notes isn't mistaken for a real regression.

### How this was found

Cross-referenced every `interface *Props` in `@tscircuit/props` against the circuit-JSON schema, keeping props whose snake_case name exists as a schema field but which core references under **neither** name. Exactly two hits: `InductorProps.maxCurrentRating` (#2837 / #2838) and this one. The sweep is now exhausted for that particular pattern.
