### PR TITLE
fix: report ports that match no pad in their footprint (#2863)

### DIFF
--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -444,7 +444,35 @@ export class Port extends PrimitiveComponent<typeof portProps> {
 
     const pcbMatches = matchedComponents.filter((c) => c.isPcbPrimitive)
 
-    if (pcbMatches.length === 0) return
+    if (pcbMatches.length === 0) {
+      // A port that matches no PCB primitive can never be routed. This happens
+      // when `pinLabels` names a pin the footprint doesn't have (e.g. `pin99`
+      // on a soic8): the source port is created, but there is no pad behind it.
+      // Without this the only feedback is a later "trace is not connected"
+      // error, which points at the trace rather than the bad pin label.
+      const parentComponent = this.getParentNormalComponent()
+      const sourceComponentId = parentComponent?.source_component_id
+      // Only meaningful when the component has *some* pads: a component with no
+      // footprint at all (e.g. a bare `<solderjumper />`) legitimately has no
+      // PCB primitives, and every one of its pins would otherwise be flagged.
+      const parentHasAnyPcbPrimitive = (parentComponent?.children ?? []).some(
+        (child: any) => child.isPcbPrimitive,
+      )
+      if (
+        sourceComponentId &&
+        parentHasAnyPcbPrimitive &&
+        this._parsedProps.pinNumber !== undefined
+      ) {
+        const componentName = parentComponent?.props?.name ?? "unknown"
+        const portLabel = this.props.name ?? `pin${this._parsedProps.pinNumber}`
+        db.source_component_misconfigured_error.insert({
+          error_type: "source_component_misconfigured_error",
+          source_component_ids: [sourceComponentId],
+          message: `Pin "${portLabel}" on ${componentName} has no matching pad in its footprint, so it cannot be connected. Check that pinLabels only names pins the footprint provides.`,
+        } as any)
+      }
+      return
+    }
 
     let matchCenter: { x: number; y: number } | null = null
 

--- a/tests/components/primitive-components/port-without-matching-pad.test.tsx
+++ b/tests/components/primitive-components/port-without-matching-pad.test.tsx
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const misconfiguredErrors = (circuit: any) =>
+  circuit
+    .getCircuitJson()
+    .filter((e: any) => String(e.type).includes("misconfigured")) as any[]
+
+test("a pinLabels entry with no matching pad is reported", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      {/* soic8 has 8 pads; pin99 has none. */}
+      <chip
+        name="U1"
+        footprint="soic8"
+        pcbX={5}
+        pinLabels={{ pin1: ["A"], pin99: ["Z"] }}
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = misconfiguredErrors(circuit)
+
+  // Previously this produced a 9th source_port with no pcb_port behind it and
+  // no diagnostic; connecting to it only yielded a "trace is not connected"
+  // error pointing at the trace instead of the bad pin label.
+  expect(errors.length).toBe(1)
+  expect(errors[0].message).toContain('Pin "Z"')
+  expect(errors[0].message).toContain("U1")
+  expect(errors[0].message).toContain("no matching pad")
+  // The valid resistor must not be flagged.
+  expect(errors[0].message).not.toContain("R1")
+})
+
+test("a component with no footprint at all is not flagged", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      {/* No footprint => no PCB primitives at all; every pin would otherwise
+          be reported as having no matching pad. */}
+      <solderjumper name="SJ1" pcbX={0} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(misconfiguredErrors(circuit)).toEqual([])
+})
+
+test("a fully valid footprint raises nothing", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pcbX={5}
+        pinLabels={{ pin1: ["VCC"], pin8: ["GND"] }}
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(misconfiguredErrors(circuit)).toEqual([])
+})


### PR DESCRIPTION
Closes #2863.

```tsx
<chip name="U1" footprint="soic8" pinLabels={{ pin1: ["A"], pin99: ["Z"] }} />
```

```
before  9 source_ports, 8 pads, 8 pcb_ports, 0 errors
after   same elements, plus
        Pin "Z" on U1 has no matching pad in its footprint, so it cannot be
        connected. Check that pinLabels only names pins the footprint provides.
```

Connecting to that pin previously produced `pcb_trace_missing_error: Trace ... is not connected`, which points at the trace when the actual mistake is the pin label.

`Port.doInitialPcbPortRender` returned early on `pcbMatches.length === 0`. The neighbouring case — a port matching *multiple* non-overlapping pads — already reports `source_ambiguous_port_reference`; only the zero-match case was silent. This reuses `source_component_misconfigured_error`, so no new error type.

### The guard condition is the whole point

My first version was a blanket check, and it **broke 6 existing tests** — `solderjumper` (×2), `jumper`, a KiCad panel repro, `subcircuit-circuit-json10`, and a subpanel placement test. The cause is legitimate:

```
<solderjumper />                              → 0 pads total  → not a misconfiguration
<chip footprint="soic8" pinLabels={{pin99}}>  → 8 pads, pin99 matches none → misconfiguration
```

A component with no footprint at all has no PCB primitives, so *every* pin matches nothing. The check now fires only when the parent has **some** PCB primitives but this particular port matches none. All 6 tests pass again without being modified — I fixed the check rather than the tests.

### Verification

**The test bites.** Reverting `Port.ts`:

```
Expected: 1   Received: 0
(fail) a pinLabels entry with no matching pad is reported
```

Three tests pin all three states:

1. `pin99` on a soic8 → exactly 1 error naming `"Z"` and `U1`, with the valid resistor not flagged;
2. a bare `<solderjumper />` → `[]` (the false-positive case that broke the 6 tests);
3. a fully valid soic8 with `pin1`/`pin8` labels → `[]`.

So neither a blanket check nor a no-op can pass.

**Suite:** `1262 pass / 0 fail`, `tsc --noEmit` 0 errors, `biome format` clean, no snapshots changed.
