### PR TITLE
Mark via obstacles as circular

### DIFF
--- a/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
+++ b/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
@@ -440,6 +440,7 @@ export const getObstaclesFromCircuitJson = (
       obstacles.push({
         componentId: pcbComponentId,
         type: "rect",
+        shape: "circle",
         layers: element.layers,
         center: {
           x: element.x,

--- a/tests/utils/autorouting/via-obstacles-are-circular.test.ts
+++ b/tests/utils/autorouting/via-obstacles-are-circular.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getObstaclesFromCircuitJson } from "lib/utils/obstacles/getObstaclesFromCircuitJson"
+
+test("vias produce explicitly circular obstacles", () => {
+  const circuitJson = [
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_without_a_type_prefix",
+      x: 1,
+      y: 2,
+      outer_diameter: 0.6,
+      hole_diameter: 0.3,
+      layers: ["top", "bottom"],
+    },
+  ] as AnyCircuitElement[]
+
+  const [viaObstacle] = getObstaclesFromCircuitJson(circuitJson)
+
+  expect(viaObstacle).toMatchObject({
+    type: "rect",
+    shape: "circle",
+    center: { x: 1, y: 2 },
+    width: 0.6,
+    height: 0.6,
+    connectedTo: ["via_without_a_type_prefix"],
+  })
+})


### PR DESCRIPTION
## What changed

- mark obstacles emitted from `pcb_via` elements with the existing `shape: "circle"` geometry field
- add a focused regression test whose via ID deliberately has no `pcb_via_` prefix

## Why

The fanout solver needs the physical shape of existing via obstacles to evaluate diagonal clearances correctly. Inferring that shape from an identifier prefix inside the solver is brittle and crosses the serialization boundary. Core already emits `shape: "circle"` for circular SMT pads; vias should carry the same explicit geometry.

This does not add routing-phase data or automatic bus behavior to Simple Route JSON.

## Validation

- `bun test tests/utils/autorouting/via-obstacles-are-circular.test.ts`
- `bunx tsc --noEmit`
- `bunx biome check lib/utils/obstacles/getObstaclesFromCircuitJson.ts tests/utils/autorouting/via-obstacles-are-circular.test.ts`
- full RK3326 board build with released, unmodified `@tscircuit/fanout-solver@0.0.11`: all 12 routing phases completed, including U1, U2, J1, J2 fanouts and the four global bus phases