### PR TITLE
fix: make getString render ids stable per circuit (#2848)

### DIFF
--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -1384,22 +1384,56 @@ export abstract class PrimitiveComponent<
 
   getString(): string {
     const { lowercaseComponentName: cname, _parsedProps: props, parent } = this
+    const id = this._getCircuitRelativeRenderId()
     if (props?.pinNumber !== undefined && parent?.props?.name && props?.name) {
-      return `<${cname}#${this._renderId}(pin:${props.pinNumber} .${parent?.props.name}>.${props.name}) />`
+      return `<${cname}#${id}(pin:${props.pinNumber} .${parent?.props.name}>.${props.name}) />`
     }
     if (parent?.props?.name && props?.name) {
-      return `<${cname}#${this._renderId}(.${parent?.props.name}>.${props?.name}) />`
+      return `<${cname}#${id}(.${parent?.props.name}>.${props?.name}) />`
     }
     if (props?.from && props?.to) {
-      return `<${cname}#${this._renderId}(from:${props.from} to:${props?.to}) />`
+      return `<${cname}#${id}(from:${props.from} to:${props?.to}) />`
     }
     if (props?.name) {
-      return `<${cname}#${this._renderId} name=".${props?.name}" />`
+      return `<${cname}#${id} name=".${props?.name}" />`
     }
     if (props?.portHints) {
-      return `<${cname}#${this._renderId}(${props.portHints.map((ph: string) => `.${ph}`).join(", ")}) />`
+      return `<${cname}#${id}(${props.portHints.map((ph: string) => `.${ph}`).join(", ")}) />`
     }
-    return `<${cname}#${this._renderId} />`
+    return `<${cname}#${id} />`
+  }
+
+  /**
+   * A render id that is stable for a given circuit.
+   *
+   * `_renderId` comes from a module-level counter that is never reset, so it
+   * keeps climbing across every circuit built in the same process. That leaks
+   * into user-facing warnings and errors via `getString()`, making the same
+   * board produce different messages on each render. This offsets it against
+   * the lowest id seen in the circuit, so the number is relative to the
+   * circuit rather than to the process.
+   */
+  _getCircuitRelativeRenderId(): string {
+    const root = this.root as unknown as {
+      _renderIdOrigin?: number
+      children?: any[]
+    } | null
+    if (!root) return this._renderId
+
+    if (root._renderIdOrigin === undefined) {
+      let lowest = Number.POSITIVE_INFINITY
+      const visit = (node: any) => {
+        const value = Number(node?._renderId)
+        if (Number.isFinite(value)) lowest = Math.min(lowest, value)
+        for (const child of node?.children ?? []) visit(child)
+      }
+      for (const child of root.children ?? []) visit(child)
+      root._renderIdOrigin = Number.isFinite(lowest) ? lowest : 0
+    }
+
+    const relative = Number(this._renderId) - root._renderIdOrigin
+    if (!Number.isFinite(relative) || relative < 0) return this._renderId
+    return `${relative}`
   }
 
   getDisplayName(): string {

--- a/tests/components/base-components/render-id-is-circuit-stable.test.tsx
+++ b/tests/components/base-components/render-id-is-circuit-stable.test.tsx
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const buildAndGetWarning = async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} />
+      <net name="VCC" />
+      <trace from=".R1 > .pin1" to="net.VCC" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const warning = circuit
+    .getCircuitJson()
+    .find((e: any) => e.type === "source_unnamed_trace_warning") as any
+
+  return warning?.message as string | undefined
+}
+
+test("warning messages are identical for identical circuits", async () => {
+  // `getString()` embeds `_renderId`, which comes from a module-level counter
+  // that is never reset. Rendering the same board three times in one process
+  // used to yield "trace#14", "trace#36", "trace#58" — so any consumer that
+  // snapshots or diffs warnings sees spurious changes.
+  const messages = [
+    await buildAndGetWarning(),
+    await buildAndGetWarning(),
+    await buildAndGetWarning(),
+  ]
+
+  for (const message of messages) {
+    expect(message).toBeDefined()
+    expect(message).toContain("is missing a name")
+  }
+
+  expect(new Set(messages).size).toBe(1)
+})
+
+test("render ids stay distinct within a circuit", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <resistor name="R2" resistance="2k" footprint="0402" pcbX={5} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const strings = (circuit.selectAll("resistor") as any[]).map((r) =>
+    r.getString(),
+  )
+
+  // Making the id circuit-relative must not collapse distinct components onto
+  // the same identifier.
+  expect(strings.length).toBe(2)
+  expect(new Set(strings).size).toBe(2)
+})


### PR DESCRIPTION
Closes #2848.

Rendering the same board three times in one process produced three different warnings:

```
before                                    after
<trace#14(from:.R1 > .pin1 to:net.VCC) />  <trace#14(...) />
<trace#36(...) />                          <trace#14(...) />
<trace#58(...) />                          <trace#14(...) />
```

`getString()` embeds `_renderId`, which is a module-level counter that never resets — so the number reflects how many components the *process* has constructed, not anything about the circuit.

### Why the fix is in the display path, not the counter

`_renderId` has to stay process-unique: `cssSelectPrimitiveComponentAdapter` compares it for identity (`a._renderId === b._renderId`). Resetting the counter per circuit would break that. So `getString()` now offsets against the lowest id in the circuit, computed once and memoised on the root:

```ts
_getCircuitRelativeRenderId(): string {
  // walk the tree once, cache the minimum on root._renderIdOrigin
  const relative = Number(this._renderId) - root._renderIdOrigin
  if (!Number.isFinite(relative) || relative < 0) return this._renderId
  return `${relative}`
}
```

It falls back to the raw id whenever the offset can't be computed (no root yet, non-numeric id, negative result), so no call site can end up worse off than today.

### Verification

**The test bites.** Reverting `PrimitiveComponent.ts`:

```
expect(new Set(messages).size).toBe(1)
Expected: 1
Received: 3
```

A second test guards the obvious way to "fix" this wrongly: **ids must stay distinct within a circuit**. Two resistors on one board still produce two different strings, so collapsing everything to a constant can't pass.

I also checked that circuits of different shapes still get different numbers (a board with an extra capacitor reports `trace#26` vs `trace#14`) — the id remains meaningful, it just stops depending on process history.

**Suite:** `1261 pass / 0 fail`, `tsc --noEmit` 0 errors, `biome format` clean. No snapshots changed.

### How this was found

Diffing two renders of an identical board element by element. Of 105 elements, `source_unnamed_trace_warning` was the only one that differed — which is what pointed at `getString()` rather than at any single component.

Worth noting the blast radius: `getString()` also feeds the "routed outside the board boundaries", "chipRef without connections", "manual placement and prop coordinates", "schSheetName does not match", "is ambiguous: references multiple non-overlapping pads", "Missing ports" and "Failed to route net islands" messages. All of them inherit the same instability today.
