### PR TITLE
Update copper-pour-solver to 0.0.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@tscircuit/checks": "0.0.146",
     "@tscircuit/circuit-json-util": "^0.0.101",
     "@tscircuit/common": "^0.0.20",
-    "@tscircuit/copper-pour-solver": "0.0.41",
+    "@tscircuit/copper-pour-solver": "0.0.42",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
     "@tscircuit/fanout-solver": "github:tscircuit/fanout-solver#34e4664",
     "@tscircuit/footprinter": "^0.0.387",


### PR DESCRIPTION
## Summary

- update `@tscircuit/copper-pour-solver` from `0.0.41` to `0.0.42`
- pick up plated pill-hole obstacle support from tscircuit/copper-pour-solver#69

## Validation

- `bun test tests/examples/example29-copper-pour.test.tsx tests/examples/example37-copper-pour-solver-emit.test.tsx tests/examples/example39-unbroken-copper-pour-escape-vias.test.tsx tests/components/primitive-components/copperpour-multiple-outlines.test.tsx tests/components/primitive-components/copperpour-with-via.test.tsx tests/components/primitive-components/copperpour-connectsto-net.test.tsx tests/repros/repro111-board-copperpour-and-rect-pad-plated-hole.test.tsx tests/repros/repro151-copperpour-split-into-multiple-records.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format`
