### PR TITLE
Route buses in explicit autorouting phases

### DIFF
--- a/lib/components/primitive-components/Group/Group_getRoutingPhasePlans.ts
+++ b/lib/components/primitive-components/Group/Group_getRoutingPhasePlans.ts
@@ -1,5 +1,6 @@
 import type { AutorouterProp, AutoroutingPhaseProps } from "@tscircuit/props"
 import type { z } from "zod"
+import type { Bus } from "../Bus"
 import type { Net } from "../Net"
 import type { Trace } from "../Trace/Trace"
 import type { AutoroutingPhase } from "../AutoroutingPhase"
@@ -41,7 +42,35 @@ function getNetRoutingPhaseIndex(net: Net): number | null {
   return net.props.routingPhaseIndex ?? null
 }
 
-function getTraceRoutingPhaseIndex(trace: Trace): number | null {
+function getTraceRoutingPhaseIndex(
+  trace: Trace,
+  buses: Bus[] = [],
+): number | null {
+  const busRoutingPhaseIndexes = new Set<number | null>()
+  for (const bus of buses) {
+    if (bus._parsedProps.routingPhaseIndex === undefined) continue
+    const traceIsInBus = bus._parsedProps.connections.some(
+      (connection) =>
+        connection === trace.name ||
+        traceHasEndpointMatchingConnectionSelector(
+          trace,
+          convertPortSelectorToEndpointKey(connection),
+        ),
+    )
+    if (traceIsInBus) {
+      busRoutingPhaseIndexes.add(bus._parsedProps.routingPhaseIndex)
+    }
+  }
+  if (busRoutingPhaseIndexes.size > 1) {
+    throw new Error(
+      `Trace "${trace.name}" belongs to buses with different routing phases`,
+    )
+  }
+  const busRoutingPhaseIndex = busRoutingPhaseIndexes.values().next().value
+  if (busRoutingPhaseIndex !== undefined) {
+    return busRoutingPhaseIndex
+  }
+
   const traceRoutingPhaseIndex = trace.props.routingPhaseIndex
   if (traceRoutingPhaseIndex !== undefined) return traceRoutingPhaseIndex
 
@@ -186,6 +215,7 @@ export function Group_getRoutingPhasePlans(
 ): RoutingPhasePlan[] {
   const traces = group.selectAll("trace") as Trace[]
   const nets = group.selectAll("net") as Net[]
+  const buses = group.selectAll("bus") as Bus[]
 
   const plansByPhaseIndex = new Map<number | null, RoutingPhasePlan>()
   const autoroutersByPhaseIndex = getAutoroutersByPhaseIndex(group)
@@ -221,7 +251,7 @@ export function Group_getRoutingPhasePlans(
   }
 
   for (const trace of traces) {
-    const routingPhaseIndex = getTraceRoutingPhaseIndex(trace)
+    const routingPhaseIndex = getTraceRoutingPhaseIndex(trace, buses)
     getOrCreateRoutingPhasePlan(
       plansByPhaseIndex,
       routingPhaseIndex,

--- a/lib/components/primitive-components/Group/Group_phasedAutoroutingUtils.ts
+++ b/lib/components/primitive-components/Group/Group_phasedAutoroutingUtils.ts
@@ -231,11 +231,21 @@ export function Group_filterSimpleRouteJsonForPhase(
     if (positiveConnectionIncluded) differentialPairs.push(differentialPair)
   }
 
+  const buses = (simpleRouteJson.buses ?? [])
+    .map((bus) => ({
+      ...bus,
+      connectionNames: bus.connectionNames.filter((connectionName) =>
+        includedConnectionNames.has(connectionName),
+      ),
+    }))
+    .filter((bus) => bus.connectionNames.length > 0)
+
   return {
     ...simpleRouteJson,
     connections,
     differentialPairs:
       differentialPairs.length > 0 ? differentialPairs : undefined,
+    buses: buses.length > 0 ? buses : undefined,
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
-    "@tscircuit/props": "^0.0.599",
+    "@tscircuit/props": "^0.0.602",
     "@tscircuit/schematic-match-adapt": "^0.0.18",
     "@tscircuit/schematic-trace-solver": "^0.0.116",
     "@tscircuit/solver-utils": "^0.0.16",

--- a/tests/features/autoroutingphase-bus-routing-phase.test.tsx
+++ b/tests/features/autoroutingphase-bus-routing-phase.test.tsx
@@ -1,0 +1,157 @@
+import { expect, test } from "bun:test"
+import type {
+  SimpleRouteJson,
+  SimplifiedPcbTrace,
+} from "lib/utils/autorouting/SimpleRouteJson"
+import { createBasicAutorouter } from "tests/fixtures/createBasicAutorouter"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const routeConnectionsDirectly = (
+  simpleRouteJson: SimpleRouteJson,
+): SimplifiedPcbTrace[] =>
+  simpleRouteJson.connections.map(
+    (connection): SimplifiedPcbTrace => ({
+      type: "pcb_trace",
+      pcb_trace_id: `${connection.name}_routed`,
+      connection_name: connection.source_trace_id ?? connection.name,
+      route: connection.pointsToConnect.map((point) => ({
+        route_type: "wire",
+        x: point.x,
+        y: point.y,
+        width: connection.nominalTraceWidth ?? 0.15,
+        layer: point.layer,
+      })),
+    }),
+  )
+
+test("a bus routing phase assigns its traces to that phase", async () => {
+  const { circuit } = getTestFixture()
+  const routedBusIdsByPhase: string[][] = []
+  const routedConnectionCountsByPhase: number[] = []
+
+  const createPhaseAutorouter = () =>
+    createBasicAutorouter(async (simpleRouteJson: SimpleRouteJson) => {
+      for (const bus of simpleRouteJson.buses ?? []) {
+        expect(bus).not.toHaveProperty("routingPhaseIndex")
+      }
+      routedBusIdsByPhase.push(
+        simpleRouteJson.buses?.map((bus) => bus.busId) ?? [],
+      )
+      routedConnectionCountsByPhase.push(simpleRouteJson.connections.length)
+
+      return routeConnectionsDirectly(simpleRouteJson)
+    })
+
+  circuit.add(
+    <board width="30mm" height="12mm">
+      <autoroutingphase
+        phaseIndex={0}
+        autorouter={{
+          local: true,
+          groupMode: "subcircuit",
+          algorithmFn: createPhaseAutorouter(),
+        }}
+      />
+      <autoroutingphase
+        phaseIndex={1}
+        autorouter={{
+          local: true,
+          groupMode: "subcircuit",
+          algorithmFn: createPhaseAutorouter(),
+        }}
+      />
+
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-9} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={-6} />
+      <resistor name="R3" resistance="1k" footprint="0402" pcbX={-3} />
+      <resistor name="R4" resistance="1k" footprint="0402" pcbX={0} />
+      <resistor name="R5" resistance="1k" footprint="0402" pcbX={3} />
+      <resistor name="R6" resistance="1k" footprint="0402" pcbX={6} />
+      <resistor name="R7" resistance="1k" footprint="0402" pcbX={9} />
+      <resistor name="R8" resistance="1k" footprint="0402" pcbX={12} />
+
+      <trace name="CONTROL0" from=".R1 > .pin1" to=".R2 > .pin1" />
+      <trace name="CONTROL1" from=".R3 > .pin1" to=".R4 > .pin1" />
+      <trace name="DATA0" from=".R5 > .pin1" to=".R6 > .pin1" />
+      <trace name="DATA1" from=".R7 > .pin1" to=".R8 > .pin1" />
+
+      <bus
+        name="CONTROL"
+        connections={["CONTROL0", "CONTROL1"]}
+        routingPhaseIndex={0}
+      />
+      <bus name="DATA" connections={["DATA0", "DATA1"]} routingPhaseIndex={1} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(routedBusIdsByPhase).toEqual([["CONTROL"], ["DATA"]])
+  expect(routedConnectionCountsByPhase).toEqual([2, 2])
+})
+
+test("a bus without a phase does not change its trace phases", async () => {
+  const { circuit } = getTestFixture()
+  const routedBusIdsByPhase: string[][] = []
+  const routedConnectionCountsByPhase: number[] = []
+  const routedBusConnectionCountsByPhase: number[] = []
+
+  const createPhaseAutorouter = () =>
+    createBasicAutorouter(async (simpleRouteJson: SimpleRouteJson) => {
+      routedBusIdsByPhase.push(
+        simpleRouteJson.buses?.map((bus) => bus.busId) ?? [],
+      )
+      routedConnectionCountsByPhase.push(simpleRouteJson.connections.length)
+      routedBusConnectionCountsByPhase.push(
+        simpleRouteJson.buses?.[0]?.connectionNames.length ?? 0,
+      )
+      return routeConnectionsDirectly(simpleRouteJson)
+    })
+
+  circuit.add(
+    <board width="14mm" height="8mm">
+      <autoroutingphase
+        phaseIndex={0}
+        autorouter={{
+          local: true,
+          groupMode: "subcircuit",
+          algorithmFn: createPhaseAutorouter(),
+        }}
+      />
+      <autoroutingphase
+        phaseIndex={1}
+        autorouter={{
+          local: true,
+          groupMode: "subcircuit",
+          algorithmFn: createPhaseAutorouter(),
+        }}
+      />
+
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={-2} />
+      <resistor name="R3" resistance="1k" footprint="0402" pcbX={2} />
+      <resistor name="R4" resistance="1k" footprint="0402" pcbX={5} />
+
+      <trace
+        name="DATA0"
+        from=".R1 > .pin1"
+        to=".R2 > .pin1"
+        routingPhaseIndex={0}
+      />
+      <trace
+        name="DATA1"
+        from=".R3 > .pin1"
+        to=".R4 > .pin1"
+        routingPhaseIndex={1}
+      />
+
+      <bus name="DATA" connections={["DATA0", "DATA1"]} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(routedBusIdsByPhase).toEqual([["DATA"], ["DATA"]])
+  expect(routedConnectionCountsByPhase).toEqual([1, 1])
+  expect(routedBusConnectionCountsByPhase).toEqual([1, 1])
+})


### PR DESCRIPTION
## Behavior

Declaring a bus does not select or change a routing phase:

```tsx
<trace
  name="DAT0"
  from=".U1 > .DAT0"
  to=".U2 > .DAT0"
  routingPhaseIndex={0}
/>
<trace
  name="DAT1"
  from=".U1 > .DAT1"
  to=".U2 > .DAT1"
  routingPhaseIndex={1}
/>

<bus name="EMMC_DATA" connections={["DAT0", "DAT1"]} />
```

`DAT0` remains in phase 0 and `DAT1` remains in phase 1. The bus only records their grouping; each phase's autorouter receives the members routed in that phase.

An explicit bus phase assigns every member trace to that phase:

```tsx
<trace name="DAT0" from=".U1 > .DAT0" to=".U2 > .DAT0" />
<trace name="DAT1" from=".U1 > .DAT1" to=".U2 > .DAT1" />

<bus
  name="EMMC_DATA"
  connections={["DAT0", "DAT1"]}
  routingPhaseIndex={1}
/>
```

Both traces are routed with everything else in phase 1.

## Changes

- resolve an explicitly phased bus while core builds its routing-phase plans
- preserve unphased bus membership without changing independently selected trace/net phases
- filter each phase's bus membership to the connections present in that phase
- update to the released `@tscircuit/props@0.0.602` schema from tscircuit/props#769
- add TSX integration coverage for both behaviors

`SimpleRouteJson` is unchanged. Bus objects sent to autorouters still contain only the existing autorouter-facing fields (`busId`, `name`, `connectionNames`, and optional `termination`); they do not contain `routingPhaseIndex`.

## Validation

- `bun test tests/features/autoroutingphase-bus-routing-phase.test.tsx tests/features/autorouter-fanout-plane-termination.test.tsx tests/utils/autorouting/differential-pair-phase-filter.test.ts`
- `bunx tsc --noEmit`
- `bun run smoke-test:dist`
- downstream RK3326 board: 282 PCB traces, 297 vias, zero circuit errors