### PR TITLE
Use the npm-published fanout solver

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "0.0.42",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
-    "@tscircuit/fanout-solver": "github:tscircuit/fanout-solver#b19ca25ccb54edb3f9f8d7481c5239addcdba03e",
+    "@tscircuit/fanout-solver": "0.0.10",
     "@tscircuit/footprinter": "^0.0.387",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/infer-cable-insertion-point": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "0.0.42",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
-    "@tscircuit/fanout-solver": "0.0.11",
+    "@tscircuit/fanout-solver": "0.0.10",
     "@tscircuit/footprinter": "^0.0.387",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/infer-cable-insertion-point": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "0.0.42",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
-    "@tscircuit/fanout-solver": "0.0.10",
+    "@tscircuit/fanout-solver": "0.0.11",
     "@tscircuit/footprinter": "^0.0.387",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/infer-cable-insertion-point": "^0.0.2",


### PR DESCRIPTION
Replaces Core's GitHub-pinned @tscircuit/fanout-solver dependency with its public npm release, 0.0.10. This lets Core's release and downstream Eval update workflows resolve the package from npm rather than GitHub. Validated package.json syntax and git diff whitespace checks.