### PR TITLE
fix: report non-positive physical dimensions (#2857)

### DIFF
--- a/lib/components/normal-components/Board_doInitialPcbPlacementDesignRuleChecks.ts
+++ b/lib/components/normal-components/Board_doInitialPcbPlacementDesignRuleChecks.ts
@@ -9,6 +9,60 @@ import {
 import type { AnyCircuitElement } from "circuit-json"
 import type { Board } from "./Board"
 
+/**
+ * Physical dimensions that must be greater than zero, per element type.
+ *
+ * A negative or zero size is silently accepted today: `<hole diameter="-2mm" />`
+ * produces `hole_diameter: -2` with no error, and a `<board width="0mm" />`
+ * renders an empty board. Nothing downstream rejects it, so the mistake only
+ * surfaces as a confusing render or an unmanufacturable export.
+ */
+const POSITIVE_DIMENSION_FIELDS: Record<string, string[]> = {
+  pcb_board: ["width", "height"],
+  pcb_hole: ["hole_diameter", "hole_width", "hole_height"],
+  pcb_plated_hole: [
+    "hole_diameter",
+    "outer_diameter",
+    "hole_width",
+    "hole_height",
+    "outer_width",
+    "outer_height",
+    "rect_pad_width",
+    "rect_pad_height",
+  ],
+  pcb_via: ["hole_diameter", "outer_diameter"],
+  pcb_smtpad: ["width", "height", "radius"],
+}
+
+const reportNonPositiveDimensions = ({
+  board,
+  elements,
+}: {
+  board: Board
+  elements: AnyCircuitElement[]
+}) => {
+  const { db } = board.root!
+
+  for (const element of elements as any[]) {
+    const fields = POSITIVE_DIMENSION_FIELDS[element.type]
+    if (!fields) continue
+
+    for (const field of fields) {
+      const value = element[field]
+      if (typeof value !== "number" || Number.isNaN(value)) continue
+      if (value > 0) continue
+
+      const label =
+        element.name ?? element[`${element.type}_id`] ?? element.type
+      db.pcb_placement_error.insert({
+        error_type: "pcb_placement_error",
+        message: `${element.type} "${label}" has ${field}=${value}mm, which must be greater than zero.`,
+        subcircuit_id: board.subcircuit_id ?? undefined,
+      } as any)
+    }
+  }
+}
+
 export const Board_doInitialPcbPlacementDesignRuleChecks = (board: Board) => {
   if (board.root?.pcbDisabled) return
 
@@ -27,6 +81,8 @@ export const Board_doInitialPcbPlacementDesignRuleChecks = (board: Board) => {
   const subcircuitCircuitJson = db
     .subtree({ subcircuit_id: board.subcircuit_id })
     .toArray()
+
+  reportNonPositiveDimensions({ board, elements: subcircuitCircuitJson })
 
   try {
     const placementCheckResults = [

--- a/tests/components/normal-components/non-positive-dimension-error.test.tsx
+++ b/tests/components/normal-components/non-positive-dimension-error.test.tsx
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("non-positive physical dimensions are reported", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <hole name="H1" diameter="-2mm" pcbX={-5} pcbY={0} />
+      <via
+        name="V1"
+        pcbX={5}
+        pcbY={0}
+        holeDiameter="-0.3mm"
+        outerDiameter="0.6mm"
+      />
+      {/* A valid component in the same board must not be flagged. */}
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} pcbY={5} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit
+    .getCircuitJson()
+    .filter((e: any) => e.type === "pcb_placement_error") as any[]
+
+  // A negative diameter used to be accepted silently: the element carried
+  // `hole_diameter: -2` and no error was raised at all.
+  expect(errors.length).toBe(2)
+
+  const messages = errors.map((e) => e.message).join("\n")
+  expect(messages).toContain("pcb_hole")
+  expect(messages).toContain("hole_diameter=-2mm")
+  expect(messages).toContain("pcb_via")
+  expect(messages).toContain("must be greater than zero")
+  // The valid resistor's pads must not appear.
+  expect(messages).not.toContain("pcb_smtpad")
+})
+
+test("a zero-size board is reported", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="0mm" height="0mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit
+    .getCircuitJson()
+    .filter((e: any) => e.type === "pcb_placement_error") as any[]
+
+  expect(errors.some((e) => String(e.message).includes("pcb_board"))).toBe(true)
+})
+
+test("valid dimensions raise no placement errors", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm">
+      <hole name="H1" diameter="2mm" pcbX={-8} pcbY={0} />
+      <via
+        name="V1"
+        pcbX={8}
+        pcbY={0}
+        holeDiameter="0.3mm"
+        outerDiameter="0.6mm"
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} pcbY={8} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit
+    .getCircuitJson()
+    .filter(
+      (e: any) =>
+        e.type === "pcb_placement_error" &&
+        String(e.message).includes("greater than zero"),
+    )
+
+  expect(errors).toEqual([])
+})


### PR DESCRIPTION
Closes #2857.

Negative and zero physical dimensions were accepted with **zero diagnostics**:

```
before                                          after
pcb_hole.hole_diameter        -2    errors: 0   pcb_hole "..." has hole_diameter=-2mm, which must be greater than zero.
pcb_via.hole_diameter         -0.3  errors: 0   (same)
pcb_plated_hole.hole_diameter -0.5  errors: 0   (same)
pcb_board.width                0    errors: 0   (same)
```

These are unmanufacturable geometries. A negative-diameter hole simply doesn't render, a zero-size board looks empty, and nothing tells the user why — the mistake surfaces downstream or at fabrication.

### Where the check lives

`Board_doInitialPcbPlacementDesignRuleChecks` already walks the whole subcircuit's circuit JSON for the other placement checks, so the dimension scan piggybacks on that single pass rather than being added to each primitive's insert site (there are many — `Hole.ts` alone has four).

It reuses the existing `pcb_placement_error` element, so no new error type is introduced.

The field list is explicit per element type (`pcb_board`, `pcb_hole`, `pcb_plated_hole`, `pcb_via`, `pcb_smtpad`) rather than "any numeric field", so coordinates, rotations and offsets — which are legitimately negative — can't be caught by accident.

### Verification

**The test bites.** Reverting the check:

```
Expected: 2   Received: 0    (non-positive dimensions reported)
Expected: true Received: false (zero-size board reported)
```

Three tests cover both directions:

1. a board with a bad hole and a bad via reports exactly 2 errors, and the valid resistor in the **same board** is not flagged (asserted explicitly — `not.toContain("pcb_smtpad")`);
2. a zero-size board is reported;
3. an all-valid board with a real hole, via and resistor produces **no** dimension errors.

So a check that fires on everything, or one that only handles the negative case, can't pass.

**Suite:** `1262 pass / 0 fail`, `tsc --noEmit` 0 errors, `biome format` clean, no snapshots changed. Notably the existing suite raised **no new failures**, which is the evidence that nothing in the repo legitimately relies on a non-positive dimension.

### Deliberately out of scope

`holeDiameter` larger than `outerDiameter` (a hole bigger than its own pad) is also accepted silently, but whether that's ever legitimate is a judgement call rather than a clear invariant, so I left it out and noted it in #2857.
