### PR TITLE
fix: report empty connections targets instead of crashing the render (#2865)

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -2107,6 +2107,25 @@ export class NormalComponent<
       for (const [pinName, target] of Object.entries(props.connections)) {
         const targets = Array.isArray(target) ? target : [target]
         for (const targetPath of targets) {
+          // An empty or whitespace-only target isn't a selector. Passing it
+          // through produces `to: ""`, which reaches the CSS selector parser and
+          // throws `Expected name, found .` — an internal parser error that
+          // aborts the whole render and names neither the component nor the pin.
+          if (
+            targetPath === undefined ||
+            targetPath === null ||
+            String(targetPath).trim() === ""
+          ) {
+            const { db } = this.root!
+            db.source_component_misconfigured_error.insert({
+              error_type: "source_component_misconfigured_error",
+              source_component_ids: this.source_component_id
+                ? [this.source_component_id]
+                : [],
+              message: `${this.getString()} has an empty connections target for pin "${pinName}". Provide a selector such as ".R1 > .pin1" or "net.VCC", or remove the entry.`,
+            })
+            continue
+          }
           this.add(
             new Trace({
               from: `.${this.name} > .${pinName}`,

--- a/tests/components/normal-components/empty-connections-target.test.tsx
+++ b/tests/components/normal-components/empty-connections-target.test.tsx
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("an empty connections target is reported instead of throwing a css parser error", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <capacitor
+        name="C1"
+        capacitance="1uF"
+        footprint="0402"
+        pcbX={0}
+        connections={{ pin1: "", pin2: ".R1 > .pin1" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_component_misconfigured_error.list()
+  expect(errors.length).toBe(1)
+  expect(errors[0].message).toContain("empty connections target")
+  expect(errors[0].message).toContain("pin1")
+
+  // The sibling, valid connection is still honoured.
+  expect(circuit.db.source_trace.list().length).toBe(1)
+})
+
+test("a whitespace-only connections target is reported too", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <capacitor
+        name="C1"
+        capacitance="1uF"
+        footprint="0402"
+        pcbX={0}
+        connections={{ pin1: "   " }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_component_misconfigured_error.list().length).toBe(1)
+})
+
+test("fully valid connections raise nothing", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <capacitor
+        name="C1"
+        capacitance="1uF"
+        footprint="0402"
+        pcbX={0}
+        connections={{ pin1: ".R1 > .pin2", pin2: ".R1 > .pin1" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_component_misconfigured_error.list()).toEqual([])
+  expect(circuit.db.source_trace.list().length).toBe(2)
+})


### PR DESCRIPTION
Fixes #2865.

### What was wrong

`connections={{ pin1: "" }}` didn't produce an error — it produced a **crash**:

```
error: Expected name, found .
  at getName (node_modules/css-what/lib/commonjs/parse.js:95:23)
  at selectOne (lib/.../PrimitiveComponent.ts:1253:18)
  at resolveImplicitSinglePort (lib/.../Trace__findConnectedPorts.ts:29:47)
```

`_createTracesFromConnectionsProp` forwarded the empty string into a `Trace`'s `to`, and `""` reached the CSS selector parser. Two consequences: the message came from `css-what` internals and named neither the component nor the pin (it points at `.` — which reads as if the *valid* sibling selector were the problem), and because it throws rather than records, the entire render aborted and no circuit JSON was produced.

### The fix

One guard in `_createTracesFromConnectionsProp`, before the `Trace` is constructed: an empty or whitespace-only target inserts a `source_component_misconfigured_error` and skips that entry.

```
<capacitor#13 name=".C1" /> has an empty connections target for pin "pin1".
Provide a selector such as ".R1 > .pin1" or "net.VCC", or remove the entry.
```

The board keeps rendering, and the sibling valid connection still gets its `source_trace`.

Reused the existing `source_component_misconfigured_error` — **no new error type**. It's the same one used elsewhere for bad component input, and it takes the type-checked insert without a cast.

The guard is placed inside the per-target loop, so it covers both the string form and the array form of a `connections` entry.

### Scope

Deliberately narrow: only **empty / whitespace-only** targets. A non-empty but unresolvable selector (`".R9 > .pin1"` where R9 doesn't exist) has its own existing downstream handling and is untouched by this change.

I considered rejecting `""` in the `props` schema instead, which would catch it earlier — but that's a cross-repo change that converts a runtime crash into a hard parse failure, so I kept the fix in core. Happy to follow up in `tscircuit/props` if you'd prefer that boundary.

### Tests

`tests/components/normal-components/empty-connections-target.test.tsx`, three tests pinning all three states so neither a blanket check nor a no-op passes:

| input | expected |
|---|---|
| `{ pin1: "", pin2: ".R1 > .pin1" }` | 1 error naming `pin1`, **and** 1 `source_trace` from the valid sibling |
| `{ pin1: "   " }` | 1 error |
| `{ pin1: ".R1 > .pin2", pin2: ".R1 > .pin1" }` | `[]` errors, 2 `source_trace`s |

Bite-proofed: reverting only `NormalComponent.ts` takes the file from **3 pass** to **1 pass / 2 fail**, with the original `Expected name, found .` throw reappearing.

Full suite: **1262 pass / 0 fail**, `tsc --noEmit` clean, biome clean, no snapshot churn.
