### PR TITLE
fix: make hole circuit json parse against circuit-json schemas (#2843)

### DIFF
--- a/lib/components/primitive-components/Hole.ts
+++ b/lib/components/primitive-components/Hole.ts
@@ -8,6 +8,7 @@ import type {
   PcbHoleRect,
   PcbHoleCircle,
 } from "circuit-json"
+import { optionalId } from "lib/utils/optional-id"
 
 export class Hole extends PrimitiveComponent<typeof holeProps> {
   pcb_hole_id: string | null = null
@@ -52,9 +53,13 @@ export class Hole extends PrimitiveComponent<typeof holeProps> {
     const position = this._getGlobalPcbPositionBeforeLayout()
     const soldermaskMargin = props.solderMaskMargin
     const isCoveredWithSolderMask = props.coveredWithSolderMask ?? false
-    const pcb_component_id =
+    // `pcb_component_id` is `string | null` on PrimitiveComponent, and `??`
+    // only falls through on `undefined` — a board-level hole has no owning
+    // component, so the `null` used to reach circuit JSON and fail validation.
+    const pcb_component_id = optionalId(
       this.parent?.pcb_component_id ??
-      this.getPrimitiveContainer()?.pcb_component_id
+        this.getPrimitiveContainer()?.pcb_component_id,
+    )
 
     this.emitSolderMaskMarginWarning(isCoveredWithSolderMask, soldermaskMargin)
 

--- a/lib/components/primitive-components/PlatedHole.ts
+++ b/lib/components/primitive-components/PlatedHole.ts
@@ -13,6 +13,7 @@ import type {
 } from "circuit-json"
 import { decomposeTSR } from "transformation-matrix"
 import { selectPortForPcbPrimitive } from "./Port/selectPortForPcbPrimitive"
+import { optionalId } from "lib/utils/optional-id"
 
 export class PlatedHole extends PrimitiveComponent<typeof platedHoleProps> {
   pcb_plated_hole_id: string | null = null
@@ -125,9 +126,12 @@ export class PlatedHole extends PrimitiveComponent<typeof platedHoleProps> {
     const { db } = this.root!
     const { _parsedProps: props } = this
     const position = this._getGlobalPcbPositionBeforeLayout()
-    const pcb_component_id =
+    // See `optionalId`: `pcb_component_id` is `string | null`, and a
+    // board-level plated hole has no owning component.
+    const pcb_component_id = optionalId(
       this.parent?.pcb_component_id ??
-      this.getPrimitiveContainer()?.pcb_component_id!
+        this.getPrimitiveContainer()?.pcb_component_id,
+    )
     const subcircuit = this.getSubcircuit()
     const platedHoleLayers = this.getAvailablePcbLayers()
     const soldermaskMargin = props.solderMaskMargin
@@ -265,6 +269,10 @@ export class PlatedHole extends PrimitiveComponent<typeof platedHoleProps> {
         rect_pad_width: props.rectPadWidth,
         rect_pad_height: props.rectPadHeight,
         shape: "circular_hole_with_rect_pad" as const,
+        // Required by the `circular_hole_with_rect_pad` schema variant; the
+        // sibling pill variants below already set them.
+        hole_shape: "circle" as const,
+        pad_shape: "rect" as const,
         port_hints: this.getNameAndAliases(),
         x: position.x,
         y: position.y,

--- a/lib/utils/optional-id.ts
+++ b/lib/utils/optional-id.ts
@@ -1,0 +1,13 @@
+/**
+ * Normalizes an id that may be `null` into `undefined`.
+ *
+ * `PrimitiveComponent` initialises its id fields to `null`
+ * (`pcb_component_id: string | null = null`), but circuit-json types every id
+ * as `z.string().optional()` — which accepts `undefined` and rejects `null`.
+ *
+ * Primitives placed directly on a board have no owning `pcb_component`, so the
+ * `null` was reaching circuit JSON and making the whole element fail
+ * `any_circuit_element.parse()`.
+ */
+export const optionalId = (id: string | null | undefined): string | undefined =>
+  id ?? undefined

--- a/tests/components/primitive-components/hole-board-level-circuit-json-validity.test.tsx
+++ b/tests/components/primitive-components/hole-board-level-circuit-json-validity.test.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("board-level holes produce valid circuit json", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <hole name="H1" pcbX={-5} pcbY={5} diameter="1mm" />
+      <platedhole
+        name="PH1"
+        pcbX={5}
+        pcbY={-5}
+        shape="circle"
+        holeDiameter="0.5mm"
+        outerDiameter="0.9mm"
+      />
+      {/* A footprint whose holes DO belong to a component. */}
+      <chip name="U1" footprint="dip8" pcbX={0} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const holes = circuitJson.filter(
+    (e: any) => e.type === "pcb_hole" || e.type === "pcb_plated_hole",
+  ) as any[]
+
+  const boardLevelHoles = holes.filter((h) => h.pcb_component_id === undefined)
+  const componentHoles = holes.filter((h) => h.pcb_component_id !== undefined)
+
+  expect(boardLevelHoles.length).toBeGreaterThan(0)
+  expect(componentHoles.length).toBeGreaterThan(0)
+
+  // `pcb_component_id` is `z.string().optional()` on these schemas, so `null`
+  // is rejected while an absent value is fine. A board-level hole has no
+  // owning component, and the `null` used to make the element fail
+  // `any_circuit_element.parse()` entirely.
+  for (const hole of boardLevelHoles) {
+    expect(hole.pcb_component_id).toBeUndefined()
+  }
+
+  // Holes that belong to a footprint must keep their component id.
+  for (const hole of componentHoles) {
+    expect(typeof hole.pcb_component_id).toBe("string")
+  }
+
+  for (const hole of holes) {
+    const result = any_circuit_element.safeParse(hole)
+    expect({ type: hole.type, valid: result.success }).toEqual({
+      type: hole.type,
+      valid: true,
+    })
+  }
+})

--- a/tests/components/primitive-components/plated-hole-pill-rotated2.test.tsx
+++ b/tests/components/primitive-components/plated-hole-pill-rotated2.test.tsx
@@ -33,7 +33,7 @@ test("PlatedHole pill shape", () => {
       ],
       "outer_height": 4,
       "outer_width": 2,
-      "pcb_component_id": null,
+      "pcb_component_id": undefined,
       "pcb_group_id": undefined,
       "pcb_plated_hole_id": "pcb_plated_hole_0",
       "pcb_port_id": undefined,


### PR DESCRIPTION
Closes #2843.

Two independent defects that both make core emit circuit JSON which fails `any_circuit_element.parse()`.

```
                                          before   after
board-level <hole />                      invalid  valid
board-level <platedhole />                invalid  valid
<chip footprint="dip8" /> plated holes    invalid  valid
```

### 1. `pcb_component_id: null` on board-level holes

`PrimitiveComponent` initialises ids to `null` (`pcb_component_id: string | null = null`), and the holes resolve their owner with `??`, which only falls through on `undefined`. A hole inside a footprint has an owner; one placed directly on the board doesn't, so `null` reached circuit JSON — and every id on these schemas is `z.string().optional()`, which rejects `null`.

Isolated it before fixing, so the diagnosis isn't a guess:

```
as-is                                     → false
{ ...hole, pcb_component_id: undefined }  → true
omitted entirely                          → true
```

Fixed with a small `optionalId` helper at the two sites where the schema actually permits an absent id.

### 2. `circular_hole_with_rect_pad` missing `hole_shape` / `pad_shape`

Found while verifying the first fix — the test still failed, and the culprit was a *different* element. That schema variant requires both fields:

```ts
var pcb_circular_hole_with_rect_pad = z.object({
  shape: z.literal("circular_hole_with_rect_pad"),
  hole_shape: z.literal("circle"),
  pad_shape: z.literal("rect"),
  ...
})
```

`PlatedHole.ts` omitted them at that one insertion site while the neighbouring pill variants in the same file already set them, so I matched the existing pattern. A plain `<chip footprint="dip8" />` was enough to trigger this.

### Deliberately out of scope

The sweep also found `pcb_silkscreen_text` and `pcb_fabrication_note_text` carrying `pcb_component_id: null`. I tried the same normalisation there and `tsc` rejected it — those schemas require a **non-optional** string. That makes it a design question (what should a board-level silkscreen text reference?) rather than a null→undefined fix, so I reverted it and reported it in #2843 instead of guessing.

### Verification

**The test bites.** Reverting `Hole.ts` + `PlatedHole.ts`:

```
Expected: > 0
Received: 0
(fail) board-level holes produce valid circuit json
```

The test asserts both directions: board-level holes have **no** id, footprint holes **keep** theirs (`typeof === "string"`), and every hole passes `any_circuit_element.safeParse`. So it can't be satisfied by blanket-clearing the field.

**Suite:** `1260 pass / 0 fail`, `tsc --noEmit` 0 errors, `biome format` clean.

One inline snapshot changed — `plated-hole-pill-rotated2` had `"pcb_component_id": null` recorded, i.e. the bug was captured in an expectation. It now reads `undefined`.

Worth noting how this was found: validating core's own output against `circuit-json`'s exported schemas across several board shapes. It's cheap and it also surfaced `pcb_group.anchor_alignment: null` and `schematic_group.subcircuit_id: null`, which I've left for separate triage.
