### PR TITLE
Automatically detect and constrain decoupling capacitor traces

### DIFF
--- a/lib/components/normal-components/Capacitor.ts
+++ b/lib/components/normal-components/Capacitor.ts
@@ -8,6 +8,7 @@ import {
 import { NormalComponent } from "../base-components/NormalComponent/NormalComponent"
 import { Trace } from "../primitive-components/Trace/Trace"
 import { formatSiUnit } from "format-si-unit"
+import { applyAutomaticDecouplingTraceLength } from "./apply-automatic-decoupling-trace-length"
 
 export class Capacitor extends NormalComponent<
   typeof capacitorProps,
@@ -108,5 +109,10 @@ export class Capacitor extends NormalComponent<
     } as SourceSimpleCapacitorInput)
 
     this.source_component_id = source_component.source_component_id
+  }
+
+  override doInitialSourceDesignRuleChecks(): void {
+    super.doInitialSourceDesignRuleChecks()
+    applyAutomaticDecouplingTraceLength(this)
   }
 }

--- a/lib/components/normal-components/apply-automatic-decoupling-trace-length.ts
+++ b/lib/components/normal-components/apply-automatic-decoupling-trace-length.ts
@@ -1,0 +1,123 @@
+import type { SourcePort } from "circuit-json"
+import {
+  GROUND_NET_REGEX,
+  POWER_NET_REGEX,
+} from "lib/utils/gnd-power-net-regex"
+import type { Capacitor } from "./Capacitor"
+
+const DEFAULT_MAX_DECOUPLING_TRACE_LENGTH_MM = 1
+
+const portHintsMatch = (sourcePort: SourcePort, pattern: RegExp): boolean =>
+  sourcePort.port_hints?.some((portHint) => pattern.test(portHint)) ?? false
+
+const chipPortShouldHaveDecouplingCapacitor = (
+  sourcePort: SourcePort,
+  capacitor: Capacitor,
+): boolean => {
+  if (!sourcePort.source_component_id) return false
+
+  const sourceComponent = capacitor.root!.db.source_component.get(
+    sourcePort.source_component_id,
+  )
+  if (sourceComponent?.ftype !== "simple_chip") return false
+
+  if (sourcePort.should_have_decoupling_capacitor !== undefined) {
+    return sourcePort.should_have_decoupling_capacitor
+  }
+
+  return (
+    sourcePort.requires_power ?? portHintsMatch(sourcePort, POWER_NET_REGEX)
+  )
+}
+
+const sourcePortIsGround = (sourcePort: SourcePort): boolean =>
+  sourcePort.provides_ground === true ||
+  sourcePort.requires_ground === true ||
+  portHintsMatch(sourcePort, GROUND_NET_REGEX)
+
+export const applyAutomaticDecouplingTraceLength = (
+  capacitor: Capacitor,
+): void => {
+  if (
+    capacitor._parsedProps.maxDecouplingTraceLength !== undefined ||
+    !capacitor.source_component_id
+  ) {
+    return
+  }
+
+  const { db } = capacitor.root!
+  const allSourcePorts = db.source_port.list()
+  const capacitorSourcePorts = allSourcePorts.filter(
+    (sourcePort) =>
+      sourcePort.source_component_id === capacitor.source_component_id,
+  )
+
+  const chipPowerConnectivityMapKeys = new Set(
+    allSourcePorts
+      .filter(
+        (sourcePort) =>
+          sourcePort.subcircuit_connectivity_map_key !== undefined &&
+          chipPortShouldHaveDecouplingCapacitor(sourcePort, capacitor),
+      )
+      .map((sourcePort) => sourcePort.subcircuit_connectivity_map_key!),
+  )
+  const groundConnectivityMapKeys = new Set([
+    ...db.source_net
+      .list()
+      .filter(
+        (sourceNet) =>
+          sourceNet.is_ground === true &&
+          sourceNet.subcircuit_connectivity_map_key !== undefined,
+      )
+      .map((sourceNet) => sourceNet.subcircuit_connectivity_map_key!),
+    ...allSourcePorts
+      .filter(
+        (sourcePort) =>
+          sourcePort.subcircuit_connectivity_map_key !== undefined &&
+          sourcePortIsGround(sourcePort),
+      )
+      .map((sourcePort) => sourcePort.subcircuit_connectivity_map_key!),
+  ])
+
+  const powerSideSourcePort = capacitorSourcePorts.find(
+    (sourcePort) =>
+      sourcePort.subcircuit_connectivity_map_key !== undefined &&
+      chipPowerConnectivityMapKeys.has(
+        sourcePort.subcircuit_connectivity_map_key,
+      ),
+  )
+  const groundSideSourcePort = capacitorSourcePorts.find(
+    (sourcePort) =>
+      sourcePort.source_port_id !== powerSideSourcePort?.source_port_id &&
+      sourcePort.subcircuit_connectivity_map_key !== undefined &&
+      sourcePort.subcircuit_connectivity_map_key !==
+        powerSideSourcePort?.subcircuit_connectivity_map_key &&
+      groundConnectivityMapKeys.has(sourcePort.subcircuit_connectivity_map_key),
+  )
+
+  if (!powerSideSourcePort || !groundSideSourcePort) return
+
+  db.source_component.update(capacitor.source_component_id, {
+    max_decoupling_trace_length: DEFAULT_MAX_DECOUPLING_TRACE_LENGTH_MM,
+  })
+
+  const capacitorSourcePortIds = new Set(
+    capacitorSourcePorts.map((sourcePort) => sourcePort.source_port_id),
+  )
+  for (const sourceTrace of db.source_trace.list()) {
+    if (
+      !sourceTrace.connected_source_port_ids.some((sourcePortId) =>
+        capacitorSourcePortIds.has(sourcePortId),
+      )
+    ) {
+      continue
+    }
+
+    db.source_trace.update(sourceTrace.source_trace_id, {
+      max_length: Math.min(
+        sourceTrace.max_length ?? DEFAULT_MAX_DECOUPLING_TRACE_LENGTH_MM,
+        DEFAULT_MAX_DECOUPLING_TRACE_LENGTH_MM,
+      ),
+    })
+  }
+}

