### PR TITLE
fix: honour the PinCount spelling in schPinArrangement (#2871)

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -332,7 +332,13 @@ export class NormalComponent<
       const sides = ["left", "right", "top", "bottom"]
       let pinNum = 1
       for (const side of sides) {
-        const size = (schPortArrangement as any)[`${side}Size`]
+        // `${side}PinCount` is the current spelling and `${side}Size` is the
+        // deprecated one (see schematicPortArrangement in @tscircuit/props).
+        // Only the deprecated form was read here, so an arrangement written with
+        // the current names created no ports at all.
+        const size =
+          (schPortArrangement as any)[`${side}PinCount`] ??
+          (schPortArrangement as any)[`${side}Size`]
         for (let i = 0; i < size; i++) {
           const nextPinNumber = pinNum++
           if (hasExistingOrQueuedPortWithPinNumber(nextPinNumber)) continue

--- a/lib/utils/schematic/getSizeOfSidesFromPortArrangement.ts
+++ b/lib/utils/schematic/getSizeOfSidesFromPortArrangement.ts
@@ -56,6 +56,16 @@ export const getSizeOfSidesFromPortArrangement = (
       bottomSize: getPinsFromSideDefinition(pa.bottomSide).length,
     }
   }
-  const { leftSize = 0, rightSize = 0, topSize = 0, bottomSize = 0 } = pa as any
-  return { leftSize, rightSize, topSize, bottomSize }
+  // `${side}PinCount` is the current spelling; `${side}Size` is the deprecated
+  // one (see schematicPortArrangement in @tscircuit/props, where the Size fields
+  // are marked "@deprecated, use ...PinCount"). Only the deprecated form was
+  // read here, so an arrangement written with the current names produced a box
+  // with zero pins on every side.
+  const arrangement = pa as any
+  return {
+    leftSize: arrangement.leftPinCount ?? arrangement.leftSize ?? 0,
+    rightSize: arrangement.rightPinCount ?? arrangement.rightSize ?? 0,
+    topSize: arrangement.topPinCount ?? arrangement.topSize ?? 0,
+    bottomSize: arrangement.bottomPinCount ?? arrangement.bottomSize ?? 0,
+  }
 }

--- a/tests/components/normal-components/sch-pin-arrangement-pin-count.test.tsx
+++ b/tests/components/normal-components/sch-pin-arrangement-pin-count.test.tsx
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const sidesOf = (ports: Array<{ side_of_component?: string }>) =>
+  ports.reduce<Record<string, number>>((acc, port) => {
+    const side = port.side_of_component ?? "unknown"
+    acc[side] = (acc[side] ?? 0) + 1
+    return acc
+  }, {})
+
+const renderWithArrangement = async (arrangement: unknown) => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="30mm" height="30mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        schPinArrangement={arrangement as any}
+      />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+  return circuit.db.schematic_port.list()
+}
+
+test("schPinArrangement honours the PinCount spelling", async () => {
+  const ports = await renderWithArrangement({
+    leftPinCount: 4,
+    rightPinCount: 4,
+  })
+
+  expect(ports.length).toBe(8)
+  expect(sidesOf(ports)).toEqual({ left: 4, right: 4 })
+})
+
+test("PinCount and the deprecated Size spelling agree", async () => {
+  // These are documented as equivalent — Size is marked "@deprecated, use
+  // ...PinCount" in @tscircuit/props. Asserted by comparison so the two can't
+  // drift apart again in either direction.
+  const withPinCount = await renderWithArrangement({
+    leftPinCount: 2,
+    rightPinCount: 6,
+  })
+  const withSize = await renderWithArrangement({ leftSize: 2, rightSize: 6 })
+
+  expect(withPinCount.length).toBe(withSize.length)
+  expect(sidesOf(withPinCount)).toEqual(sidesOf(withSize))
+  expect(sidesOf(withPinCount)).toEqual({ left: 2, right: 6 })
+})
+
+test("top and bottom PinCount place ports on all four sides", async () => {
+  const ports = await renderWithArrangement({
+    leftPinCount: 2,
+    rightPinCount: 2,
+    topPinCount: 2,
+    bottomPinCount: 2,
+  })
+
+  expect(ports.length).toBe(8)
+  expect(sidesOf(ports)).toEqual({ left: 2, right: 2, top: 2, bottom: 2 })
+})
+
+test("the deprecated Size spelling still works on its own", async () => {
+  // The fix must not break the existing spelling.
+  const ports = await renderWithArrangement({ leftSize: 4, rightSize: 4 })
+
+  expect(ports.length).toBe(8)
+  expect(sidesOf(ports)).toEqual({ left: 4, right: 4 })
+})


