### PR TITLE
fix(SmtPad): emit solder paste for polygon pads

### DIFF
--- a/lib/components/primitive-components/SmtPad.ts
+++ b/lib/components/primitive-components/SmtPad.ts
@@ -15,6 +15,7 @@ import { PrimitiveComponent } from "../base-components/PrimitiveComponent"
 import type { Port } from "./Port"
 import { selectPortForPcbPrimitive } from "./Port/selectPortForPcbPrimitive"
 import { getAxisAlignedSizeFromRotatedRect } from "lib/utils/pcb/get-axis-aligned-size-from-rotated-rect"
+import { getRectsInsidePolygon } from "lib/utils/pcb/get-rects-inside-polygon"
 
 export class SmtPad extends PrimitiveComponent<typeof smtPadProps> {
   pcb_smtpad_id: string | null = null
@@ -294,6 +295,29 @@ export class SmtPad extends PrimitiveComponent<typeof smtPadProps> {
         subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
         pcb_group_id: this.getGroup()?.pcb_group_id ?? undefined,
       } as PcbSmtPadPolygon) as PcbSmtPadPolygon
+
+      if (shouldCreateSolderPaste) {
+        // The rects tile the pad, so they are emitted 1:1 - shrinking each rect
+        // would open gaps between them instead of insetting the aperture.
+        // 0.05mm floor: no stencil can release a smaller aperture, and float
+        // noise after a 90-degree rotation otherwise yields sliver rects.
+        for (const rect of getRectsInsidePolygon(transformedPoints, {
+          minRectDim: 0.05,
+        })) {
+          db.pcb_solder_paste.insert({
+            layer: pcb_smtpad.layer,
+            shape: "rect",
+            width: rect.width,
+            height: rect.height,
+            x: rect.x,
+            y: rect.y,
+            pcb_component_id: pcb_smtpad.pcb_component_id,
+            pcb_smtpad_id: pcb_smtpad.pcb_smtpad_id,
+            subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
+            pcb_group_id: this.getGroup()?.pcb_group_id ?? undefined,
+          } as PcbSmtPadRect)
+        }
+      }
     } else if (props.shape === "pill") {
       if (finalRotationDegrees !== 0) {
         pcb_smtpad = db.pcb_smtpad.insert({
@@ -477,18 +501,34 @@ export class SmtPad extends PrimitiveComponent<typeof smtPadProps> {
 
   _setPositionFromLayout(newCenter: { x: number; y: number }) {
     const { db } = this.root!
-    db.pcb_smtpad.update(this.pcb_smtpad_id!, {
-      x: newCenter.x,
-      y: newCenter.y,
-    })
+    const pad = db.pcb_smtpad.get(this.pcb_smtpad_id!)!
+    const { center } = this._getPcbCircuitJsonBounds()
+    const deltaX = newCenter.x - center.x
+    const deltaY = newCenter.y - center.y
 
-    const solderPaste = db.pcb_solder_paste
-      .list()
-      .find((elm) => elm.pcb_smtpad_id === this.pcb_smtpad_id)
-    if (solderPaste) {
-      db.pcb_solder_paste.update(solderPaste.pcb_solder_paste_id, {
+    if (pad.shape === "polygon") {
+      db.pcb_smtpad.update(this.pcb_smtpad_id!, {
+        points: pad.points.map((p) => ({
+          x: p.x + deltaX,
+          y: p.y + deltaY,
+        })),
+      })
+    } else {
+      db.pcb_smtpad.update(this.pcb_smtpad_id!, {
         x: newCenter.x,
         y: newCenter.y,
+      })
+    }
+
+    // A polygon pad is tiled by several paste rects that are not concentric
+    // with the pad, so every paste element is translated by the pad's delta
+    // rather than snapped to its new center.
+    for (const solderPaste of db.pcb_solder_paste
+      .list()
+      .filter((elm) => elm.pcb_smtpad_id === this.pcb_smtpad_id)) {
+      db.pcb_solder_paste.update(solderPaste.pcb_solder_paste_id, {
+        x: solderPaste.x + deltaX,
+        y: solderPaste.y + deltaY,
       })
     }
 
@@ -514,18 +554,11 @@ export class SmtPad extends PrimitiveComponent<typeof smtPadProps> {
     ) {
       this._setPositionFromLayout({ x: pad.x + deltaX, y: pad.y + deltaY })
     } else if (pad.shape === "polygon") {
-      db.pcb_smtpad.update(this.pcb_smtpad_id, {
-        points: pad.points.map((p) => ({
-          x: p.x + deltaX,
-          y: p.y + deltaY,
-        })),
+      const { center } = this._getPcbCircuitJsonBounds()
+      this._setPositionFromLayout({
+        x: center.x + deltaX,
+        y: center.y + deltaY,
       })
-
-      const newCenter = {
-        x: this._getPcbCircuitJsonBounds().center.x + deltaX / 2,
-        y: this._getPcbCircuitJsonBounds().center.y + deltaY / 2,
-      }
-      this.matchedPort?._setPositionFromLayout(newCenter)
     }
   }
 }

--- a/lib/utils/pcb/get-rects-inside-polygon.ts
+++ b/lib/utils/pcb/get-rects-inside-polygon.ts
@@ -1,0 +1,100 @@
+const EPSILON = 1e-9
+
+/**
+ * Decomposes a simple polygon into axis-aligned rects contained by it.
+ *
+ * The polygon is sliced into vertical slabs bounded by consecutive vertex x
+ * coordinates, so no vertex lies inside a slab and the inside spans are bounded
+ * by straight edges across it. Spans are sampled just inside each slab boundary
+ * and extrapolated back to the exact boundary (the bounding edges are linear
+ * across the slab), so every emitted rect is contained by the polygon up to
+ * float rounding. The decomposition is exact for rectilinear polygons (leadless
+ * pads with notched or stepped corners, at any 90°-family rotation); for other
+ * simple polygons it is a conservative partial cover.
+ *
+ * `minRectDim` drops rects with any dimension under the given size. Slabs
+ * bounded by two converging edges (the tip of a polygonised circle) or by
+ * float noise after a 90° rotation otherwise degenerate to slivers that are
+ * artifacts of the sweep rather than geometry.
+ */
+export function getRectsInsidePolygon(
+  points: { x: number; y: number }[],
+  opts: { minRectDim?: number } = {},
+): { x: number; y: number; width: number; height: number }[] {
+  if (points.length < 3) return []
+  const minRectDim = opts.minRectDim ?? 0
+
+  const xs = Array.from(new Set(points.map((p) => p.x))).sort((a, b) => a - b)
+  const rects: { x: number; y: number; width: number; height: number }[] = []
+
+  for (let i = 0; i < xs.length - 1; i++) {
+    const left = xs[i]!
+    const right = xs[i + 1]!
+    const width = right - left
+    if (width <= EPSILON || width < minRectDim) continue
+
+    const sampleInset = width * 1e-6
+    const xLeft = left + sampleInset
+    const xRight = right - sampleInset
+    if (!(xLeft > left && xRight < right && xLeft < xRight)) continue
+    const leftSpans = getInsideSpansAtX(points, xLeft)
+    const rightSpans = getInsideSpansAtX(points, xRight)
+    if (leftSpans.length !== rightSpans.length) continue
+
+    // Extrapolation factor from the sampled x back to the slab boundary.
+    const k = sampleInset / (xRight - xLeft)
+
+    for (let spanIndex = 0; spanIndex < leftSpans.length; spanIndex++) {
+      const bottomLeft = leftSpans[spanIndex]![0]
+      const bottomRight = rightSpans[spanIndex]![0]
+      const topLeft = leftSpans[spanIndex]![1]
+      const topRight = rightSpans[spanIndex]![1]
+
+      // Span bounds at exactly x=left and x=right; taking the tighter side
+      // keeps the rect inside both bounding edges across the whole slab.
+      const bottom = Math.max(
+        bottomLeft - (bottomRight - bottomLeft) * k,
+        bottomRight + (bottomRight - bottomLeft) * k,
+      )
+      const top = Math.min(
+        topLeft - (topRight - topLeft) * k,
+        topRight + (topRight - topLeft) * k,
+      )
+      const height = top - bottom
+      if (height <= EPSILON || height < minRectDim) continue
+
+      rects.push({
+        x: left + width / 2,
+        y: (bottom + top) / 2,
+        width,
+        height,
+      })
+    }
+  }
+
+  return rects
+}
+
+function getInsideSpansAtX(
+  points: { x: number; y: number }[],
+  x: number,
+): [number, number][] {
+  const crossings: number[] = []
+
+  for (let i = 0; i < points.length; i++) {
+    const start = points[i]!
+    const end = points[(i + 1) % points.length]!
+    if (x <= Math.min(start.x, end.x) || x >= Math.max(start.x, end.x)) continue
+    crossings.push(
+      start.y + ((x - start.x) / (end.x - start.x)) * (end.y - start.y),
+    )
+  }
+
+  crossings.sort((a, b) => a - b)
+
+  const spans: [number, number][] = []
+  for (let i = 0; i + 1 < crossings.length; i += 2) {
+    spans.push([crossings[i]!, crossings[i + 1]!])
+  }
+  return spans
+}

--- a/tests/components/primitive-components/create-solderpaste-from-polygon-smtpad.test.tsx
+++ b/tests/components/primitive-components/create-solderpaste-from-polygon-smtpad.test.tsx
@@ -1,0 +1,246 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("create solderpaste from L-shaped polygon smtpad", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="12mm" height="10mm">
+      <smtpad
+        shape="polygon"
+        points={[
+          { x: 0, y: 0 },
+          { x: 2, y: 0 },
+          { x: 2, y: 1 },
+          { x: 1, y: 1 },
+          { x: 1, y: 2 },
+          { x: 0, y: 2 },
+        ]}
+        layer={"top"}
+        portHints={[]}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const [smtpad] = circuit.db.pcb_smtpad.list()
+  const solderPastes = circuit.db.pcb_solder_paste.list()
+
+  expect(solderPastes.length).toBe(2)
+  expect(
+    solderPastes.every(
+      (sp) => sp.pcb_smtpad_id === smtpad.pcb_smtpad_id && sp.layer === "top",
+    ),
+  ).toBe(true)
+  expect(
+    solderPastes.map((sp) => ({
+      shape: sp.shape,
+      x: sp.x,
+      y: sp.y,
+      width: "width" in sp ? sp.width : undefined,
+      height: "height" in sp ? sp.height : undefined,
+    })),
+  ).toEqual([
+    { shape: "rect", x: 0.5, y: 1, width: 1, height: 2 },
+    { shape: "rect", x: 1.5, y: 0.5, width: 1, height: 1 },
+  ])
+})
+
+test("create solderpaste from polygon smtpad with a notched edge", async () => {
+  const { circuit } = getTestFixture()
+  // Land shape used by leadless packages such as TI's B0QFN: a rect with a
+  // notch cut out of the middle of its right edge.
+  circuit.add(
+    <board width="12mm" height="10mm">
+      <smtpad
+        shape="polygon"
+        points={[
+          { x: 0, y: 0 },
+          { x: 4, y: 0 },
+          { x: 4, y: 1 },
+          { x: 3, y: 1 },
+          { x: 3, y: 2 },
+          { x: 4, y: 2 },
+          { x: 4, y: 3 },
+          { x: 0, y: 3 },
+        ]}
+        layer={"top"}
+        portHints={[]}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const solderPastes = circuit.db.pcb_solder_paste.list()
+
+  // 3 x 3 slab left of the notch, plus the two 1 x 1 spans beside it
+  expect(
+    solderPastes.map((sp) => ({
+      x: sp.x,
+      y: sp.y,
+      width: "width" in sp ? sp.width : undefined,
+      height: "height" in sp ? sp.height : undefined,
+    })),
+  ).toEqual([
+    { x: 1.5, y: 1.5, width: 3, height: 3 },
+    { x: 3.5, y: 0.5, width: 1, height: 1 },
+    { x: 3.5, y: 2.5, width: 1, height: 1 },
+  ])
+
+  // the notch is not pasted
+  const pastedArea = solderPastes.reduce(
+    (area, sp) =>
+      area + ("width" in sp && "height" in sp ? sp.width * sp.height : 0),
+    0,
+  )
+  expect(pastedArea).toBe(11)
+})
+
+test("polygon smtpad solderpaste is not created when covered with solder mask", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="12mm" height="10mm">
+      <smtpad
+        shape="polygon"
+        points={[
+          { x: 0, y: 0 },
+          { x: 1, y: 0 },
+          { x: 1, y: 1 },
+          { x: 0, y: 1 },
+        ]}
+        layer={"top"}
+        coveredWithSolderMask
+        portHints={[]}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  expect(circuit.db.pcb_solder_paste.list().length).toBe(0)
+})
+
+test("polygon smtpad solderpaste follows the pad when layout moves it", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="12mm" height="10mm">
+      <chip
+        name="U1"
+        footprint={
+          <footprint>
+            <smtpad
+              shape="polygon"
+              points={[
+                { x: 0, y: 0 },
+                { x: 2, y: 0 },
+                { x: 2, y: 1 },
+                { x: 1, y: 1 },
+                { x: 1, y: 2 },
+                { x: 0, y: 2 },
+              ]}
+              portHints={["pin1"]}
+            />
+            <smtpad
+              shape="rect"
+              width="0.6mm"
+              height="0.6mm"
+              portHints={["pin2"]}
+            />
+            <constraint
+              pcb
+              centerToCenter
+              xDist="4mm"
+              left=".pin1"
+              right=".pin2"
+            />
+            <constraint sameY for={[".pin1", ".pin2"]} />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const pad = circuit.db.pcb_smtpad
+    .list()
+    .find((p) => p.shape === "polygon") as any
+  const solderPastes = circuit.db.pcb_solder_paste
+    .list()
+    .filter((sp) => sp.pcb_smtpad_id === pad.pcb_smtpad_id) as any[]
+
+  expect(solderPastes.length).toBe(2)
+
+  // the layout moved the pad, so the paste has to have moved with it
+  const xs = pad.points.map((p: any) => p.x)
+  const ys = pad.points.map((p: any) => p.y)
+  for (const sp of solderPastes) {
+    expect(sp.x - sp.width / 2).toBeGreaterThanOrEqual(Math.min(...xs) - 1e-9)
+    expect(sp.x + sp.width / 2).toBeLessThanOrEqual(Math.max(...xs) + 1e-9)
+    expect(sp.y - sp.height / 2).toBeGreaterThanOrEqual(Math.min(...ys) - 1e-9)
+    expect(sp.y + sp.height / 2).toBeLessThanOrEqual(Math.max(...ys) + 1e-9)
+  }
+})
+
+test("non-rectilinear polygon smtpad does not emit sliver apertures", async () => {
+  const { circuit } = getTestFixture()
+  // A polygonised round pad: the slabs at the left and right extremes are
+  // bounded by two converging edges and degenerate to slivers.
+  const points = Array.from({ length: 32 }, (_, i) => ({
+    x: 0.5 * Math.cos((i / 32) * 2 * Math.PI),
+    y: 0.5 * Math.sin((i / 32) * 2 * Math.PI),
+  }))
+  circuit.add(
+    <board width="12mm" height="10mm">
+      <smtpad shape="polygon" points={points} layer={"top"} portHints={[]} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const solderPastes = circuit.db.pcb_solder_paste.list() as any[]
+  expect(solderPastes.length).toBeGreaterThan(0)
+  for (const sp of solderPastes) {
+    expect(Math.min(sp.width, sp.height)).toBeGreaterThan(0.005)
+  }
+})
+
+test("paste rects never extend outside a non-rectilinear polygon pad", async () => {
+  const { circuit } = getTestFixture()
+  // House pentagon: slabs bounded above by the two slanted roof edges. The
+  // pre-extrapolation sweep emitted rect corners past a slanted bounding edge
+  // (paste off copper); the extrapolated sweep must keep every corner inside.
+  const points = [
+    { x: 0, y: 0 },
+    { x: 2, y: 0 },
+    { x: 2, y: 1 },
+    { x: 1, y: 2 },
+    { x: 0, y: 1 },
+  ]
+  circuit.add(
+    <board width="12mm" height="10mm">
+      <smtpad shape="polygon" points={points} layer={"top"} portHints={[]} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const solderPastes = circuit.db.pcb_solder_paste.list() as any[]
+  expect(solderPastes.length).toBeGreaterThan(0)
+  for (const sp of solderPastes) {
+    for (const [cx, cy] of [
+      [sp.x - sp.width / 2, sp.y - sp.height / 2],
+      [sp.x + sp.width / 2, sp.y - sp.height / 2],
+      [sp.x - sp.width / 2, sp.y + sp.height / 2],
+      [sp.x + sp.width / 2, sp.y + sp.height / 2],
+    ] as const) {
+      // inside the house: 0 <= x <= 2, y >= 0, x+y <= 3, y <= x+1
+      expect(cx).toBeGreaterThanOrEqual(-1e-9)
+      expect(cx).toBeLessThanOrEqual(2 + 1e-9)
+      expect(cy).toBeGreaterThanOrEqual(-1e-9)
+      expect(cx + cy).toBeLessThanOrEqual(3 + 1e-9)
+      expect(cy).toBeLessThanOrEqual(cx + 1 + 1e-9)
+    }
+  }
+})


### PR DESCRIPTION
## Bug

`<smtpad shape="polygon">` is the only pad shape that emits no `pcb_solder_paste` — the
polygon branch in `SmtPad.doInitialPcbPrimitiveRender()` inserts the pad and falls through.

Footprint imports produce polygon pads for leadless lands with notched or stepped corners
(TI's B0QFN packages are the common case). On a TPSM82913RDUR buck module, 8 of 28 lands are
polygons — including the only VIN land — and all 8 went to fabrication with zero stencil
aperture. A missing aperture violates no DFM rule, so it passed three JLCPCB DFM rounds
before an aperture census caught it. Reproduced on `main` with the real footprint: 20 paste
flashes for 28 pads; with this PR, all lands are covered.

## Fix

Decompose the pad polygon into axis-aligned rects (`lib/utils/pcb/get-rects-inside-polygon.ts`)
and emit one rect paste per rect:

- **Exact tiling for rectilinear lands** (the real-world case) at any 90°-family rotation.
- **Contained by construction otherwise**: spans are sampled just inside each slab boundary and
  extrapolated back to the exact boundary, so no rect extends outside the polygon (property-
  fuzzed over 19k random simple polygons; worst escape is float noise).
- **No sliver apertures**: rects under 0.05 mm are dropped — no stencil releases them, and
  float noise after a 90° rotation otherwise produces them.

Layout moves: `_setPositionFromLayout` previously wrote `x`/`y` (absent on polygon pads) and
snapped a single paste element to the pad center — wrong for off-center tiled rects. It now
translates the polygon points and every owned paste element by the layout delta, and
`_moveCircuitJsonElements` delegates to it.

**Why rect paste, not polygon paste:** `pcb_solder_paste`'s union has no polygon variant, and
`circuit-json-to-gerber` throws on unsupported shapes — polygon paste today would break Gerber
export. Happy to do the schema addition (mirroring how copper/mask already emit these pads as
regions) as a follow-up; this PR is the part that is correct and non-breaking on its own.

**Why 1:1, not ×0.7:** the rects tile the pad — shrinking each opens gaps between them rather
than insetting the aperture. Vendors' own stencil designs for leadless lands are 1:1 (e.g. TI's
B0QFN/VQFN/WSON stencil drawings). #2896 tracks making the paste ratio configurable.

## Tests

Six in `tests/components/primitive-components/create-solderpaste-from-polygon-smtpad.test.tsx`:
L-shape and notched-B0QFN tiling geometry (area = copper, notch unpasted), mask suppression,
layout-move tracking, sliver floor on a polygonised round pad, and containment on slanted
edges (house pentagon — every rect corner inside all five half-planes; a bare right triangle
correctly emits nothing rather than an escaping sliver).

Full suite green, `tsc --noEmit` clean, `biome format` clean.

## Related (not in this PR)

- The `pill` branch also emits no paste — same shape-switch fall-through, separate fix.
- Grid/array layout paths reposition pads without transforming paste of any shape (reproduced
  on `main` with rect pads — pre-existing; filed separately with the repro).
