### PR TITLE
Read fanout controls from breakout groups

### DIFF
--- a/lib/components/primitive-components/Group/Group_getRoutingPhasePlans.ts
+++ b/lib/components/primitive-components/Group/Group_getRoutingPhasePlans.ts
@@ -10,6 +10,14 @@ import type {
   RoutingPhasePlan,
 } from "./GroupRoutingPhasePlan"
 
+type GroupFanoutProps = Pick<
+  AutoroutingPhaseProps,
+  | "busFanoutDirections"
+  | "fanoutBoundaryPadding"
+  | "fanoutRoutingLayers"
+  | "fanoutPourNetMap"
+>
+
 function getPhaseSortValue(routingPhaseIndex: number | null): number {
   return routingPhaseIndex === null
     ? Number.POSITIVE_INFINITY
@@ -220,11 +228,7 @@ export function Group_getRoutingPhasePlans(
   const plansByPhaseIndex = new Map<number | null, RoutingPhasePlan>()
   const autoroutersByPhaseIndex = getAutoroutersByPhaseIndex(group)
   const phasePropsByPhaseIndex = getAutoroutingPhasePropsByPhaseIndex(group)
-  const groupFanoutBoundaryPadding = (
-    group._parsedProps as {
-      fanoutBoundaryPadding?: AutoroutingPhaseProps["fanoutBoundaryPadding"]
-    }
-  ).fanoutBoundaryPadding
+  const groupFanoutProps = group._parsedProps as GroupFanoutProps
   const hasDirectRoutingTargets = traces.length > 0 || nets.length > 0
   const hasReroutePhase = Array.from(phasePropsByPhaseIndex.values()).some(
     (phaseProps) => phaseProps.reroute,
@@ -304,13 +308,18 @@ export function Group_getRoutingPhasePlans(
     plan.connectionSelectors = phaseProps
       ? getConnectionSelectorsFromAutoroutingPhaseProps(phaseProps)
       : undefined
-    plan.busFanoutDirections = phaseProps?.busFanoutDirections
+    plan.busFanoutDirections =
+      phaseProps?.busFanoutDirections ?? groupFanoutProps.busFanoutDirections
     plan.fanoutBoundaryPadding =
-      phaseProps?.fanoutBoundaryPadding ?? groupFanoutBoundaryPadding
-    plan.fanoutRoutingLayers = phaseProps?.fanoutRoutingLayers?.map((layer) =>
+      phaseProps?.fanoutBoundaryPadding ??
+      groupFanoutProps.fanoutBoundaryPadding
+    const fanoutRoutingLayers =
+      phaseProps?.fanoutRoutingLayers ?? groupFanoutProps.fanoutRoutingLayers
+    plan.fanoutRoutingLayers = fanoutRoutingLayers?.map((layer) =>
       typeof layer === "string" ? layer : layer.name,
     )
-    plan.fanoutPourNetMap = phaseProps?.fanoutPourNetMap
+    plan.fanoutPourNetMap =
+      phaseProps?.fanoutPourNetMap ?? groupFanoutProps.fanoutPourNetMap
     plan.drcTolerances = phaseProps
       ? getDrcTolerancesFromAutoroutingPhaseProps(phaseProps)
       : undefined

--- a/lib/components/primitive-components/Group/Group_getRoutingPhasePlans.ts
+++ b/lib/components/primitive-components/Group/Group_getRoutingPhasePlans.ts
@@ -1,4 +1,8 @@
-import type { AutorouterProp, AutoroutingPhaseProps } from "@tscircuit/props"
+import type {
+  AutorouterProp,
+  AutoroutingPhaseProps,
+  BreakoutProps,
+} from "@tscircuit/props"
 import type { z } from "zod"
 import type { Bus } from "../Bus"
 import type { Net } from "../Net"
@@ -11,7 +15,7 @@ import type {
 } from "./GroupRoutingPhasePlan"
 
 type GroupFanoutProps = Pick<
-  AutoroutingPhaseProps,
+  BreakoutProps,
   | "busFanoutDirections"
   | "fanoutBoundaryPadding"
   | "fanoutRoutingLayers"

--- a/lib/utils/autorouting/FanoutAutorouter.ts
+++ b/lib/utils/autorouting/FanoutAutorouter.ts
@@ -17,7 +17,12 @@ import type {
   AutorouterProgressEvent,
   GenericLocalAutorouter,
 } from "./GenericLocalAutorouter"
-import type { SimpleRouteJson, SimplifiedPcbTrace } from "./SimpleRouteJson"
+import type {
+  SimpleRouteBus,
+  SimpleRouteJson,
+  SimpleRoutePoint,
+  SimplifiedPcbTrace,
+} from "./SimpleRouteJson"
 import { getFanoutSharedBoundary } from "./get-fanout-shared-boundary"
 
 export type FanoutAutorouterMode = "single_layer_fanout" | "fanout"
@@ -80,6 +85,97 @@ const getPlaneFanoutDirection = (
     case "bottom_right":
       return "down"
   }
+}
+
+const getSourceComponentIdForPoint = (
+  input: SimpleRouteJson,
+  point: SimpleRoutePoint,
+): string | undefined => {
+  const matchingObstacle = input.obstacles.find(
+    (obstacle) =>
+      obstacle.componentId &&
+      obstacle.layers.includes(point.layer) &&
+      ((point.pointId && obstacle.connectedTo.includes(point.pointId)) ||
+        (point.x >= obstacle.center.x - obstacle.width / 2 &&
+          point.x <= obstacle.center.x + obstacle.width / 2 &&
+          point.y >= obstacle.center.y - obstacle.height / 2 &&
+          point.y <= obstacle.center.y + obstacle.height / 2)),
+  )
+  return matchingObstacle?.componentId
+}
+
+/**
+ * Plane drops do not have a board-level target from which to infer a direction.
+ * Choose an internal via escape orientation from each source pad's position
+ * within its component instead of requiring a user-facing bus direction.
+ */
+const inferPlaneBusDirection = (
+  input: SimpleRouteJson,
+  bus: SimpleRouteBus,
+): FanoutDirection | undefined => {
+  const connectionNames = new Set(bus.connectionNames)
+  const sourcePointsByComponentId = new Map<string, SimpleRoutePoint[]>()
+  for (const connection of input.connections) {
+    if (!connectionNames.has(connection.name)) continue
+    for (const point of connection.pointsToConnect) {
+      const componentId = getSourceComponentIdForPoint(input, point)
+      if (!componentId) continue
+      const sourcePoints = sourcePointsByComponentId.get(componentId) ?? []
+      sourcePoints.push(point)
+      sourcePointsByComponentId.set(componentId, sourcePoints)
+    }
+  }
+  const sourceComponent = [...sourcePointsByComponentId.entries()].sort(
+    ([firstComponentId, firstPoints], [secondComponentId, secondPoints]) =>
+      secondPoints.length - firstPoints.length ||
+      firstComponentId.localeCompare(secondComponentId),
+  )[0]
+  if (!sourceComponent) return undefined
+
+  const [sourceComponentId, sourcePoints] = sourceComponent
+  const componentObstacles = input.obstacles.filter(
+    (obstacle) => obstacle.componentId === sourceComponentId,
+  )
+  if (componentObstacles.length === 0) return undefined
+
+  const componentXCoordinates = componentObstacles.map(
+    (obstacle) => obstacle.center.x,
+  )
+  const componentYCoordinates = componentObstacles.map(
+    (obstacle) => obstacle.center.y,
+  )
+  const minComponentX = Math.min(...componentXCoordinates)
+  const maxComponentX = Math.max(...componentXCoordinates)
+  const minComponentY = Math.min(...componentYCoordinates)
+  const maxComponentY = Math.max(...componentYCoordinates)
+  const componentCenter = {
+    x: (minComponentX + maxComponentX) / 2,
+    y: (minComponentY + maxComponentY) / 2,
+  }
+  const componentHalfSpan = {
+    x: Math.max((maxComponentX - minComponentX) / 2, 1e-6),
+    y: Math.max((maxComponentY - minComponentY) / 2, 1e-6),
+  }
+  const averageSourcePoint = {
+    x:
+      sourcePoints.reduce((sum, point) => sum + point.x, 0) /
+      sourcePoints.length,
+    y:
+      sourcePoints.reduce((sum, point) => sum + point.y, 0) /
+      sourcePoints.length,
+  }
+  const normalizedOffset = {
+    x: (averageSourcePoint.x - componentCenter.x) / componentHalfSpan.x,
+    y: (averageSourcePoint.y - componentCenter.y) / componentHalfSpan.y,
+  }
+
+  if (Math.abs(normalizedOffset.x) > Math.abs(normalizedOffset.y)) {
+    return normalizedOffset.x >= 0 ? "right" : "left"
+  }
+  if (Math.abs(normalizedOffset.y) > 1e-9) {
+    return normalizedOffset.y >= 0 ? "up" : "down"
+  }
+  return "right"
 }
 
 const createDownstreamSimpleRouteJson = ({
@@ -198,21 +294,23 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
   private getPlaneBusDirections():
     | Readonly<Record<string, FanoutDirection>>
     | undefined {
-    if (!this.options.busFanoutDirections) return undefined
-    const planeBusIds = new Set(
-      this.input.buses
-        ?.filter((bus) => bus.termination?.type === "plane")
-        .map((bus) => bus.busId) ?? [],
-    )
+    const planeBuses =
+      this.input.buses?.filter((bus) => bus.termination?.type === "plane") ?? []
+    const planeBusIds = new Set(planeBuses.map((bus) => bus.busId))
     const directions: Record<string, FanoutDirection> = {}
     for (const [busId, fanoutDirection] of Object.entries(
-      this.options.busFanoutDirections,
+      this.options.busFanoutDirections ?? {},
     )) {
       if (!planeBusIds.has(busId)) continue
       const direction = getPlaneFanoutDirection(
         getNinePointAnchor(fanoutDirection),
       )
       if (direction) directions[busId] = direction
+    }
+    for (const planeBus of planeBuses) {
+      if (directions[planeBus.busId]) continue
+      const direction = inferPlaneBusDirection(this.input, planeBus)
+      if (direction) directions[planeBus.busId] = direction
     }
     return Object.keys(directions).length > 0 ? directions : undefined
   }

--- a/tests/components/primitive-components/group-fanout-props-routing-plan.test.ts
+++ b/tests/components/primitive-components/group-fanout-props-routing-plan.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import type { z } from "zod"
+import type { Group } from "lib/components/primitive-components/Group/Group"
+import { Group_getRoutingPhasePlans } from "lib/components/primitive-components/Group/Group_getRoutingPhasePlans"
+import type { Trace } from "lib/components/primitive-components/Trace/Trace"
+
+test("group fanout props configure its default routing plan", () => {
+  const trace = {
+    props: {},
+    _findConnectedNets: () => ({ nets: [] }),
+  } as unknown as Trace
+  const group = {
+    _parsedProps: {
+      busFanoutDirections: {
+        DATA: "center_right",
+        ADDRESS: { direction: "center_left" },
+      },
+      fanoutBoundaryPadding: { left: 1.2, right: 1.4 },
+      fanoutRoutingLayers: ["top", "inner3"],
+      fanoutPourNetMap: {
+        inner1: "GND",
+        inner2: "VCC",
+      },
+    },
+    selectAll: (selector: string) => (selector === "trace" ? [trace] : []),
+  } as unknown as Group<z.ZodType>
+
+  const plans = Group_getRoutingPhasePlans(group)
+
+  expect(plans).toHaveLength(1)
+  expect(plans[0]).toMatchObject({
+    busFanoutDirections: {
+      DATA: "center_right",
+      ADDRESS: { direction: "center_left" },
+    },
+    fanoutBoundaryPadding: { left: 1.2, right: 1.4 },
+    fanoutRoutingLayers: ["top", "inner3"],
+    fanoutPourNetMap: {
+      inner1: "GND",
+      inner2: "VCC",
+    },
+    traces: [trace],
+  })
+})

--- a/tests/features/autorouter-fanout-plane-termination.test.tsx
+++ b/tests/features/autorouter-fanout-plane-termination.test.tsx
@@ -55,8 +55,6 @@ test("fanout drops source-only power and ground connections to internal planes",
           inner2: "VCC",
         }}
         busFanoutDirections={{
-          GND_B2: "center_left",
-          VCC_C3: "center_right",
           SIGNAL_BUS: "center_right",
         }}
       />
@@ -160,10 +158,7 @@ test("fanout infers plane nets from copper pours", async () => {
       minViaHoleDiameter="0.2mm"
       minViaPadDiameter="0.5mm"
     >
-      <autoroutingphase
-        autorouter="fanout"
-        busFanoutDirections={{ GND_A1: "center_left" }}
-      />
+      <autoroutingphase autorouter="fanout" />
       <chip
         name="U1"
         footprint={

--- a/tests/features/breakout-fanout-props.test.tsx
+++ b/tests/features/breakout-fanout-props.test.tsx
@@ -59,8 +59,6 @@ test("breakout fanout props escape buses and plane nets without a phase", async 
           inner2: "VCC",
         }}
         busFanoutDirections={{
-          GND_B2: "center_left",
-          VCC_C3: "center_right",
           SIGNAL_BUS: "center_right",
         }}
       >
@@ -73,8 +71,8 @@ test("breakout fanout props escape buses and plane nets without a phase", async 
           pcbY={0}
         />
         <bus name="SIGNAL_BUS" connections={["SIGNAL", "SIGNAL_RETURN"]} />
-        <trace name="GND_B2" from=".U1 > .pin6" to="net.GND" />
-        <trace name="VCC_C3" from=".U1 > .pin11" to="net.VCC" />
+        <trace name="GND_DROP" from=".U1 > .pin6" to="net.GND" />
+        <trace name="VCC_DROP" from=".U1 > .pin11" to="net.VCC" />
         <trace name="SIGNAL" from=".U1 > .pin7" to=".R1 > .pin1" />
         <trace name="SIGNAL_RETURN" from=".U1 > .pin8" to=".R1 > .pin2" />
       </breakout>
@@ -92,14 +90,14 @@ test("breakout fanout props escape buses and plane nets without a phase", async 
   const fanoutInput = autoroutingPhaseIoStack[0]!.startSimpleRouteJson!
   expect(fanoutInput.buses).toEqual([
     {
-      busId: "GND_B2",
-      name: "GND_B2",
+      busId: "GND_DROP",
+      name: "GND_DROP",
       connectionNames: [fanoutInput.connections[0]!.name],
       termination: { type: "plane", layer: "inner1" },
     },
     {
-      busId: "VCC_C3",
-      name: "VCC_C3",
+      busId: "VCC_DROP",
+      name: "VCC_DROP",
       connectionNames: [fanoutInput.connections[1]!.name],
       termination: { type: "plane", layer: "inner2" },
     },

--- a/tests/features/breakout-fanout-props.test.tsx
+++ b/tests/features/breakout-fanout-props.test.tsx
@@ -1,0 +1,118 @@
+import { expect, test } from "bun:test"
+import { createAutoroutingPhaseIoStack } from "tests/fixtures/create-autorouting-phase-io-stack"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const TestPad = ({
+  pinNumber,
+  pcbX,
+  pcbY,
+}: {
+  pinNumber: number
+  pcbX: number
+  pcbY: number
+}) => (
+  <smtpad
+    portHints={[`pin${pinNumber}`]}
+    pcbX={pcbX}
+    pcbY={pcbY}
+    shape="circle"
+    radius="0.175mm"
+  />
+)
+
+test("breakout fanout props escape buses and plane nets without a phase", async () => {
+  const { circuit } = getTestFixture()
+  const autoroutingPhaseIoStack = createAutoroutingPhaseIoStack(circuit)
+  const bgaPads = Array.from({ length: 16 }, (_, padIndex) => {
+    const pinNumber = padIndex + 1
+    return (
+      <TestPad
+        key={pinNumber}
+        pinNumber={pinNumber}
+        pcbX={(padIndex % 4) * 0.8 - 1.2}
+        pcbY={Math.floor(padIndex / 4) * 0.8 - 1.2}
+      />
+    )
+  })
+
+  circuit.add(
+    <board
+      width="12mm"
+      height="10mm"
+      layers={6}
+      minTraceWidth="0.1mm"
+      defaultTraceWidth="0.1mm"
+      minTraceToPadEdgeClearance="0.1mm"
+      minViaEdgeToPadEdgeClearance="0.1mm"
+      minViaHoleDiameter="0.2mm"
+      minViaPadDiameter="0.5mm"
+    >
+      <copperpour layer="inner1" connectsTo="net.GND" />
+      <copperpour layer="inner2" connectsTo="net.VCC" />
+      <breakout
+        name="BGA_BREAKOUT"
+        width="10mm"
+        height="8mm"
+        fanoutRoutingLayers={["top", "inner3", "bottom"]}
+        fanoutPourNetMap={{
+          inner1: "GND",
+          inner2: "VCC",
+        }}
+        busFanoutDirections={{
+          GND_B2: "center_left",
+          VCC_C3: "center_right",
+          SIGNAL_BUS: "center_right",
+        }}
+      >
+        <chip name="U1" footprint={<footprint>{bgaPads}</footprint>} />
+        <resistor
+          name="R1"
+          resistance="1k"
+          footprint="0402"
+          pcbX={4}
+          pcbY={0}
+        />
+        <bus name="SIGNAL_BUS" connections={["SIGNAL", "SIGNAL_RETURN"]} />
+        <trace name="GND_B2" from=".U1 > .pin6" to="net.GND" />
+        <trace name="VCC_C3" from=".U1 > .pin11" to="net.VCC" />
+        <trace name="SIGNAL" from=".U1 > .pin7" to=".R1 > .pin1" />
+        <trace name="SIGNAL_RETURN" from=".U1 > .pin8" to=".R1 > .pin2" />
+      </breakout>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.pcb_autorouting_error.list()).toEqual([])
+  expect(circuit.db.pcb_trace_error.list()).toEqual([])
+  expect(circuit.db.pcb_pad_trace_clearance_error.list()).toEqual([])
+  expect(circuit.db.pcb_via_clearance_error.list()).toEqual([])
+  expect(autoroutingPhaseIoStack).toHaveLength(2)
+
+  const fanoutInput = autoroutingPhaseIoStack[0]!.startSimpleRouteJson!
+  expect(fanoutInput.buses).toEqual([
+    {
+      busId: "GND_B2",
+      name: "GND_B2",
+      connectionNames: [fanoutInput.connections[0]!.name],
+      termination: { type: "plane", layer: "inner1" },
+    },
+    {
+      busId: "VCC_C3",
+      name: "VCC_C3",
+      connectionNames: [fanoutInput.connections[1]!.name],
+      termination: { type: "plane", layer: "inner2" },
+    },
+    {
+      busId: "SIGNAL_BUS",
+      name: "SIGNAL_BUS",
+      connectionNames: fanoutInput.connections
+        .slice(2)
+        .map((connection) => connection.name),
+    },
+  ])
+
+  const vias = circuit.db.pcb_via.list()
+  expect(vias.some((via) => via.to_layer === "inner1")).toBe(true)
+  expect(vias.some((via) => via.to_layer === "inner2")).toBe(true)
+})


### PR DESCRIPTION
## Summary
- consume the breakout fanout API available in the current `@tscircuit/props@^0.0.602` dependency
- type group-level fanout controls from `BreakoutProps`
- fall back to breakout routing controls when no `autoroutingphase` overrides them
- keep phase-level controls higher precedence
- infer an internal escape orientation for plane-terminated power drops from each source pad position, so VCC/GND need no `busFanoutDirections` entry
- add end-to-end coverage for bus direction, escape layers, and GND/VCC plane termination without a phase

## Why
The normal one-stage BGA breakout should configure signal-bus fanout directly on `<breakout>`. Power and ground pins are plane drops, not user-declared buses, so their layer mapping should be sufficient and the runtime should choose their local via escape orientation automatically.

## Validation
- exact 100-pin docs example routes with directions only for `DATA` and `ADDRESS`
- breakout integration test plus existing fanout and plane-termination tests (5 passing)
- verified GND/VCC vias terminate on `inner1` and `inner2`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`