### PR TITLE
fix: report non-positive schematic dimensions (#2861)

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -23,6 +23,7 @@ import { Subcircuit_doInitialRenderIsolatedSubcircuits } from "../primitive-comp
 import { Subcircuit_getSubcircuitPropHash } from "../primitive-components/Group/Subcircuit_getSubcircuitPropHash"
 import type { BoardI } from "./BoardI"
 import { Board_doInitialPcbPlacementDesignRuleChecks } from "./Board_doInitialPcbPlacementDesignRuleChecks"
+import { Board_doInitialSchematicDimensionChecks } from "./Board_doInitialSchematicDimensionChecks"
 
 const MIN_EFFECTIVE_BORDER_RADIUS_MM = 0.01
 
@@ -578,6 +579,11 @@ export class Board
 
   doInitialPcbPlacementDesignRuleChecks() {
     Board_doInitialPcbPlacementDesignRuleChecks(this)
+  }
+
+  doInitialSchematicTraceRender() {
+    super.doInitialSchematicTraceRender?.()
+    Board_doInitialSchematicDimensionChecks(this)
   }
 
   updatePcbDesignRuleChecks() {

--- a/lib/components/normal-components/Board_doInitialSchematicDimensionChecks.ts
+++ b/lib/components/normal-components/Board_doInitialSchematicDimensionChecks.ts
@@ -1,0 +1,65 @@
+import type { AnyCircuitElement } from "circuit-json"
+import type { Board } from "./Board"
+
+/**
+ * Schematic dimensions that must be greater than zero, per element type.
+ *
+ * A negative or zero size is accepted silently today — `<chip schWidth={-4} />`
+ * emits `size: { width: -4 }` and `<schematiccircle radius={-1} />` emits
+ * `radius: -1`, both with no error. The symbol either renders inside-out or
+ * disappears, and the user gets no signal at all.
+ */
+const POSITIVE_SCHEMATIC_FIELDS: Record<string, string[]> = {
+  schematic_box: ["width", "height"],
+  schematic_rect: ["width", "height"],
+  schematic_circle: ["radius"],
+  schematic_text: ["font_size"],
+}
+
+export const Board_doInitialSchematicDimensionChecks = (board: Board) => {
+  if (board.root?.schematicDisabled) return
+
+  const { db } = board.root!
+  // Not every schematic primitive carries a `subcircuit_id` (schematic_box, for
+  // one), so a subtree query would silently skip them.
+  const elements = db.toArray() as AnyCircuitElement[]
+
+  const report = (message: string, propertyName: string) => {
+    db.source_invalid_component_property_error.insert({
+      error_type: "source_invalid_component_property_error",
+      source_component_id: "",
+      property_name: propertyName,
+      message,
+    } as any)
+  }
+
+  for (const element of elements as any[]) {
+    // schematic_component carries its size in a nested `size` object.
+    if (element.type === "schematic_component" && element.size) {
+      for (const field of ["width", "height"] as const) {
+        const value = element.size[field]
+        if (typeof value !== "number" || Number.isNaN(value)) continue
+        if (value > 0) continue
+        const propName = field === "width" ? "schWidth" : "schHeight"
+        report(
+          `Invalid ${propName} for schematic_component "${element.schematic_component_id}": ${value}, which must be greater than zero.`,
+          propName,
+        )
+      }
+      continue
+    }
+
+    const fields = POSITIVE_SCHEMATIC_FIELDS[element.type]
+    if (!fields) continue
+
+    for (const field of fields) {
+      const value = element[field]
+      if (typeof value !== "number" || Number.isNaN(value)) continue
+      if (value > 0) continue
+      report(
+        `Invalid ${field} for ${element.type} "${element[`${element.type}_id`] ?? element.type}": ${value}, which must be greater than zero.`,
+        field,
+      )
+    }
+  }
+}

--- a/tests/components/normal-components/negative-schematic-dimension-error.test.tsx
+++ b/tests/components/normal-components/negative-schematic-dimension-error.test.tsx
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const propertyErrors = (circuit: any) =>
+  circuit
+    .getCircuitJson()
+    .filter((e: any) =>
+      String(e.type).includes("invalid_component_property"),
+    ) as any[]
+
+test("non-positive schematic dimensions are reported", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="40mm" height="40mm" routingDisabled>
+      <chip name="U1" footprint="soic8" schX={0} schWidth={-4} schHeight={3} />
+      <schematicbox width={-2} height={2} schX={8} schY={0} />
+      <schematiccircle center={{ x: 0, y: -8 }} radius={-1} />
+      {/* A normal component in the same board must not be flagged. */}
+      <resistor name="R1" resistance="1k" footprint="0402" schX={-8} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = propertyErrors(circuit)
+  const messages = errors.map((e) => e.message).join("\n")
+
+  // These used to be accepted silently: `size: { width: -4 }` and
+  // `radius: -1` reached circuit JSON with zero errors.
+  expect(errors.length).toBe(3)
+  expect(messages).toContain("schWidth")
+  expect(messages).toContain("schematic_box")
+  expect(messages).toContain("schematic_circle")
+  expect(messages).toContain("must be greater than zero")
+  // The valid resistor's symbol must not appear.
+  expect(messages).not.toContain("R1")
+})
+
+test("valid schematic dimensions raise no property errors", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="40mm" height="40mm" routingDisabled>
+      <chip name="U1" footprint="soic8" schX={0} schWidth={4} schHeight={3} />
+      <schematicbox width={2} height={2} schX={8} schY={0} />
+      <schematiccircle center={{ x: 0, y: -8 }} radius={1} />
+      <resistor name="R1" resistance="1k" footprint="0402" schX={-8} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(propertyErrors(circuit)).toEqual([])
+})


