### PR TITLE
fix: strip the child combinator from trace error parent selectors (#2850)

### DIFF
--- a/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
+++ b/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
@@ -57,6 +57,11 @@ export function Trace__findConnectedPorts(trace: Trace):
         parentSelector = match?.[1]?.trim() ?? ""
         portToken = match?.[2] ?? selector
       }
+      // Both branches can leave the child combinator behind: ".U1 > .pin1"
+      // yields ".U1 > ". That string doesn't select the component — it
+      // resolves to an arbitrary descendant — so the error message ends up
+      // naming the wrong element and reporting "It has no ports".
+      parentSelector = parentSelector.replace(/[\s>]+$/, "")
       let targetComponent = parentSelector
         ? trace.getSubcircuit().selectOne(parentSelector)
         : null

--- a/tests/components/normal-components/chip-connections-invalid.test.tsx
+++ b/tests/components/normal-components/chip-connections-invalid.test.tsx
@@ -38,7 +38,7 @@ test("Chip not having name messes up the connections, uses the pin of the first 
     [
       {
         "error_type": "source_trace_not_connected_error",
-        "message": "Could not find port for selector ".unnamed_chip1 > .pin1". Component ".unnamed_chip1 > " not found",
+        "message": "Could not find port for selector ".unnamed_chip1 > .pin1". Component ".unnamed_chip1" not found",
         "selectors_not_found": [
           ".unnamed_chip1 > .pin1",
         ],

--- a/tests/components/primitive-components/trace-missing-port-error-message.test.tsx
+++ b/tests/components/primitive-components/trace-missing-port-error-message.test.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("missing-pin error names the component and lists its pins", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pcbX={0}
+        pinLabels={{ pin1: ["VCC"], pin2: ["GND"] }}
+      />
+      <trace from=".U1 > .VCC" to=".U1 > .NOPE" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const error = circuit
+    .getCircuitJson()
+    .find((e: any) => String(e.type).includes("error")) as any
+
+  expect(error).toBeDefined()
+
+  // The parent selector used to keep the child combinator (".U1 > "), which
+  // selects an arbitrary descendant rather than the chip — so the message
+  // named the wrong element and claimed it had no ports.
+  expect(error.message).toContain('Component "U1" found')
+  expect(error.message).not.toContain('".U1 > "')
+  expect(error.message).not.toContain("It has no ports")
+  // The pin list must come from the chip itself.
+  expect(error.message).toContain("VCC")
+  expect(error.message).toContain("GND")
+})
+
+test("missing-component error reports the component selector without the combinator", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} />
+      <trace from=".R1 > .pin1" to=".R9 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const error = circuit
+    .getCircuitJson()
+    .find((e: any) => String(e.type).includes("error")) as any
+
+  expect(error).toBeDefined()
+  expect(error.message).toContain('Component ".R9" not found')
+  expect(error.message).not.toContain('".R9 > "')
+})


### PR DESCRIPTION
Closes #2850.

The "pin not found" error existed to tell users which pins *are* available. It was doing the opposite:

```
before  Component ".U1 > " found, but does not have pin "NOPE". It has no ports
after   Component "U1" found, but does not have pin "NOPE".
        It has [VCC, pin1, 1, GND, pin2, 2, pin3, 3, pin4, 4, pin5, 5, pin6, 6, pin7, 7, pin8, 8]

before  Component ".R9 > " not found
after   Component ".R9" not found
```

`U1` is a soic8 with 8 ports, so "It has no ports" was flatly wrong.

### Root cause

Both selector-splitting branches leave the child combinator on `parentSelector` (`".U1 > "`). That isn't a selector for the chip — it's a descendant selector with an empty right side. I checked what it resolves to rather than assuming:

```
selectOne(".U1")   → Chip  "U1", 8 ports
selectOne(".U1 >") → SmtPad (unnamed), 0 ports
```

So the code was finding an arbitrary descendant and then reporting *that* element's name and port count. One line fixes both branches:

```ts
parentSelector = parentSelector.replace(/[\s>]+$/, "")
```

I trimmed only trailing combinator characters rather than rewriting the two branches, so nothing about which selector forms are accepted changes — only the string used for lookup and display.

### Verification

**Both tests bite.** Reverting the one-line change:

```
Expected to contain: "Component \"U1\" found"
Received: ... Component ".U1 > " found, but does not have pin "NOPE". It has no ports

Expected to contain: "Component \".R9\" not found"
Received: ... Component ".R9 > " not found
```

They assert the positive (correct name, real pin list) **and** the negative (no `".U1 > "`, no false "It has no ports"), so a cosmetic trim that still resolved the wrong element wouldn't pass.

**One existing expectation changed** — `chip-connections-invalid.test.tsx` recorded `"Component \".unnamed_chip1 > \" not found"`, i.e. the bug was captured in an inline snapshot. That's why nothing caught it. Updated to the correct string; no assertion weakened.

**Suite:** `1261 pass / 0 fail`, `tsc --noEmit` 0 errors, `biome format` clean.

### How this was found

Feeding deliberately broken inputs (a dangling component reference and a nonexistent pin) and reading the resulting messages, rather than only checking that *an* error is raised. The error type and count were both correct — only the text was wrong, which is exactly the part a user reads.
