### PR TITLE
refactor: extract local autorouter strategies

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -27,7 +27,7 @@ import type { GraphicsObject } from "graphics-debug"
 
 import type { PrimitiveComponent } from "lib/components/base-components/PrimitiveComponent"
 import { AutorouterError } from "lib/errors/AutorouterError"
-import { TscircuitAutorouter } from "lib/utils/autorouting/CapacityMeshAutorouter"
+import type { AutorouterOptions } from "lib/utils/autorouting/CapacityMeshAutorouter"
 import type { GenericLocalAutorouter } from "lib/utils/autorouting/GenericLocalAutorouter"
 import type { SimplifiedPcbTrace } from "lib/utils/autorouting/SimpleRouteJson"
 import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
@@ -36,6 +36,7 @@ import {
   type NormalizedAutorouterConfig,
   getPresetAutoroutingConfig,
 } from "lib/utils/autorouting/getPresetAutoroutingConfig"
+import { getLocalAutorouterStrategy } from "lib/utils/autorouting/localAutorouterStrategies"
 import { shouldSkipAutoroutingBecauseOfPlacementErrors } from "lib/utils/autorouting/should-skip-autorouting-because-of-placement-errors"
 import { getBoundsOfPcbComponents } from "lib/utils/get-bounds-of-pcb-components"
 import { getViaBoardLayers } from "lib/utils/getViaSpanLayers"
@@ -1088,9 +1089,13 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         simpleRouteJson,
       })
 
-      const cacheEngine = phaseAutorouterConfig.algorithmFn
-        ? undefined
-        : this.root?.platform?.localCacheEngine
+      const localAutorouterStrategy = getLocalAutorouterStrategy(
+        phaseAutorouterConfig.preset,
+      )
+      const cacheEngine =
+        phaseAutorouterConfig.algorithmFn || !localAutorouterStrategy.cacheable
+          ? undefined
+          : this.root?.platform?.localCacheEngine
       const cacheKey = cacheEngine
         ? getLocalAutoroutingCacheKey(simpleRouteJson)
         : undefined
@@ -1114,7 +1119,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             const effort = effortLevel
               ? Number.parseInt(effortLevel.replace("x", ""), 10)
               : undefined
-            autorouter = new TscircuitAutorouter(simpleRouteJson, {
+            const commonAutorouterOptions: AutorouterOptions = {
               capacityDepth: phaseAutorouterConfig.capacityDepth,
               targetMinCapacity: phaseAutorouterConfig.targetMinCapacity,
               useAssignableSolver:
@@ -1130,6 +1135,10 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
                   solverParams,
                   componentName: this.getString(),
                 }),
+            }
+            autorouter = localAutorouterStrategy.create({
+              simpleRouteJson,
+              commonAutorouterOptions,
             })
           }
 

--- a/lib/utils/autorouting/localAutorouterStrategies.ts
+++ b/lib/utils/autorouting/localAutorouterStrategies.ts
@@ -1,0 +1,30 @@
+import {
+  type AutorouterOptions,
+  TscircuitAutorouter,
+} from "./CapacityMeshAutorouter"
+import type { GenericLocalAutorouter } from "./GenericLocalAutorouter"
+import type { SimpleRouteJson } from "./SimpleRouteJson"
+import type { NormalizedAutorouterConfig } from "./getPresetAutoroutingConfig"
+
+export interface LocalAutorouterStrategyContext {
+  simpleRouteJson: SimpleRouteJson
+  commonAutorouterOptions: AutorouterOptions
+}
+
+export interface LocalAutorouterStrategy {
+  cacheable: boolean
+  create: (context: LocalAutorouterStrategyContext) => GenericLocalAutorouter
+}
+
+const defaultLocalAutorouterStrategy: LocalAutorouterStrategy = {
+  cacheable: true,
+  create: ({ simpleRouteJson, commonAutorouterOptions }) =>
+    new TscircuitAutorouter(simpleRouteJson, commonAutorouterOptions),
+}
+
+const localAutorouterStrategies = new Map<string, LocalAutorouterStrategy>()
+
+export const getLocalAutorouterStrategy = (
+  preset: NormalizedAutorouterConfig["preset"],
+): LocalAutorouterStrategy =>
+  localAutorouterStrategies.get(preset ?? "") ?? defaultLocalAutorouterStrategy

--- a/tests/utils/autorouting/localAutorouterStrategies.test.ts
+++ b/tests/utils/autorouting/localAutorouterStrategies.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { TscircuitAutorouter } from "lib/utils/autorouting/CapacityMeshAutorouter"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+import { getLocalAutorouterStrategy } from "lib/utils/autorouting/localAutorouterStrategies"
+
+test("the default local autorouter strategy preserves existing behavior", () => {
+  const simpleRouteJson: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.15,
+    obstacles: [],
+    connections: [],
+    bounds: { minX: -1, maxX: 1, minY: -1, maxY: 1 },
+  }
+  const strategy = getLocalAutorouterStrategy("default")
+  const autorouter = strategy.create({
+    simpleRouteJson,
+    commonAutorouterOptions: {},
+  })
+
+  expect(strategy.cacheable).toBe(true)
+  expect(autorouter).toBeInstanceOf(TscircuitAutorouter)
+  expect(autorouter.input).toBe(simpleRouteJson)
+})


### PR DESCRIPTION
## Summary

- move default local-autorouter construction out of `Group.ts`
- introduce a small strategy interface for router creation and cache policy
- keep the strategy registry empty so every current preset follows the unchanged default path
- add a focused regression proving the default strategy remains cacheable and constructs `TscircuitAutorouter` with the original SimpleRouteJson

This is deliberately behavior-neutral. It creates the extension point needed by specialized autorouters without including fanout presets, fanout dependencies, multi-stage routing, or breakout behavior.

## Validation

- `bunx tsc --noEmit`
- focused autorouter tests: 3 passing, 0 failing
- `git diff --check`
- all GitHub test, type-check, format, smoke-test, and Vercel checks passing
