### PR TITLE
fix: report traces that connect a port to itself (#2859)

### DIFF
--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -268,6 +268,28 @@ export class Trace
 
     if (!allPortsFound) return
 
+    // A trace whose endpoints resolve to the same port connects nothing. It is
+    // almost always a copy-paste slip (`from=".R1 > .pin1" to=".R1 > .pin1"`),
+    // and today it silently produces a source_trace listing the same port
+    // twice with no diagnostic at all.
+    const resolvedPortIds = ports.map((p) => p.port.source_port_id)
+    if (
+      resolvedPortIds.length >= 2 &&
+      new Set(resolvedPortIds).size === 1 &&
+      this._findConnectedNets().nets.length === 0
+    ) {
+      const subcircuit = this.getSubcircuit()
+      db.source_trace_not_connected_error.insert({
+        error_type: "source_trace_not_connected_error",
+        message: `${this.getString()} connects a port to itself; both ends resolve to the same port. Did you mean to connect two different pins?`,
+        subcircuit_id: subcircuit.subcircuit_id ?? undefined,
+        source_group_id: subcircuit.getGroup()?.source_group_id ?? undefined,
+        selectors_not_found: [],
+      } as any)
+      this._couldNotFindPort = true
+      return
+    }
+
     this._traceConnectionHash = this._computeTraceConnectionHash()
 
     const existingTraces = db.source_trace.list()

--- a/tests/components/primitive-components/trace-self-connection.test.tsx
+++ b/tests/components/primitive-components/trace-self-connection.test.tsx
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("a trace whose ends resolve to the same port is reported", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={8} />
+      <net name="VCC" />
+      <trace from=".R1 > .pin1" to=".R1 > .pin1" />
+      {/* Valid traces in the same board must be unaffected. */}
+      <trace from=".R1 > .pin2" to=".R2 > .pin1" />
+      <trace from=".R2 > .pin2" to="net.VCC" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const errors = circuitJson.filter((e: any) =>
+    String(e.type).includes("error"),
+  ) as any[]
+  const sourceTraces = circuitJson.filter(
+    (e: any) => e.type === "source_trace",
+  ) as any[]
+
+  // This used to emit a source_trace listing the same port twice, with no
+  // diagnostic at all.
+  expect(errors.length).toBe(1)
+  expect(errors[0].message).toContain("connects a port to itself")
+
+  // The two real traces still exist...
+  expect(sourceTraces.length).toBe(2)
+  // ...and no trace lists a duplicated port.
+  for (const trace of sourceTraces) {
+    const ids = trace.connected_source_port_ids ?? []
+    expect(new Set(ids).size).toBe(ids.length)
+  }
+})
+
+test("a trace from a port to its own net is not flagged", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} />
+      <net name="VCC" />
+      <trace from=".R1 > .pin1" to="net.VCC" />
+      <trace from=".R1 > .pin2" to="net.VCC" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  // Both pins joining the same net is a legitimate (if unusual) circuit, and a
+  // single-port trace to a net resolves to one port — neither must trip the
+  // self-connection check.
+  const errors = circuit
+    .getCircuitJson()
+    .filter((e: any) => String(e.type).includes("error"))
+
+  expect(errors).toEqual([])
+})


### PR DESCRIPTION
Closes #2859.

```
before  <trace from=".R1 > .pin1" to=".R1 > .pin1" />
        → source_trace with connected_source_port_ids ["source_port_0", "source_port_0"], 0 errors

after   → <trace#27(from:.R1 > .pin1 to:.R1 > .pin1) /> connects a port to itself;
          both ends resolve to the same port. Did you mean to connect two different pins?
```

The trace connects nothing but still emitted a `source_trace` listing the same port twice — a connection record that can never be routed. The only feedback was a `source_pin_missing_trace_warning` about the *other* pin, which points away from the actual mistake.

### Scope — what is deliberately still allowed

The guard requires **≥2 resolved ports, all identical, and no connected nets**. That last condition matters: `<trace from=".R1 > .pin1" to="net.VCC" />` also resolves to a single port, and flagging it would break ordinary net connections. There's a test for exactly that.

I checked the neighbouring cases and left them alone because they can be legitimate:

- a port joined to a net (above);
- both pins of a part on the same net — unusual but a real circuit (a link/jumper), not obviously wrong;
- duplicate identical traces — already deduplicated by the existing connection-hash lookup, so no new handling needed.

Reuses `source_trace_not_connected_error`, which already exists for traces that can't be connected, so no new error type.

### Verification

**The test bites.** Reverting `Trace.ts`:

```
Expected: 1   Received: 0
(fail) a trace whose ends resolve to the same port is reported
```

Both directions are asserted:

1. a board with one self-trace **and two valid traces** → exactly 1 error, the two real `source_trace` elements survive, and no trace lists a duplicated port;
2. a board where both pins join the same net, plus port→net traces → **zero** errors.

So a guard that fires on any single-port resolution can't pass.

**Suite:** `1261 pass / 0 fail`, `tsc --noEmit` 0 errors, `biome format` clean, no snapshots changed — evidence that no existing test relies on a self-connecting trace being accepted.
