### PR TITLE
update fanout solver to 0.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "0.0.42",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
-    "@tscircuit/fanout-solver": "0.0.10",
+    "@tscircuit/fanout-solver": "0.0.11",
     "@tscircuit/footprinter": "^0.0.387",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/infer-cable-insertion-point": "^0.0.2",


### PR DESCRIPTION
## Summary

- update `@tscircuit/fanout-solver` from `0.0.10` to `0.0.11`
- pick up adaptive single-layer fanout support when only selected boundary corners or sides are available

## Impact

Core's `fanout` and `single_layer_fanout` integrations can use the solver's latest constrained-boundary exit behavior without changing existing props or defaults.

## Validation

- `bunx tsc --noEmit`
- `bun run build`
- focused fanout, single-layer fanout, BGA breakout, shared-boundary, preset, and strategy tests — 8 passed, 0 failed
- `git diff --check`