### PR DESCRIPTION
Closes #2861. Schematic-side counterpart to #2858 (PCB dimensions); the two touch different files and merge in any order.

```
before                                              after
schematic_component.size { width: -4 }  errors: 0   Invalid schWidth for schematic_component "...": -4, which must be greater than zero.
schematic_box.width      -2             errors: 0   Invalid width for schematic_box "..." ...
schematic_circle.radius  -1             errors: 0   Invalid radius for schematic_circle "..." ...
```

All four element types also pass `any_circuit_element.safeParse` — the schemas don't constrain sign — so nothing downstream catches them either. The symbol renders inside-out or vanishes, and a typo like `schWidth={-4}` looks like a rendering bug rather than a bad input.

### A trap worth flagging

**`schematic_box` does not carry a `subcircuit_id`.** My first implementation used `db.subtree({ subcircuit_id })`, matching the PCB check, and the box was silently skipped — the test showed 2 errors instead of 3 and the box looked fine when it wasn't. I traced it by dumping `subcircuit_id` per element:

```
schematic_box    → undefined
schematic_circle → "subcircuit_source_group_0"
```

The scan now walks the full element list. Worth knowing for any future schematic-wide check.

### Scope

Explicit per-type field list (`schematic_box`, `schematic_rect`, `schematic_circle`, `schematic_text`, plus the nested `size` on `schematic_component`) rather than "any numeric field" — schematic coordinates and rotations are legitimately negative and must not be flagged.

Reuses `source_invalid_component_property_error`, already used for bad `calc()` expressions and (in #2856) unparseable unit values, so no new error type. The message names the **prop the user wrote** (`schWidth`, not `size.width`).

### Verification

**The test bites.** Reverting the `Board.ts` hook:

```
Expected: 3   Received: 0
(fail) non-positive schematic dimensions are reported
```

Both directions asserted: three bad dimensions → exactly 3 errors naming `schWidth` / `schematic_box` / `schematic_circle`, with the valid resistor in the **same board** explicitly not flagged (`not.toContain("R1")`); and an all-valid board expects `[]`.

**Suite:** `1261 pass / 0 fail`, `tsc --noEmit` 0 errors, `biome format` clean, no snapshots changed — evidence that nothing in the repo relies on a non-positive schematic dimension.
