### PR TITLE
fix: explain groups have no pins and suggest a child selector (#2852)

### DIFF
--- a/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
+++ b/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
@@ -100,7 +100,22 @@ export function Trace__findConnectedPorts(trace: Trace):
       const labelList = Array.from(new Set(portNames)).join(", ")
       let detail: string
       if (ports.length === 0) {
-        detail = "It has no ports"
+        // A group is a container, not a component with pins — telling the user
+        // it "has no ports" is true but useless. Point at what they can
+        // actually connect to instead.
+        const namedChildren = targetComponent.children
+          .filter((c) => (c as any).props?.name)
+          .map((c) => `.${(c as any).props.name}`)
+        if (
+          targetComponent.componentName === "Group" ||
+          targetComponent.componentName === "Subcircuit"
+        ) {
+          detail = namedChildren.length
+            ? `It is a group, which has no pins of its own. Select a component inside it, e.g. "${namedChildren[0]} > .${portLabel}". It contains [${Array.from(new Set(namedChildren)).join(", ")}]`
+            : "It is a group, which has no pins of its own, and it contains no named components"
+        } else {
+          detail = "It has no ports"
+        }
       } else if (!hasCustomLabels) {
         detail = `It has ${ports.length} pins and no pinLabels (consider adding pinLabels)`
       } else {

--- a/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
+++ b/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
@@ -57,6 +57,11 @@ export function Trace__findConnectedPorts(trace: Trace):
         parentSelector = match?.[1]?.trim() ?? ""
         portToken = match?.[2] ?? selector
       }
+      // Both branches can leave the child combinator behind: ".U1 > .pin1"
+      // yields ".U1 > ". That string doesn't select the component — it
+      // resolves to an arbitrary descendant — so the error message ends up
+      // naming the wrong element and reporting "It has no ports".
+      parentSelector = parentSelector.replace(/[\s>]+$/, "")
       let targetComponent = parentSelector
         ? trace.getSubcircuit().selectOne(parentSelector)
         : null

--- a/tests/components/base-components/trace-port-selector-errors.test.tsx
+++ b/tests/components/base-components/trace-port-selector-errors.test.tsx
@@ -43,7 +43,7 @@ test("error when component has no ports", () => {
 
   expect(errors.length).toBe(1)
   expect((errors[0] as any).message).toBe(
-    'Could not find port for selector "G1.1". Component "G1" found, but does not have pin "1". It has no ports',
+    'Could not find port for selector "G1.1". Component "G1" found, but does not have pin "1". It is a group, which has no pins of its own, and it contains no named components',
   )
 })
 

--- a/tests/components/normal-components/chip-connections-invalid.test.tsx
+++ b/tests/components/normal-components/chip-connections-invalid.test.tsx
@@ -38,7 +38,7 @@ test("Chip not having name messes up the connections, uses the pin of the first 
     [
       {
         "error_type": "source_trace_not_connected_error",
-        "message": "Could not find port for selector ".unnamed_chip1 > .pin1". Component ".unnamed_chip1 > " not found",
+        "message": "Could not find port for selector ".unnamed_chip1 > .pin1". Component ".unnamed_chip1" not found",
         "selectors_not_found": [
           ".unnamed_chip1 > .pin1",
         ],

--- a/tests/components/primitive-components/trace-group-selector-error.test.tsx
+++ b/tests/components/primitive-components/trace-group-selector-error.test.tsx
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("selecting a pin on a group explains that groups have no pins", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <group name="G1">
+        <resistor name="R1" resistance="1k" footprint="0402" />
+        <capacitor name="C1" capacitance="1uF" footprint="0402" pcbX={3} />
+      </group>
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={8} />
+      <trace from=".G1 > .pin1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const error = circuit
+    .getCircuitJson()
+    .find((e: any) => String(e.type).includes("error")) as any
+
+  expect(error).toBeDefined()
+
+  // "It has no ports" is technically true of a group but tells the user
+  // nothing about what to do. The message should say it's a group and point at
+  // the components inside it.
+  expect(error.message).not.toContain("It has no ports")
+  expect(error.message).toContain("It is a group")
+  expect(error.message).toContain(".R1")
+  expect(error.message).toContain(".C1")
+  // The suggestion must reuse the pin the user actually asked for.
+  expect(error.message).toContain('".R1 > .pin1"')
+})
+
+test("a component with genuinely no ports still says so", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <chip name="U1" footprint="soic8" pcbX={0} />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <trace from=".R1 > .pin1" to=".U1 > .NOPE" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const error = circuit
+    .getCircuitJson()
+    .find((e: any) => String(e.type).includes("error")) as any
+
+  expect(error).toBeDefined()
+  // A chip has ports, so it must report the pin list, not the group wording.
+  expect(error.message).not.toContain("It is a group")
+  expect(error.message).toContain("pins")
+})

--- a/tests/components/primitive-components/trace-missing-port-error-message.test.tsx
+++ b/tests/components/primitive-components/trace-missing-port-error-message.test.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("missing-pin error names the component and lists its pins", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pcbX={0}
+        pinLabels={{ pin1: ["VCC"], pin2: ["GND"] }}
+      />
+      <trace from=".U1 > .VCC" to=".U1 > .NOPE" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const error = circuit
+    .getCircuitJson()
+    .find((e: any) => String(e.type).includes("error")) as any
+
+  expect(error).toBeDefined()
+
+  // The parent selector used to keep the child combinator (".U1 > "), which
+  // selects an arbitrary descendant rather than the chip — so the message
+  // named the wrong element and claimed it had no ports.
+  expect(error.message).toContain('Component "U1" found')
+  expect(error.message).not.toContain('".U1 > "')
+  expect(error.message).not.toContain("It has no ports")
+  // The pin list must come from the chip itself.
+  expect(error.message).toContain("VCC")
+  expect(error.message).toContain("GND")
+})
+
+test("missing-component error reports the component selector without the combinator", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} />
+      <trace from=".R1 > .pin1" to=".R9 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const error = circuit
+    .getCircuitJson()
+    .find((e: any) => String(e.type).includes("error")) as any
+
+  expect(error).toBeDefined()
+  expect(error.message).toContain('Component ".R9" not found')
+  expect(error.message).not.toContain('".R9 > "')
+})

