### PR TITLE
feat: wire topola autorouter preset to local solve-endpoint

### DIFF
--- a/lib/utils/autorouting/getPresetAutoroutingConfig.ts
+++ b/lib/utils/autorouting/getPresetAutoroutingConfig.ts
@@ -116,6 +116,23 @@ export function getPresetAutoroutingConfig(
         ...rest,
       }
     }
+    case "topola": {
+      const {
+        preset: _preset,
+        local: _local,
+        groupMode: _groupMode,
+        ...rest
+      } = providedConfig
+      return {
+        local: false,
+        groupMode: "subcircuit",
+        serverUrl: "http://127.0.0.1:3099",
+        serverMode: "solve-endpoint",
+        inputFormat: "simplified",
+        serverCacheEnabled: false,
+        ...rest,
+      }
+    }
     default:
       return {
         local: true,

--- a/tests/utils/autorouting/getPresetAutoroutingConfig.test.ts
+++ b/tests/utils/autorouting/getPresetAutoroutingConfig.test.ts
@@ -27,4 +27,27 @@ describe("getPresetAutoroutingConfig", () => {
 
     expect(alias).toEqual(expected)
   })
+
+  test("topola preset points at local solve-endpoint", () => {
+    const config = getPresetAutoroutingConfig(
+      "topola" as unknown as AutorouterConfig,
+    )
+    expect(config).toMatchObject({
+      local: false,
+      groupMode: "subcircuit",
+      serverUrl: "http://127.0.0.1:3099",
+      serverMode: "solve-endpoint",
+      inputFormat: "simplified",
+      serverCacheEnabled: false,
+    })
+  })
+
+  test("topola preset allows overriding serverUrl", () => {
+    const config = getPresetAutoroutingConfig({
+      preset: "topola",
+      serverUrl: "http://127.0.0.1:4099",
+    } as AutorouterConfig)
+    expect(config.serverUrl).toBe("http://127.0.0.1:4099")
+    expect(config.serverMode).toBe("solve-endpoint")
+  })
 })


### PR DESCRIPTION
## Summary
- Wire `autorouter="topola"` in `getPresetAutoroutingConfig` to a local Topola HTTP adapter:
  - `serverUrl: http://127.0.0.1:3099`
  - `serverMode: solve-endpoint`
  - `inputFormat: simplified`
- Add unit tests for the preset and `serverUrl` override.

## Context
https://github.com/tscircuit/tscircuit/issues/4078

Pairs with the props PR adding `"topola"` to `AutorouterPreset`.

Reference adapter: https://github.com/djmango/lightbar-dock/tree/master/packages/topola-autorouter

## Test plan
- [ ] `bun test tests/utils/autorouting/getPresetAutoroutingConfig.test.ts`
- [ ] With a local Topola solve-endpoint on `:3099`, `autorouter="topola"` routes via that server