### PR DESCRIPTION
Fixes #2871.

### What was wrong

`schPinArrangement={{ leftPinCount: 4, rightPinCount: 4 }}` produced a chip with **zero schematic ports**, silently:

| arrangement | `schematic_port`s | sides |
|---|---|---|
| `{ leftSize: 4, rightSize: 4 }` | 8 | `{left: 4, right: 4}` |
| `{ leftPinCount: 4, rightPinCount: 4 }` | **0** | `{}` |
| no arrangement at all | 8 | `{left: 4, right: 4}` |

Worse than passing nothing, and with no error — it reads as a broken symbol rather than a dropped prop.

`...PinCount` is the **current** spelling. `@tscircuit/props` marks the `Size` fields `"@deprecated, use leftPinCount"`, so the documented name was the broken one.

### The fix — two sites, and both are required

**1. Port creation** (`NormalComponent`, ~line 335) read only `${side}Size`, so `size` was `undefined` and the loop never ran.

**2. Box layout** (`getSizeOfSidesFromPortArrangement`) destructured only the `Size` keys, returning `0` for every side.

Patching just the first is not enough, and I verified that rather than assuming: with only site 1 fixed the render produces **`source_port` 8 / `schematic_port` 0** — the ports exist but the box has no room allocated for them. Both sites needed the fallback.

Support was already partial elsewhere in the same area, which is what made this look like an oversight rather than a deliberate omission: `underscorifyPortArrangement` maps `leftPinCount → left_size` correctly, and `NormalComponent` already lists all eight key names when deciding whether an arrangement is explicit. Only these two spots missed it.

Implemented as `?? ` fallbacks (`PinCount` first, then the deprecated `Size`), so existing arrangements are untouched.

### Verification

After the fix:

```
{ leftPinCount: 4, rightPinCount: 4 }                          → 8 ports {left:4, right:4}
{ leftSize: 4, rightSize: 4 }                                  → 8 ports {left:4, right:4}
{ leftPinCount: 2, rightPinCount: 6 }                          → 8 ports {left:2, right:6}
{ leftPinCount:2, rightPinCount:2, topPinCount:2, bottomPinCount:2 } → 8 ports on all four sides
```

### Tests

`tests/components/normal-components/sch-pin-arrangement-pin-count.test.tsx`, four tests:

| case | expected |
|---|---|
| `leftPinCount`/`rightPinCount` 4/4 | 8 ports, `{left: 4, right: 4}` |
| `PinCount` 2/6 vs `Size` 2/6 | **results must be equal** — asserted by comparison, not against a constant |
| all four `PinCount` sides | ports on `left`, `right`, `top`, `bottom` |
| `leftSize`/`rightSize` alone | unchanged — the fix must not break the existing spelling |

The comparison test is the important one: it fails in either direction if the two spellings ever diverge again. The last row is the regression guard.

Bite-proofed: reverting `lib/` takes the file from **4 pass** to **1 pass / 3 fail**, with only the deprecated-spelling test still passing.

Full suite: **1259 pass / 0 fail**, `npx tsc --noEmit` clean, biome clean, no snapshot churn.
