### PR TITLE
fix: report unparseable unit values instead of emitting NaN (#2855)

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -125,6 +125,19 @@ export type PortMap<T extends string> = {
  * }
  */
 
+/**
+ * circuit-JSON field name -> the prop the user wrote, where the two differ by
+ * more than snake_case/camelCase.
+ */
+const NAN_CHECKED_SOURCE_FIELD_TO_PROP: Record<string, string> = {
+  current_rating_amps: "currentRating",
+  voltage_rating_volts: "voltageRating",
+  max_voltage_rating: "maxVoltageRating",
+  max_current_rating: "maxCurrentRating",
+  load_capacitance: "loadCapacitance",
+  max_resistance: "maxResistance",
+}
+
 export class NormalComponent<
     ZodProps extends z.ZodType = any,
     PortNames extends string = never,
@@ -700,6 +713,35 @@ export class NormalComponent<
     return getDefaultExpectedRefDesPrefixesForFtype(this.config.sourceFtype)
   }
 
+  /**
+   * Reports props that parsed into `NaN`.
+   *
+   * The unit-bearing props (`resistance`, `capacitance`, ...) are declared as a
+   * zod transform that accepts a string, so a typo like `resistance="abc"`
+   * passes validation and becomes `NaN`. Nothing downstream checks for that, so
+   * it silently reaches circuit JSON and renders as "NaNpΩ" on the schematic
+   * with no error at all.
+   */
+  _reportNaNSourceValues(): void {
+    if (!this.source_component_id) return
+    const { db } = this.root!
+    const sourceComponent = db.source_component.get(this.source_component_id)
+    if (!sourceComponent) return
+
+    for (const [key, value] of Object.entries(sourceComponent)) {
+      if (typeof value !== "number" || !Number.isNaN(value)) continue
+      // Report against the prop the user actually wrote where we can map it.
+      const propName =
+        NAN_CHECKED_SOURCE_FIELD_TO_PROP[key] ??
+        key.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
+      const rawValue = (this.props as Record<string, unknown>)?.[propName]
+      this._reportInvalidComponentPropertyError(
+        propName,
+        `Invalid ${propName} value for ${this.componentName} "${this.name}": ${JSON.stringify(rawValue)} could not be parsed as a number.`,
+      )
+    }
+  }
+
   doInitialCheckRefDesConvention(): void {
     NormalComponent_doInitialCheckRefDesConvention(this)
   }
@@ -711,6 +753,8 @@ export class NormalComponent<
    */
   doInitialSourceParentAttachment(): void {
     const { db } = this.root!
+
+    this._reportNaNSourceValues()
 
     const internallyConnectedSourcePortIds = this._getInternallyConnectedPins()
       .map((ports) =>

--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -176,7 +176,7 @@ export abstract class PrimitiveComponent<
   cad_component_id: string | null = null
   _reportedInvalidPcbCalcWarnings = new Set<string>()
 
-  private _reportInvalidComponentPropertyError(
+  protected _reportInvalidComponentPropertyError(
     propertyName: string,
     message: string,
   ): void {

--- a/tests/components/base-components/unparseable-value-error.test.tsx
+++ b/tests/components/base-components/unparseable-value-error.test.tsx
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("unparseable unit values are reported instead of rendering NaN", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="40mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="abc" footprint="0402" pcbX={-12} />
+      <capacitor name="C1" capacitance="xyz" footprint="0402" pcbX={-6} />
+      <fuse name="F1" currentRating="bad" footprint="0402" pcbX={6} />
+      {/* A valid component must stay silent. */}
+      <resistor name="R9" resistance="1k" footprint="0402" pcbX={12} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit
+    .getCircuitJson()
+    .filter((e: any) =>
+      String(e.type).includes("invalid_component_property"),
+    ) as any[]
+
+  const byProperty = Object.fromEntries(
+    errors.map((e) => [`${e.property_name}`, e.message]),
+  )
+
+  // These props are zod transforms that accept a string, so a typo parses to
+  // NaN and used to reach circuit JSON silently — rendering "NaNpΩ" on the
+  // schematic with zero errors raised.
+  expect(Object.keys(byProperty).sort()).toEqual([
+    "capacitance",
+    "currentRating",
+    "resistance",
+  ])
+  expect(byProperty.resistance).toContain('"abc"')
+  expect(byProperty.resistance).toContain("R1")
+  expect(byProperty.currentRating).toContain("F1")
+
+  // Exactly one error per bad value — a valid component must not be flagged.
+  expect(errors.length).toBe(3)
+  expect(errors.some((e) => String(e.message).includes("R9"))).toBe(false)
+})
+
+test("valid values raise no property errors", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <capacitor name="C1" capacitance="1uF" footprint="0402" pcbX={5} />
+      <fuse name="F1" currentRating="2A" voltageRating="32V" footprint="0402" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit
+    .getCircuitJson()
+    .filter((e: any) => String(e.type).includes("invalid_component_property"))
+
+  expect(errors).toEqual([])
+})


### PR DESCRIPTION
Closes #2855.

A typo in a unit-bearing prop used to produce **zero errors** and draw garbage on the schematic:

```
before  resistance="abc"   → NaN, display "NaNpΩ", symbol "NaNpΩ", 0 errors
after   resistance="abc"   → same NaN in the value, plus
        Invalid resistance value for Resistor "R1": "abc" could not be parsed as a number.
```

These props are zod **transforms** accepting `string | number`, so validation succeeds and hands back `NaN`:

```ts
resistorProps.safeParse({ name: "R1", resistance: "abc" })
// → { success: true, data: { resistance: NaN } }
```

Worth noting the asymmetry that makes this bite: **omitting** `resistance` gives a clear `resistance (Required)` error, while **misspelling** it fails silently. The more likely mistake is the one with no diagnostic.

### Approach

Rather than adding a check to each component, this inspects the emitted `source_component` for `NaN` numbers once, in `doInitialSourceParentAttachment`. That covers every ftype — the sweep found `resistance`, `capacitance`, `inductance`, `currentRating` — and any future one, without touching the individual `doInitialSourceRender` implementations.

It reuses the existing `source_invalid_component_property_error` element and `_reportInvalidComponentPropertyError` helper (already used for bad `calc()` expressions), so this introduces no new error type and no new reporting path. The helper changed from `private` to `protected` for the subclass call; that's the only signature change.

The message names the **prop the user wrote**, not the circuit-JSON field — there's a small map for the cases where they differ (`current_rating_amps` → `currentRating`, `max_voltage_rating` → `maxVoltageRating`, …), with camelCase conversion as the fallback.

### Deliberately not a throw

I kept it as an error element rather than throwing, matching how the existing invalid-property path behaves. One bad value shouldn't abort the whole render — the user still gets a board plus a precise message.

### Verification

**The test bites.** Reverting `NormalComponent.ts` drops the expectation from 3 property errors to 0.

Both directions are asserted:

- three bad values → exactly three errors, keyed by `resistance` / `capacitance` / `currentRating`, each naming the offending component and the raw string;
- a valid `<resistor resistance="1k" />` in the *same* board raises nothing, and a second test with only valid values expects `[]`.

So a blanket "always warn" implementation can't pass.

**Suite:** `1261 pass / 0 fail`, `tsc --noEmit` 0 errors, `biome format` clean, no snapshots changed.
