### PR TITLE
Add WLED matrix Matchpack iteration repro

### DIFF
--- a/tests/repros/repro159-matchpack-led-matrix-iterations.test.tsx
+++ b/tests/repros/repro159-matchpack-led-matrix-iterations.test.tsx
@@ -24,7 +24,7 @@ const WLED = ({ name }: { name: string }) => (
   />
 )
 
-test("repro159: matchpack lays out a 12x12 WLED matrix", async () => {
+test.failing("repro159: matchpack lays out a 12x12 WLED matrix", async () => {
   const { circuit } = getTestFixture()
 
   circuit.add(

--- a/tests/repros/repro159-matchpack-led-matrix-iterations.test.tsx
+++ b/tests/repros/repro159-matchpack-led-matrix-iterations.test.tsx
@@ -24,92 +24,96 @@ const WLED = ({ name }: { name: string }) => (
   />
 )
 
-test.failing("repro159: matchpack lays out a 12x12 WLED matrix", async () => {
-  const { circuit } = getTestFixture()
+test.failing(
+  "repro159: matchpack lays out a 12x12 WLED matrix",
+  async () => {
+    const { circuit } = getTestFixture()
 
-  circuit.add(
-    <board routingDisabled>
-      <net name="V5" isPowerNet />
-      <net name="GND" isGroundNet />
+    circuit.add(
+      <board routingDisabled>
+        <net name="V5" isPowerNet />
+        <net name="GND" isGroundNet />
 
-      <chip
-        name="U1"
-        manufacturerPartNumber="Seeed Studio XIAO ESP32-C3"
-        pinLabels={{
-          pin1: "D0_GPIO2",
-          pin2: "D1_GPIO3",
-          pin3: "D2_GPIO4",
-          pin4: "D3_GPIO5",
-          pin5: "D4_GPIO6",
-          pin6: "D5_GPIO7",
-          pin7: "D6_GPIO21",
-          pin8: "D7_GPIO20",
-          pin9: "D8_GPIO8",
-          pin10: "D9_GPIO9",
-          pin11: "D10_GPIO10",
-          pin12: "3V3",
-          pin13: "GND",
-          pin14: "5V",
-        }}
-        pinAttributes={{
-          D4_GPIO6: { isGpio: true },
-          GND: { requiresGround: true },
-          "5V": { requiresPower: true, requiresVoltage: "5V" },
-          "3V3": { providesPower: true, providesVoltage: "3.3V" },
-        }}
-      />
-      <resistor name="RDATA" resistance="330" />
-      <capacitor name="CBULK" capacitance="1000uF" polarized />
-
-      <trace from=".U1 > .pin14" to="net.V5" />
-      <trace from=".U1 > .pin13" to="net.GND" />
-      <trace from=".U1 > .pin5" to=".RDATA > .pin1" />
-      <trace from=".RDATA > .pin2" to=".D1 > .DI" />
-      <trace from=".CBULK > .pos" to="net.V5" />
-      <trace from=".CBULK > .neg" to="net.GND" />
-
-      {Array.from({ length: LED_COUNT }, (_, ledIndex) => (
-        <WLED key={`D${ledIndex + 1}`} name={`D${ledIndex + 1}`} />
-      ))}
-
-      {Array.from({ length: LED_COUNT - 1 }, (_, ledIndex) => (
-        <trace
-          key={`data-${ledIndex + 1}`}
-          from={`.D${ledIndex + 1} > .DO`}
-          to={`.D${ledIndex + 2} > .DI`}
-        />
-      ))}
-
-      {Array.from({ length: LED_COUNT }, (_, ledIndex) => (
-        <trace
-          key={`v5-${ledIndex + 1}`}
-          from={`.D${ledIndex + 1} > .VDD`}
-          to="net.V5"
-        />
-      ))}
-      {Array.from({ length: LED_COUNT }, (_, ledIndex) => (
-        <trace
-          key={`gnd-${ledIndex + 1}`}
-          from={`.D${ledIndex + 1} > .GND`}
-          to="net.GND"
-        />
-      ))}
-
-      {Array.from({ length: ROWS }, (_, rowIndex) => (
-        <capacitor
-          key={`CROW${rowIndex + 1}`}
-          name={`CROW${rowIndex + 1}`}
-          capacitance="100nF"
-          connections={{
-            pin1: "net.V5",
-            pin2: "net.GND",
+        <chip
+          name="U1"
+          manufacturerPartNumber="Seeed Studio XIAO ESP32-C3"
+          pinLabels={{
+            pin1: "D0_GPIO2",
+            pin2: "D1_GPIO3",
+            pin3: "D2_GPIO4",
+            pin4: "D3_GPIO5",
+            pin5: "D4_GPIO6",
+            pin6: "D5_GPIO7",
+            pin7: "D6_GPIO21",
+            pin8: "D7_GPIO20",
+            pin9: "D8_GPIO8",
+            pin10: "D9_GPIO9",
+            pin11: "D10_GPIO10",
+            pin12: "3V3",
+            pin13: "GND",
+            pin14: "5V",
+          }}
+          pinAttributes={{
+            D4_GPIO6: { isGpio: true },
+            GND: { requiresGround: true },
+            "5V": { requiresPower: true, requiresVoltage: "5V" },
+            "3V3": { providesPower: true, providesVoltage: "3.3V" },
           }}
         />
-      ))}
-    </board>,
-  )
+        <resistor name="RDATA" resistance="330" />
+        <capacitor name="CBULK" capacitance="1000uF" polarized />
 
-  await circuit.renderUntilSettled()
+        <trace from=".U1 > .pin14" to="net.V5" />
+        <trace from=".U1 > .pin13" to="net.GND" />
+        <trace from=".U1 > .pin5" to=".RDATA > .pin1" />
+        <trace from=".RDATA > .pin2" to=".D1 > .DI" />
+        <trace from=".CBULK > .pos" to="net.V5" />
+        <trace from=".CBULK > .neg" to="net.GND" />
 
-  expect(circuit).toMatchSchematicSnapshot(import.meta.path)
-}, 30_000)
+        {Array.from({ length: LED_COUNT }, (_, ledIndex) => (
+          <WLED key={`D${ledIndex + 1}`} name={`D${ledIndex + 1}`} />
+        ))}
+
+        {Array.from({ length: LED_COUNT - 1 }, (_, ledIndex) => (
+          <trace
+            key={`data-${ledIndex + 1}`}
+            from={`.D${ledIndex + 1} > .DO`}
+            to={`.D${ledIndex + 2} > .DI`}
+          />
+        ))}
+
+        {Array.from({ length: LED_COUNT }, (_, ledIndex) => (
+          <trace
+            key={`v5-${ledIndex + 1}`}
+            from={`.D${ledIndex + 1} > .VDD`}
+            to="net.V5"
+          />
+        ))}
+        {Array.from({ length: LED_COUNT }, (_, ledIndex) => (
+          <trace
+            key={`gnd-${ledIndex + 1}`}
+            from={`.D${ledIndex + 1} > .GND`}
+            to="net.GND"
+          />
+        ))}
+
+        {Array.from({ length: ROWS }, (_, rowIndex) => (
+          <capacitor
+            key={`CROW${rowIndex + 1}`}
+            name={`CROW${rowIndex + 1}`}
+            capacitance="100nF"
+            connections={{
+              pin1: "net.V5",
+              pin2: "net.GND",
+            }}
+          />
+        ))}
+      </board>,
+    )
+
+    await circuit.renderUntilSettled()
+
+    expect(circuit).toMatchSchematicSnapshot(import.meta.path)
+  },
+  30_000,
+)

--- a/tests/repros/repro159-matchpack-led-matrix-iterations.test.tsx
+++ b/tests/repros/repro159-matchpack-led-matrix-iterations.test.tsx
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const ROWS = 12
+const COLS = 12
+const LED_COUNT = ROWS * COLS
+
+const WLED = ({ name }: { name: string }) => (
+  <chip
+    name={name}
+    manufacturerPartNumber="XL_5050RGBC_2812B_S"
+    pinLabels={{
+      pin1: ["VDD"],
+      pin2: ["DO"],
+      pin3: ["GND"],
+      pin4: ["DI"],
+    }}
+    pinAttributes={{
+      VDD: { requiresPower: true, requiresVoltage: "5V" },
+      DO: { isGpio: true },
+      GND: { requiresGround: true },
+      DI: { isGpio: true },
+    }}
+  />
+)
+
+test("repro159: matchpack lays out a 12x12 WLED matrix", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board routingDisabled>
+      <net name="V5" isPowerNet />
+      <net name="GND" isGroundNet />
+
+      <chip
+        name="U1"
+        manufacturerPartNumber="Seeed Studio XIAO ESP32-C3"
+        pinLabels={{
+          pin1: "D0_GPIO2",
+          pin2: "D1_GPIO3",
+          pin3: "D2_GPIO4",
+          pin4: "D3_GPIO5",
+          pin5: "D4_GPIO6",
+          pin6: "D5_GPIO7",
+          pin7: "D6_GPIO21",
+          pin8: "D7_GPIO20",
+          pin9: "D8_GPIO8",
+          pin10: "D9_GPIO9",
+          pin11: "D10_GPIO10",
+          pin12: "3V3",
+          pin13: "GND",
+          pin14: "5V",
+        }}
+        pinAttributes={{
+          D4_GPIO6: { isGpio: true },
+          GND: { requiresGround: true },
+          "5V": { requiresPower: true, requiresVoltage: "5V" },
+          "3V3": { providesPower: true, providesVoltage: "3.3V" },
+        }}
+      />
+      <resistor name="RDATA" resistance="330" />
+      <capacitor name="CBULK" capacitance="1000uF" polarized />
+
+      <trace from=".U1 > .pin14" to="net.V5" />
+      <trace from=".U1 > .pin13" to="net.GND" />
+      <trace from=".U1 > .pin5" to=".RDATA > .pin1" />
+      <trace from=".RDATA > .pin2" to=".D1 > .DI" />
+      <trace from=".CBULK > .pos" to="net.V5" />
+      <trace from=".CBULK > .neg" to="net.GND" />
+
+      {Array.from({ length: LED_COUNT }, (_, ledIndex) => (
+        <WLED key={`D${ledIndex + 1}`} name={`D${ledIndex + 1}`} />
+      ))}
+
+      {Array.from({ length: LED_COUNT - 1 }, (_, ledIndex) => (
+        <trace
+          key={`data-${ledIndex + 1}`}
+          from={`.D${ledIndex + 1} > .DO`}
+          to={`.D${ledIndex + 2} > .DI`}
+        />
+      ))}
+
+      {Array.from({ length: LED_COUNT }, (_, ledIndex) => (
+        <trace
+          key={`v5-${ledIndex + 1}`}
+          from={`.D${ledIndex + 1} > .VDD`}
+          to="net.V5"
+        />
+      ))}
+      {Array.from({ length: LED_COUNT }, (_, ledIndex) => (
+        <trace
+          key={`gnd-${ledIndex + 1}`}
+          from={`.D${ledIndex + 1} > .GND`}
+          to="net.GND"
+        />
+      ))}
+
+      {Array.from({ length: ROWS }, (_, rowIndex) => (
+        <capacitor
+          key={`CROW${rowIndex + 1}`}
+          name={`CROW${rowIndex + 1}`}
+          capacitance="100nF"
+          connections={{
+            pin1: "net.V5",
+            pin2: "net.GND",
+          }}
+        />
+      ))}
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit).toMatchSchematicSnapshot(import.meta.path)
+}, 30_000)


### PR DESCRIPTION
## What changed

Adds `repro159`, a reduced reproduction of a 12×12 WLED matrix circuit. It preserves the schematic topology from the reported circuit—144 four-pin WLED chips, a chained data path, shared 5 V and GND rails, a XIAO ESP32-C3, series resistor, bulk capacitor, and 12 row decoupling capacitors—while omitting PCB-only footprint and placement detail.

## Why

Rendering this circuit currently fails during initial schematic Matchpack layout:

```text
Matchpack layout solver failed: Partition 0 failed: PackSolver2 failed: PackSolver2 ran out of iterations
```

The repro uses Bun's `test.failing` so the known solver failure is exercised and documented without making CI red. Once the solver issue is fixed, the test should be changed back to a normal `test` and a schematic snapshot can be recorded.

## Impact

Provides a focused regression case for large, highly connected LED matrices without involving PCB routing or detailed imported footprint geometry.

## Validation

- `./node_modules/.bin/tsc --noEmit` — passes
- `bun test tests/repros/repro159-matchpack-led-matrix-iterations.test.tsx` — passes as an expected failure while reproducing the Matchpack iteration-exhaustion error in about 11 seconds
- `git diff --check` — passes