### PR TITLE
update copper-pour-solver to 0.0.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@tscircuit/checks": "0.0.146",
     "@tscircuit/circuit-json-util": "^0.0.101",
     "@tscircuit/common": "^0.0.20",
-    "@tscircuit/copper-pour-solver": "0.0.39",
+    "@tscircuit/copper-pour-solver": "0.0.41",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
     "@tscircuit/footprinter": "^0.0.387",
     "@tscircuit/image-utils": "^0.0.8",


### PR DESCRIPTION
## Summary

Updates `@tscircuit/copper-pour-solver` from `0.0.39` to `0.0.41` so `@tscircuit/core` uses the latest published solver release.

## Impact

Consumers of `@tscircuit/core` will receive the latest copper-pour solver behavior. No core API or implementation code changes are included.

## Validation

- `bunx tsc --noEmit`
- `bun run build`
- 21 copper-pour-focused tests across 13 test files