### PR TITLE
fix: omit group anchor_alignment and subcircuit_id instead of writing null (#2845)

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -465,7 +465,9 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             trace_clearance: props.autorouter.traceClearance,
           }
         : undefined,
-      anchor_alignment: props.pcbAnchorAlignment ?? null,
+      // circuit-json declares this as `ninePointAnchor.default("center")`, so a
+      // `null` fails validation while omitting it lets the schema default apply.
+      anchor_alignment: props.pcbAnchorAlignment ?? undefined,
     })
     this.pcb_group_id = pcb_group.pcb_group_id
 
@@ -1587,7 +1589,10 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     const { _parsedProps: props } = this
     const schematic_group = db.schematic_group.insert({
       is_subcircuit: this.isSubcircuit,
-      subcircuit_id: this.subcircuit_id!,
+      // `subcircuit_id` is `string | null` on the component but
+      // `z.string().optional()` on the schema, so `null` fails validation.
+      // A group outside any subcircuit simply has none.
+      subcircuit_id: this.subcircuit_id ?? undefined,
       name: this.name,
       center: this._getGlobalSchematicPositionBeforeLayout(),
       width: 0,

--- a/tests/components/primitive-components/group-circuit-json-nulls.test.tsx
+++ b/tests/components/primitive-components/group-circuit-json-nulls.test.tsx
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import * as CJ from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("groups do not emit null anchor_alignment / subcircuit_id", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <group name="G1" pcbX={4}>
+        <resistor name="R1" resistance="1k" footprint="0402" />
+      </group>
+      <group name="G2" pcbX={-6} pcbAnchorAlignment="top_left">
+        <resistor name="R2" resistance="1k" footprint="0402" />
+      </group>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const pcbGroups = circuitJson.filter(
+    (e: any) => e.type === "pcb_group",
+  ) as any[]
+  const schematicGroups = circuitJson.filter(
+    (e: any) => e.type === "schematic_group",
+  ) as any[]
+
+  expect(pcbGroups.length).toBeGreaterThan(0)
+  expect(schematicGroups.length).toBeGreaterThan(0)
+
+  // `anchor_alignment` is `ninePointAnchor.default("center")` — `null` fails
+  // validation, while omitting it lets the schema default apply.
+  for (const group of pcbGroups) {
+    expect(group.anchor_alignment).not.toBeNull()
+  }
+
+  // `subcircuit_id` is `z.string().optional()`, so `null` is rejected.
+  for (const group of schematicGroups) {
+    expect(group.subcircuit_id).not.toBeNull()
+  }
+
+  // An explicitly requested alignment must still survive.
+  const explicit = pcbGroups.find((g) => g.anchor_alignment === "top_left")
+  expect(explicit).toBeDefined()
+
+  // And these two fields must no longer be the reason validation fails.
+  for (const group of [...pcbGroups, ...schematicGroups]) {
+    const schema = (CJ as any)[group.type]
+    const result = schema.safeParse(group)
+    const relevantIssues = result.success
+      ? []
+      : result.error.issues
+          .filter((i: any) =>
+            ["anchor_alignment", "subcircuit_id"].includes(String(i.path[0])),
+          )
+          .map((i: any) => `${i.path.join(".")}: ${i.message}`)
+    expect({ type: group.type, relevantIssues }).toEqual({
+      type: group.type,
+      relevantIssues: [],
+    })
+  }
+})

--- a/tests/components/primitive-components/group-subcircuit-id.test.tsx
+++ b/tests/components/primitive-components/group-subcircuit-id.test.tsx
@@ -34,7 +34,7 @@ test("Subcircuit group should have subcircuit_id", async () => {
   expect(circuit.db.pcb_group.list()).toMatchInlineSnapshot(`
 [
   {
-    "anchor_alignment": null,
+    "anchor_alignment": undefined,
     "anchor_position": {
       "x": 0,
       "y": 0,

--- a/tests/groups/group-outline.test.tsx
+++ b/tests/groups/group-outline.test.tsx
@@ -26,7 +26,7 @@ test("group with outline specified", async () => {
   expect(pcb_groups).toMatchInlineSnapshot(`
     [
       {
-        "anchor_alignment": null,
+        "anchor_alignment": undefined,
         "anchor_position": {
           "x": 0,
           "y": 0,

--- a/tests/groups/group-schematic-box.test.tsx
+++ b/tests/groups/group-schematic-box.test.tsx
@@ -33,7 +33,7 @@ test("group schematic box", () => {
         "schematic_group_id": "schematic_group_0",
         "show_as_schematic_box": true,
         "source_group_id": "source_group_0",
-        "subcircuit_id": null,
+        "subcircuit_id": undefined,
         "type": "schematic_group",
         "width": 0.4,
       },


### PR DESCRIPTION
Closes #2845.

`<group />` wrote `null` into two fields that circuit-json types as string-or-absent, so both elements failed validation:

```
                                    before                    after
pcb_group.anchor_alignment          null (rejected)           undefined → schema default "center"
schematic_group.subcircuit_id       null (rejected)           undefined
```

### Why `undefined` rather than a value

```ts
pcb_group.anchor_alignment     → ninePointAnchor.default("center")
schematic_group.subcircuit_id  → z.string().optional()
```

For `anchor_alignment`, omitting is strictly better than substituting `"center"` in core: the schema already supplies that default, so leaving it out keeps a single source of truth and stays correct if the default ever changes. The explicit `pcbAnchorAlignment` prop still passes through unchanged — the test asserts a `"top_left"` group survives, so this can't be satisfied by blanket-clearing the field.

For `subcircuit_id`, the `!` assertion was hiding that the field is `string | null = null` on the component. A group outside any subcircuit genuinely has none, and `undefined` is what the schema expects.

### Three existing tests recorded the invalid values

That's why nothing caught this — the bug was baked into expectations:

- `group-outline.test.tsx` — `"anchor_alignment": null`
- `group-subcircuit-id.test.tsx` — `"anchor_alignment": null`
- `group-schematic-box.test.tsx` — `"subcircuit_id": null`

All three updated to `undefined`. No assertion was weakened; they're inline snapshots of emitted values.

### Verification

**The test bites.** Reverting `Group.ts`:

```
Received: null
(fail) groups do not emit null anchor_alignment / subcircuit_id
```

It asserts neither field is `null`, that an explicitly requested alignment survives, **and** that neither field appears in `safeParse` issues — so it pins the schema contract rather than just the absence of `null`.

**Suite:** `1260 pass / 0 fail`, `tsc --noEmit` 0 errors, `biome format` clean.

### Note

Locating one of the three failures took a moment because **five test files share the test name "group schematic box"** — a single-file rerun of the wrong one passes and looks like flakiness. I isolated it by running each candidate file separately.

This is the third and final batch from validating core's output against circuit-json's exported schemas (#2841 `display_offset_x/y`, #2843 hole elements). With this merged, `<group />` no longer contributes violations.