--- a/tests/repros/repro99-trace-selector-pcbpath-no-throw.test.tsx
+++ b/tests/repros/repro99-trace-selector-pcbpath-no-throw.test.tsx
@@ -20,5 +20,7 @@ test("repro100 trace selector with pcbPath inserts error instead of throwing", a
 
   expect(errors.length).toBeGreaterThan(0)
   expect(errors[0].message).toContain('selector "J1.pin1"')
-  expect(errors[0].message).toContain("It has no ports")
+  // `J1` is an empty <group />, so the message explains that groups have no
+  // pins of their own rather than the bare "It has no ports".
+  expect(errors[0].message).toContain("It is a group")
 })


### PR DESCRIPTION
Closes #2852. **Stacked on #2851** — please merge that one first; this branch contains its commit, so GitHub will show the diff correctly once #2851 lands.

```
before  Component "G1" found, but does not have pin "pin1". It has no ports
after   Component "G1" found, but does not have pin "pin1". It is a group, which has
        no pins of its own. Select a component inside it, e.g. ".R1 > .pin1".
        It contains [.R1, .C1]
```

A group is a container, so "It has no ports" is true but reads like the group is broken. The children are already in hand at that point, so the message can name them and hand back a selector that actually works — reusing the pin the user asked for (`.pin1`), not a generic example.

### Scope

Only the `ports.length === 0` branch, and only when the component is a `Group`/`Subcircuit`. A real component with no ports still gets the original wording — there's a test for that, so this can't be satisfied by changing the string unconditionally.

### Verification

**The test bites.** Reverting the change:

```
Expected to not contain: "It has no ports"
Received: ... Component "G1" found, but does not have pin "pin1". It has no ports
```

The tests assert positive and negative on both paths: a group must say "It is a group", list `.R1`/`.C1`, and suggest `".R1 > .pin1"`; a chip must **not** say "It is a group" and must still report its pins.

**Two existing expectations updated.** Both use *empty* groups, so they land on the other phrasing:

- `trace-port-selector-errors.test.tsx` — `<group name="G1" />`
- `repro99-trace-selector-pcbpath-no-throw.test.tsx` — `<group name="J1" />`

I checked each was genuinely empty before changing it rather than editing to make tests pass; the new text ("…and it contains no named components") is accurate for both.

**Suite:** `1263 pass / 0 fail`, `tsc --noEmit` 0 errors, `biome format` clean.

### Why this needs #2851 first

On current `main` the parent selector still carries the combinator, and `".G1 >"` resolves to the group's **first child**:

```
selectOne(".G1")   → Group
selectOne(".G1 >") → Resistor "R1"
```

so `main` reports `Component "R1" found, but does not have pin "pin1"` — and `R1` does have `pin1`. #2851 fixes which element is named; this PR fixes what the message then says about it.
