### PR TITLE
Add semantic port selectors to simple route points

### DIFF
--- a/lib/utils/autorouting/SimpleRouteJson.ts
+++ b/lib/utils/autorouting/SimpleRouteJson.ts
@@ -67,6 +67,21 @@ export type Obstacle = {
 /** A connection identifier in Simple Route JSON. */
 export type SrjConnectionName = string
 
+export type SimpleRoutePoint = {
+  x: number
+  y: number
+  layer: string
+  layers?: string[]
+  pointId?: string
+  pcb_port_id?: string
+  /** Stable semantic selector for the source port, e.g. `U1.USB_DM`. */
+  port_selector?: string
+  terminalVia?: {
+    toLayer: string
+    viaDiameter?: number
+  }
+}
+
 export type SimpleRouteConnection = {
   name: SrjConnectionName
   source_trace_id?: string
@@ -77,18 +92,7 @@ export type SimpleRouteConnection = {
   nominalTraceWidth?: number
   /** @deprecated Use `nominalTraceWidth` instead. */
   width?: number
-  pointsToConnect: Array<{
-    x: number
-    y: number
-    layer: string
-    layers?: string[]
-    pointId?: string
-    pcb_port_id?: string
-    terminalVia?: {
-      toLayer: string
-      viaDiameter?: number
-    }
-  }>
+  pointsToConnect: SimpleRoutePoint[]
   /** @deprecated DO NOT USE **/
   externallyConnectedPointIds?: string[][]
 }

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -1,6 +1,6 @@
 import type { CircuitJsonUtilObjects } from "@tscircuit/circuit-json-util"
 import { su } from "@tscircuit/circuit-json-util"
-import type { AnyCircuitElement, PcbBoard } from "circuit-json"
+import type { AnyCircuitElement, PcbBoard, SourcePort } from "circuit-json"
 import {
   ConnectivityMap,
   getFullConnectivityMapFromCircuitJson,
@@ -107,6 +107,14 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   }
 
   db = su(subcircuitElements)
+  const getPortSelector = (sourcePort: SourcePort | null | undefined) => {
+    if (!sourcePort?.source_component_id) return undefined
+    const sourceComponent = db.source_component.get(
+      sourcePort.source_component_id,
+    )
+    if (!sourceComponent?.name) return undefined
+    return `${sourceComponent.name}.${sourcePort.name}`
+  }
   const pcbGroup = subcircuit_id
     ? db.pcb_group.getWhere({ subcircuit_id })
     : undefined
@@ -404,8 +412,14 @@ export const getSimpleRouteJsonFromCircuitJson = ({
         sourcePortId: string,
       ) => {
         const bp = sourcePortIdToBreakoutPoint.get(sourcePortId)
+        const portSelector = getPortSelector(db.source_port.get(sourcePortId))
         if (bp && bp.subcircuit_id !== subcircuit_id) {
-          return { x: bp.x, y: bp.y, layer }
+          return {
+            x: bp.x,
+            y: bp.y,
+            layer,
+            port_selector: portSelector,
+          }
         }
         return {
           x: port.x!,
@@ -413,6 +427,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
           layer,
           pointId: port.pcb_port_id,
           pcb_port_id: port.pcb_port_id,
+          port_selector: portSelector,
         }
       }
       return {
@@ -569,6 +584,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
           layer: (p.layers?.[0] as any) ?? "top",
           pointId: p.pcb_port_id,
           pcb_port_id: p.pcb_port_id,
+          port_selector: getPortSelector(db.source_port.get(p.source_port_id)),
         })
       }
     }
@@ -605,6 +621,9 @@ export const getSimpleRouteJsonFromCircuitJson = ({
         layer: (pcb_port.layers?.[0] as any) ?? "top",
         pointId: pcb_port.pcb_port_id,
         pcb_port_id: pcb_port.pcb_port_id,
+        port_selector: getPortSelector(
+          db.source_port.get(pcb_port.source_port_id),
+        ),
       }
 
       // Inner routing (same subcircuit): create [port → bp] so the

--- a/tests/utils/autorouting/simple-route-json-port-selectors.test.tsx
+++ b/tests/utils/autorouting/simple-route-json-port-selectors.test.tsx
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { RootCircuit } from "lib/RootCircuit"
+import "lib/register-catalogue"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+import type { SimpleRoutePoint } from "lib/utils/autorouting/SimpleRouteJson"
+
+test("simple route json points include semantic port selectors", async () => {
+  const circuit = new RootCircuit()
+
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "USB_DM", pin8: "GND" }}
+        pcbX={-2}
+      />
+      <resistor name="R1" resistance="22" footprint="0402" pcbX={2} />
+      <net name="USB_DN" />
+      <trace from="U1.USB_DM" to="net.USB_DN" />
+      <trace from="R1.pin1" to="net.USB_DN" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
+    circuitJson: circuit.getCircuitJson(),
+  })
+
+  const points = simpleRouteJson.connections.flatMap(
+    (connection) => connection.pointsToConnect,
+  )
+
+  expect(points.map((point) => point.port_selector)).toContain("U1.USB_DM")
+  expect(points.map((point) => point.port_selector)).toContain("R1.pin1")
+
+  const typedPoint: SimpleRoutePoint = points[0]!
+  expect(typedPoint.port_selector).toBeDefined()
+})


### PR DESCRIPTION
## What changed

- exports a named `SimpleRoutePoint` type
- adds optional `port_selector` metadata such as `U1.USB_DM`
- populates selectors while converting Circuit JSON into Simple Route JSON, including named-net and breakout routing points
- adds coverage for semantic selectors on a named-net connection

## Why

Routing configuration should be able to identify endpoints with stable semantic selectors instead of generated Circuit JSON IDs such as `pcb_port_12`.

## Validation

- `bun test --config=/dev/null tests/utils/autorouting/simple-route-json-port-selectors.test.tsx`
- `bunx tsc --noEmit`
- `git diff --check`

The repository-wide test preload currently requires a working native `sharp` postinstall in the local environment, so the focused test was run without the global visual-snapshot preload; the test itself does not use snapshot matchers.