--- a/lib/components/normal-components/apply-automatic-decoupling-trace-length.ts
+++ b/lib/components/normal-components/apply-automatic-decoupling-trace-length.ts
@@ -1,13 +1,10 @@
 import type { SourcePort } from "circuit-json"
+import type { SubcircuitConnectivityMapKey } from "lib/utils/circuit-json/subcircuit-connectivity-map-key"
 import type { Capacitor } from "./Capacitor"
 import { chipSourcePortShouldHaveDecouplingCapacitor } from "./chip-source-port-should-have-decoupling-capacitor"
 import { sourcePortIsGround } from "./source-port-is-ground"
 
 const DEFAULT_MAX_DECOUPLING_TRACE_LENGTH_MM = 1
-
-type SubcircuitConnectivityMapKey = NonNullable<
-  SourcePort["subcircuit_connectivity_map_key"]
->
 
 /**
  * Detects a capacitor bridging a chip power pin and ground, then applies the
@@ -93,6 +90,7 @@ export const applyAutomaticDecouplingTraceLength = (
   )
   for (const sourceTrace of db.source_trace.list()) {
     if (
+      sourceTrace.max_length !== undefined ||
       !sourceTrace.connected_source_port_ids.some((sourcePortId) =>
         capacitorSourcePortIds.has(sourcePortId),
       )
@@ -101,10 +99,7 @@ export const applyAutomaticDecouplingTraceLength = (
     }
 
     db.source_trace.update(sourceTrace.source_trace_id, {
-      max_length: Math.min(
-        sourceTrace.max_length ?? DEFAULT_MAX_DECOUPLING_TRACE_LENGTH_MM,
-        DEFAULT_MAX_DECOUPLING_TRACE_LENGTH_MM,
-      ),
+      max_length: DEFAULT_MAX_DECOUPLING_TRACE_LENGTH_MM,
     })
   }
 }

--- a/lib/components/normal-components/apply-automatic-decoupling-trace-length.ts
+++ b/lib/components/normal-components/apply-automatic-decoupling-trace-length.ts
@@ -1,40 +1,20 @@
 import type { SourcePort } from "circuit-json"
-import {
-  GROUND_NET_REGEX,
-  POWER_NET_REGEX,
-} from "lib/utils/gnd-power-net-regex"
 import type { Capacitor } from "./Capacitor"
+import { chipSourcePortShouldHaveDecouplingCapacitor } from "./chip-source-port-should-have-decoupling-capacitor"
+import { sourcePortIsGround } from "./source-port-is-ground"
 
 const DEFAULT_MAX_DECOUPLING_TRACE_LENGTH_MM = 1
 
-const portHintsMatch = (sourcePort: SourcePort, pattern: RegExp): boolean =>
-  sourcePort.port_hints?.some((portHint) => pattern.test(portHint)) ?? false
+type SubcircuitConnectivityMapKey = NonNullable<
+  SourcePort["subcircuit_connectivity_map_key"]
+>
 
-const chipPortShouldHaveDecouplingCapacitor = (
-  sourcePort: SourcePort,
-  capacitor: Capacitor,
-): boolean => {
-  if (!sourcePort.source_component_id) return false
-
-  const sourceComponent = capacitor.root!.db.source_component.get(
-    sourcePort.source_component_id,
-  )
-  if (sourceComponent?.ftype !== "simple_chip") return false
-
-  if (sourcePort.should_have_decoupling_capacitor !== undefined) {
-    return sourcePort.should_have_decoupling_capacitor
-  }
-
-  return (
-    sourcePort.requires_power ?? portHintsMatch(sourcePort, POWER_NET_REGEX)
-  )
-}
-
-const sourcePortIsGround = (sourcePort: SourcePort): boolean =>
-  sourcePort.provides_ground === true ||
-  sourcePort.requires_ground === true ||
-  portHintsMatch(sourcePort, GROUND_NET_REGEX)
-
+/**
+ * Detects a capacitor bridging a chip power pin and ground, then applies the
+ * default decoupling trace limit to the capacitor and its attached traces.
+ * Explicit maxDecouplingTraceLength values and unrelated capacitors are left
+ * unchanged.
+ */
 export const applyAutomaticDecouplingTraceLength = (
   capacitor: Capacitor,
 ): void => {
@@ -47,37 +27,44 @@ export const applyAutomaticDecouplingTraceLength = (
 
   const { db } = capacitor.root!
   const allSourcePorts = db.source_port.list()
-  const capacitorSourcePorts = allSourcePorts.filter(
-    (sourcePort) =>
-      sourcePort.source_component_id === capacitor.source_component_id,
-  )
+  const capacitorSourcePorts: SourcePort[] = []
+  const chipPowerConnectivityMapKeys = new Set<SubcircuitConnectivityMapKey>()
+  const groundConnectivityMapKeys = new Set<SubcircuitConnectivityMapKey>()
 
-  const chipPowerConnectivityMapKeys = new Set(
-    allSourcePorts
-      .filter(
-        (sourcePort) =>
-          sourcePort.subcircuit_connectivity_map_key !== undefined &&
-          chipPortShouldHaveDecouplingCapacitor(sourcePort, capacitor),
+  for (const sourcePort of allSourcePorts) {
+    if (sourcePort.source_component_id === capacitor.source_component_id) {
+      capacitorSourcePorts.push(sourcePort)
+    }
+
+    const connectivityMapKey = sourcePort.subcircuit_connectivity_map_key
+    if (!connectivityMapKey) continue
+
+    const sourcePortParent = sourcePort.source_component_id
+      ? db.source_component.get(sourcePort.source_component_id)
+      : undefined
+    const sourcePortParentIsChip =
+      sourcePortParent !== null &&
+      sourcePortParent !== undefined &&
+      "ftype" in sourcePortParent &&
+      sourcePortParent.ftype === "simple_chip"
+    if (
+      chipSourcePortShouldHaveDecouplingCapacitor(
+        sourcePort,
+        sourcePortParentIsChip,
       )
-      .map((sourcePort) => sourcePort.subcircuit_connectivity_map_key!),
-  )
-  const groundConnectivityMapKeys = new Set([
-    ...db.source_net
-      .list()
-      .filter(
-        (sourceNet) =>
-          sourceNet.is_ground === true &&
-          sourceNet.subcircuit_connectivity_map_key !== undefined,
-      )
-      .map((sourceNet) => sourceNet.subcircuit_connectivity_map_key!),
-    ...allSourcePorts
-      .filter(
-        (sourcePort) =>
-          sourcePort.subcircuit_connectivity_map_key !== undefined &&
-          sourcePortIsGround(sourcePort),
-      )
-      .map((sourcePort) => sourcePort.subcircuit_connectivity_map_key!),
-  ])
+    ) {
+      chipPowerConnectivityMapKeys.add(connectivityMapKey)
+    }
+    if (sourcePortIsGround(sourcePort)) {
+      groundConnectivityMapKeys.add(connectivityMapKey)
+    }
+  }
+
+  for (const sourceNet of db.source_net.list()) {
+    if (sourceNet.is_ground && sourceNet.subcircuit_connectivity_map_key) {
+      groundConnectivityMapKeys.add(sourceNet.subcircuit_connectivity_map_key)
+    }
+  }
 
   const powerSideSourcePort = capacitorSourcePorts.find(
     (sourcePort) =>

--- a/lib/components/normal-components/chip-source-port-should-have-decoupling-capacitor.ts
+++ b/lib/components/normal-components/chip-source-port-should-have-decoupling-capacitor.ts
@@ -1,0 +1,19 @@
+import type { SourcePort } from "circuit-json"
+import { POWER_NET_REGEX } from "lib/utils/gnd-power-net-regex"
+
+export const chipSourcePortShouldHaveDecouplingCapacitor = (
+  sourcePort: SourcePort,
+  sourcePortParentIsChip: boolean,
+): boolean => {
+  if (!sourcePortParentIsChip) return false
+
+  if (sourcePort.should_have_decoupling_capacitor !== undefined) {
+    return sourcePort.should_have_decoupling_capacitor
+  }
+
+  return (
+    sourcePort.requires_power ??
+    sourcePort.port_hints?.some((portHint) => POWER_NET_REGEX.test(portHint)) ??
+    false
+  )
+}

--- a/lib/components/normal-components/source-port-is-ground.ts
+++ b/lib/components/normal-components/source-port-is-ground.ts
@@ -1,0 +1,8 @@
+import type { SourcePort } from "circuit-json"
+import { GROUND_NET_REGEX } from "lib/utils/gnd-power-net-regex"
+
+export const sourcePortIsGround = (sourcePort: SourcePort): boolean =>
+  sourcePort.provides_ground === true ||
+  sourcePort.requires_ground === true ||
+  (sourcePort.port_hints?.some((portHint) => GROUND_NET_REGEX.test(portHint)) ??
+    false)

--- a/lib/utils/circuit-json/subcircuit-connectivity-map-key.ts
+++ b/lib/utils/circuit-json/subcircuit-connectivity-map-key.ts
@@ -1,0 +1,5 @@
+import type { SourcePort } from "circuit-json"
+
+export type SubcircuitConnectivityMapKey = NonNullable<
+  SourcePort["subcircuit_connectivity_map_key"]
+>

--- a/tests/components/normal-components/capacitor-automatic-decoupling-detection.test.tsx
+++ b/tests/components/normal-components/capacitor-automatic-decoupling-detection.test.tsx
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import type { SourceSimpleCapacitor } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("a capacitor between an inferred chip power pin and ground defaults to a 1mm trace limit", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{
+          1: "VCC",
+          4: "GND",
+        }}
+      />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 > .VCC" to=".C1 > .1" />
+      <trace from=".C1 > .2" to="net.GND" />
+      <trace from=".U1 > .GND" to="net.GND" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const capacitorSourceComponent = circuit.db.source_component
+    .list()
+    .find(
+      (sourceComponent): sourceComponent is SourceSimpleCapacitor =>
+        sourceComponent.ftype === "simple_capacitor" &&
+        sourceComponent.name === "C1",
+    )
+  const capacitorSourcePortIds = new Set(
+    circuit.db.source_port
+      .list()
+      .filter(
+        (sourcePort) =>
+          sourcePort.source_component_id ===
+          capacitorSourceComponent?.source_component_id,
+      )
+      .map((sourcePort) => sourcePort.source_port_id),
+  )
+  const capacitorSourceTraces = circuit.db.source_trace
+    .list()
+    .filter((sourceTrace) =>
+      sourceTrace.connected_source_port_ids.some((sourcePortId) =>
+        capacitorSourcePortIds.has(sourcePortId),
+      ),
+    )
+
+  expect(capacitorSourceComponent?.max_decoupling_trace_length).toBe(1)
+  expect(
+    capacitorSourceTraces.map((sourceTrace) => sourceTrace.max_length),
+  ).toEqual([1, 1])
+})

--- a/tests/components/normal-components/capacitor-automatic-decoupling-detection.test.tsx
+++ b/tests/components/normal-components/capacitor-automatic-decoupling-detection.test.tsx
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import type { SourceSimpleCapacitor } from "circuit-json"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test("a capacitor between an inferred chip power pin and ground defaults to a 1mm trace limit", () => {
+test("automatic decoupling preserves existing trace limits", () => {
   const { circuit } = getTestFixture()
 
   circuit.add(
@@ -16,7 +16,7 @@ test("a capacitor between an inferred chip power pin and ground defaults to a 1m
         }}
       />
       <capacitor name="C1" capacitance="100nF" footprint="0402" />
-      <trace from=".U1 > .VCC" to=".C1 > .1" />
+      <trace from=".U1 > .VCC" to=".C1 > .1" maxLength={5} />
       <trace from=".C1 > .2" to="net.GND" />
       <trace from=".U1 > .GND" to="net.GND" />
     </board>,
@@ -52,5 +52,5 @@ test("a capacitor between an inferred chip power pin and ground defaults to a 1m
   expect(capacitorSourceComponent?.max_decoupling_trace_length).toBe(1)
   expect(
     capacitorSourceTraces.map((sourceTrace) => sourceTrace.max_length),
-  ).toEqual([1, 1])
+  ).toEqual([5, 1])
 })

--- a/tests/components/normal-components/capacitor-automatic-decoupling-opt-out.test.tsx
+++ b/tests/components/normal-components/capacitor-automatic-decoupling-opt-out.test.tsx
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import type { SourceSimpleCapacitor } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("shouldHaveDecouplingCapacitor false opts a power pin out of automatic detection", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{
+          1: "VBAT",
+          4: "GND",
+        }}
+        pinAttributes={{
+          VBAT: {
+            requiresPower: true,
+            shouldHaveDecouplingCapacitor: false,
+          },
+        }}
+      />
+      <capacitor name="C1" capacitance="100uF" footprint="1210" />
+      <trace from=".U1 > .VBAT" to=".C1 > .1" />
+      <trace from=".C1 > .2" to="net.GND" />
+      <trace from=".U1 > .GND" to="net.GND" />
+    </board>,
+  )
+
+  circuit.render()
+
+  const capacitorSourceComponent = circuit.db.source_component
+    .list()
+    .find(
+      (sourceComponent): sourceComponent is SourceSimpleCapacitor =>
+        sourceComponent.ftype === "simple_capacitor" &&
+        sourceComponent.name === "C1",
+    )
+
+  expect(capacitorSourceComponent?.max_decoupling_trace_length).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

- detect capacitors connected between a qualifying chip power pin and ground
- infer power requirements from common labels such as `VCC` while honoring `requiresPower` and `shouldHaveDecouplingCapacitor: false`
- default detected decoupling capacitors and their attached traces to a 1 mm maximum length
- preserve explicit `maxDecouplingTraceLength` values and leave unrelated capacitors unchanged

This implements the trace-length portion of https://github.com/tscircuit/rfc/blob/main/rfcs/2026-07-31-automatic-decoupling-capacitor-detection-and-enforcement.md without adding a new warning or enforcement mechanism.

## Impact

Circuits matching the RFC connectivity pattern now populate the existing maximum trace-length metadata automatically, allowing the existing routing and DRC pipeline to enforce short decoupling paths.

## Validation

- `bunx tsc --noEmit`
- focused Biome checks
- RFC good-case and explicit opt-out tests
- existing explicit trace-length and crystal trace-length tests
- full suite: 1,301 passed; one unrelated differential-pair test exceeded its 5-second timeout under full-suite load and passed when rerun alone
