### PR TITLE
Fix fuse sch show ratings

### DIFF
--- a/lib/components/normal-components/Fuse.ts
+++ b/lib/components/normal-components/Fuse.ts
@@ -19,7 +19,7 @@ export class Fuse extends NormalComponent<typeof fuseProps, PassivePorts> {
   }
 
   _getSchematicSymbolDisplayValue(): string | undefined {
-    if (!this._parsedProps.schShowRatings) {
+    if (this._parsedProps.schShowRatings === false) {
       return undefined
     }
 
@@ -56,10 +56,10 @@ export class Fuse extends NormalComponent<typeof fuseProps, PassivePorts> {
       supplier_part_numbers: props.supplierPartNumbers,
       current_rating_amps: currentRating,
       voltage_rating_volts: voltageRating,
-      display_current_rating: props.schShowRatings
+      display_current_rating: props.schShowRatings !== false
         ? `${formatSiUnit(currentRating)}A`
         : undefined,
-      display_voltage_rating: props.schShowRatings
+      display_voltage_rating: props.schShowRatings !== false
         ? `${formatSiUnit(voltageRating)}V`
         : undefined,
       display_name: props.displayName,

--- a/lib/components/normal-components/Fuse.ts
+++ b/lib/components/normal-components/Fuse.ts
@@ -19,6 +19,10 @@ export class Fuse extends NormalComponent<typeof fuseProps, PassivePorts> {
   }
 
   _getSchematicSymbolDisplayValue(): string | undefined {
+    if (!this._parsedProps.schShowRatings) {
+      return undefined
+    }
+
     const rawCurrent = this._parsedProps.currentRating
     const rawVoltage = this._parsedProps.voltageRating
 

--- a/lib/components/normal-components/Fuse.ts
+++ b/lib/components/normal-components/Fuse.ts
@@ -49,6 +49,14 @@ export class Fuse extends NormalComponent<typeof fuseProps, PassivePorts> {
         ? parseFloat(props.voltageRating)
         : props.voltageRating
 
+    let display_current_rating: string | undefined
+    let display_voltage_rating: string | undefined
+
+    if (props.schShowRatings !== false) {
+      display_current_rating = `${formatSiUnit(currentRating)}A`
+      display_voltage_rating = `${formatSiUnit(voltageRating)}V`
+    }
+
     const source_component = db.source_component.insert({
       name: this.name,
       ftype: FTYPE.simple_fuse,
@@ -56,14 +64,8 @@ export class Fuse extends NormalComponent<typeof fuseProps, PassivePorts> {
       supplier_part_numbers: props.supplierPartNumbers,
       current_rating_amps: currentRating,
       voltage_rating_volts: voltageRating,
-      display_current_rating:
-        props.schShowRatings !== false
-          ? `${formatSiUnit(currentRating)}A`
-          : undefined,
-      display_voltage_rating:
-        props.schShowRatings !== false
-          ? `${formatSiUnit(voltageRating)}V`
-          : undefined,
+      display_current_rating,
+      display_voltage_rating,
       display_name: props.displayName,
     } as any)
 

--- a/lib/components/normal-components/Fuse.ts
+++ b/lib/components/normal-components/Fuse.ts
@@ -20,7 +20,7 @@ export class Fuse extends NormalComponent<typeof fuseProps, PassivePorts> {
 
   _getSchematicSymbolDisplayValue(): string | undefined {
     if (this._parsedProps.schShowRatings === false) {
-      return undefined
+      return ""
     }
 
     const rawCurrent = this._parsedProps.currentRating

--- a/lib/components/normal-components/Fuse.ts
+++ b/lib/components/normal-components/Fuse.ts
@@ -56,12 +56,14 @@ export class Fuse extends NormalComponent<typeof fuseProps, PassivePorts> {
       supplier_part_numbers: props.supplierPartNumbers,
       current_rating_amps: currentRating,
       voltage_rating_volts: voltageRating,
-      display_current_rating: props.schShowRatings !== false
-        ? `${formatSiUnit(currentRating)}A`
-        : undefined,
-      display_voltage_rating: props.schShowRatings !== false
-        ? `${formatSiUnit(voltageRating)}V`
-        : undefined,
+      display_current_rating:
+        props.schShowRatings !== false
+          ? `${formatSiUnit(currentRating)}A`
+          : undefined,
+      display_voltage_rating:
+        props.schShowRatings !== false
+          ? `${formatSiUnit(voltageRating)}V`
+          : undefined,
       display_name: props.displayName,
     } as any)
 

--- a/lib/components/normal-components/Fuse.ts
+++ b/lib/components/normal-components/Fuse.ts
@@ -56,8 +56,12 @@ export class Fuse extends NormalComponent<typeof fuseProps, PassivePorts> {
       supplier_part_numbers: props.supplierPartNumbers,
       current_rating_amps: currentRating,
       voltage_rating_volts: voltageRating,
-      display_current_rating: `${formatSiUnit(currentRating)}A`,
-      display_voltage_rating: `${formatSiUnit(voltageRating)}V`,
+      display_current_rating: props.schShowRatings
+        ? `${formatSiUnit(currentRating)}A`
+        : undefined,
+      display_voltage_rating: props.schShowRatings
+        ? `${formatSiUnit(voltageRating)}V`
+        : undefined,
       display_name: props.displayName,
     } as any)
 

--- a/tests/components/normal-components/fuse.test.tsx
+++ b/tests/components/normal-components/fuse.test.tsx
@@ -40,6 +40,8 @@ test("<fuse /> schShowRatings={false}", async () => {
   circuit.render()
 
   const circuitJson = circuit.getCircuitJson()
-  const schComponent = circuitJson.find((c: any) => c.type === "schematic_component") as any
+  const schComponent = circuitJson.find(
+    (c: any) => c.type === "schematic_component",
+  ) as any
   expect(schComponent.symbol_display_value).toBeUndefined()
 })

--- a/tests/components/normal-components/fuse.test.tsx
+++ b/tests/components/normal-components/fuse.test.tsx
@@ -20,3 +20,26 @@ test("<fuse /> component", async () => {
 
   expect(circuit).toMatchSchematicSnapshot(import.meta.path)
 })
+
+test("<fuse /> schShowRatings={false}", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="12mm" height="10mm">
+      <fuse
+        name="F1"
+        currentRating="1A"
+        voltageRating="24V"
+        schShowRatings={false}
+        pcbX={0}
+        pcbY={0}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const circuitJson = circuit.getCircuitJson()
+  const schComponent = circuitJson.find((c: any) => c.type === "schematic_component") as any
+  expect(schComponent.symbol_display_value).toBeUndefined()
+})

--- a/tests/components/normal-components/fuse.test.tsx
+++ b/tests/components/normal-components/fuse.test.tsx
@@ -43,5 +43,5 @@ test("<fuse /> schShowRatings={false}", async () => {
   const schComponent = circuitJson.find(
     (c: any) => c.type === "schematic_component",
   ) as any
-  expect(schComponent.symbol_display_value).toBeUndefined()
+  expect(schComponent.symbol_display_value).toBe("")
 })


### PR DESCRIPTION
Motivation: 


The <fuse /> component already accepted the schShowRatings prop, but setting it to false was broken and had no effect. The component would always render the 1A / 24V text regardless of what the user passed. This PR fixes the internal rendering logic so that schShowRatings={false} correctly hides the ratings on the schematic symbol as expected.

Before:
<img width="1440" height="900" alt="Screenshot 2026-07-29 at 9 53 57 PM" src="https://github.com/user-attachments/assets/48b53d90-6e4e-4583-aa7f-db4e9647c706" />

After:
<img width="1440" height="900" alt="Screenshot 2026-07-29 at 9 47 48 PM" src="https://github.com/user-attachments/assets/74b95d69-df5a-4a2b-a249-b3c40b178ded" />
