### PR TITLE
Serialize chip pin capabilities to source ports

### DIFF
--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -9,7 +9,7 @@ import { applyToPoint, compose, translate } from "transformation-matrix"
 import { z } from "zod"
 import { PrimitiveComponent } from "../../base-components/PrimitiveComponent"
 import type { Trace } from "../Trace/Trace"
-import type { LayerRef, SchematicPort } from "circuit-json"
+import type { LayerRef, SchematicPort, SourcePinAttributes } from "circuit-json"
 import { areAllPcbPrimitivesOverlapping } from "./areAllPcbPrimitivesOverlapping"
 import { getCenterOfPcbPrimitives } from "./getCenterOfPcbPrimitives"
 import { type PinAttributeMap, portProps } from "@tscircuit/props"
@@ -393,7 +393,7 @@ export class Port extends PrimitiveComponent<typeof portProps> {
 
     // Get pin attributes from parent component and apply them to this port
     const pinAttributes = this._getMatchingPinAttributes()
-    const portAttributesFromParent: Record<string, unknown> = {}
+    const portAttributesFromParent: SourcePinAttributes = {}
 
     for (const attributes of pinAttributes) {
       applyPinAttributesToSourcePort(portAttributesFromParent, attributes)

--- a/lib/components/primitive-components/Port/apply-pin-attributes-to-source-port.ts
+++ b/lib/components/primitive-components/Port/apply-pin-attributes-to-source-port.ts
@@ -1,11 +1,86 @@
-import type { PinAttributeMap } from "@tscircuit/props"
+import type { PinAttributeMap, PinCapability } from "@tscircuit/props"
+import type { SourcePinAttributes } from "circuit-json"
+
+const setSupportedCapability = (
+  sourcePortProps: SourcePinAttributes,
+  capability: PinCapability,
+): void => {
+  switch (capability) {
+    case "i2c_sda":
+      sourcePortProps.supports_i2c_sda = true
+      return
+    case "i2c_scl":
+      sourcePortProps.supports_i2c_scl = true
+      return
+    case "spi_cs":
+      sourcePortProps.supports_spi_cs = true
+      return
+    case "spi_sck":
+      sourcePortProps.supports_spi_sck = true
+      return
+    case "spi_mosi":
+      sourcePortProps.supports_spi_mosi = true
+      return
+    case "spi_miso":
+      sourcePortProps.supports_spi_miso = true
+      return
+    case "uart_tx":
+      sourcePortProps.supports_uart_tx = true
+      return
+    case "uart_rx":
+      sourcePortProps.supports_uart_rx = true
+      return
+    default: {
+      const unhandledCapability: never = capability
+      throw new Error(`Unhandled pin capability: ${unhandledCapability}`)
+    }
+  }
+}
+
+const setConfiguredCapability = (
+  sourcePortProps: SourcePinAttributes,
+  capability: PinCapability,
+): void => {
+  switch (capability) {
+    case "i2c_sda":
+      sourcePortProps.is_configured_for_i2c_sda = true
+      return
+    case "i2c_scl":
+      sourcePortProps.is_configured_for_i2c_scl = true
+      return
+    case "spi_cs":
+      sourcePortProps.is_configured_for_spi_cs = true
+      return
+    case "spi_sck":
+      sourcePortProps.is_configured_for_spi_sck = true
+      return
+    case "spi_mosi":
+      sourcePortProps.is_configured_for_spi_mosi = true
+      return
+    case "spi_miso":
+      sourcePortProps.is_configured_for_spi_miso = true
+      return
+    case "uart_tx":
+      sourcePortProps.is_configured_for_uart_tx = true
+      return
+    case "uart_rx":
+      sourcePortProps.is_configured_for_uart_rx = true
+      return
+    default: {
+      const unhandledCapability: never = capability
+      throw new Error(
+        `Unhandled configured pin capability: ${unhandledCapability}`,
+      )
+    }
+  }
+}
 
 export const applyPinAttributesToSourcePort = (
-  sourcePortProps: Record<string, unknown>,
+  sourcePortProps: SourcePinAttributes,
   attributes: PinAttributeMap,
 ): void => {
   for (const capability of attributes.capabilities ?? []) {
-    sourcePortProps[`supports_${capability}`] = true
+    setSupportedCapability(sourcePortProps, capability)
   }
 
   const configuredCapabilities = new Set([
@@ -14,7 +89,7 @@ export const applyPinAttributesToSourcePort = (
   ])
 
   for (const capability of configuredCapabilities) {
-    sourcePortProps[`is_configured_for_${capability}`] = true
+    setConfiguredCapability(sourcePortProps, capability)
   }
 
   if (attributes.mustBeConnected !== undefined) {

--- a/lib/components/primitive-components/Port/apply-pin-attributes-to-source-port.ts
+++ b/lib/components/primitive-components/Port/apply-pin-attributes-to-source-port.ts
@@ -4,6 +4,19 @@ export const applyPinAttributesToSourcePort = (
   sourcePortProps: Record<string, unknown>,
   attributes: PinAttributeMap,
 ): void => {
+  for (const capability of attributes.capabilities ?? []) {
+    sourcePortProps[`supports_${capability}`] = true
+  }
+
+  const configuredCapabilities = new Set([
+    ...(attributes.activeCapabilities ?? []),
+    ...(attributes.activeCapability ? [attributes.activeCapability] : []),
+  ])
+
+  for (const capability of configuredCapabilities) {
+    sourcePortProps[`is_configured_for_${capability}`] = true
+  }
+
   if (attributes.mustBeConnected !== undefined) {
     sourcePortProps.must_be_connected = attributes.mustBeConnected
   }

--- a/tests/components/normal-components/chip-source-port-pin-attributes.test.tsx
+++ b/tests/components/normal-components/chip-source-port-pin-attributes.test.tsx
@@ -13,7 +13,7 @@ test("chip pinAttributes are copied onto source_port records", async () => {
           pin1: "VCC",
           pin2: "GND",
           pin3: "VOUT",
-          pin4: "SCK",
+          pin4: "NC",
         }}
         pinAttributes={{
           VCC: { requiresPower: true, mustBeConnected: true },
@@ -21,12 +21,26 @@ test("chip pinAttributes are copied onto source_port records", async () => {
           VOUT: {
             providesPower: true,
             providesVoltage: 3.3,
-            capabilities: ["i2c_sda", "spi_mosi", "uart_tx"],
-            activeCapabilities: ["i2c_sda", "uart_tx"],
-          },
-          SCK: {
-            capabilities: ["spi_sck"],
-            activeCapability: "spi_sck",
+            capabilities: [
+              "i2c_sda",
+              "i2c_scl",
+              "spi_cs",
+              "spi_sck",
+              "spi_mosi",
+              "spi_miso",
+              "uart_tx",
+              "uart_rx",
+            ],
+            activeCapabilities: [
+              "i2c_sda",
+              "i2c_scl",
+              "spi_cs",
+              "spi_sck",
+              "spi_mosi",
+              "spi_miso",
+              "uart_tx",
+            ],
+            activeCapability: "uart_rx",
           },
         }}
       />
@@ -45,10 +59,19 @@ test("chip pinAttributes are copied onto source_port records", async () => {
   expect(getPort("VOUT")?.provides_power).toBe(true)
   expect(getPort("VOUT")?.provides_voltage).toBe(3.3)
   expect(getPort("VOUT")?.supports_i2c_sda).toBe(true)
+  expect(getPort("VOUT")?.supports_i2c_scl).toBe(true)
+  expect(getPort("VOUT")?.supports_spi_cs).toBe(true)
+  expect(getPort("VOUT")?.supports_spi_sck).toBe(true)
   expect(getPort("VOUT")?.supports_spi_mosi).toBe(true)
+  expect(getPort("VOUT")?.supports_spi_miso).toBe(true)
   expect(getPort("VOUT")?.supports_uart_tx).toBe(true)
+  expect(getPort("VOUT")?.supports_uart_rx).toBe(true)
   expect(getPort("VOUT")?.is_configured_for_i2c_sda).toBe(true)
+  expect(getPort("VOUT")?.is_configured_for_i2c_scl).toBe(true)
+  expect(getPort("VOUT")?.is_configured_for_spi_cs).toBe(true)
+  expect(getPort("VOUT")?.is_configured_for_spi_sck).toBe(true)
+  expect(getPort("VOUT")?.is_configured_for_spi_mosi).toBe(true)
+  expect(getPort("VOUT")?.is_configured_for_spi_miso).toBe(true)
   expect(getPort("VOUT")?.is_configured_for_uart_tx).toBe(true)
-  expect(getPort("SCK")?.supports_spi_sck).toBe(true)
-  expect(getPort("SCK")?.is_configured_for_spi_sck).toBe(true)
+  expect(getPort("VOUT")?.is_configured_for_uart_rx).toBe(true)
 })

--- a/tests/components/normal-components/chip-source-port-pin-attributes.test.tsx
+++ b/tests/components/normal-components/chip-source-port-pin-attributes.test.tsx
@@ -9,11 +9,25 @@ test("chip pinAttributes are copied onto source_port records", async () => {
       <chip
         name="U1"
         footprint="soic8"
-        pinLabels={{ pin1: "VCC", pin2: "GND", pin3: "VOUT" }}
+        pinLabels={{
+          pin1: "VCC",
+          pin2: "GND",
+          pin3: "VOUT",
+          pin4: "SCK",
+        }}
         pinAttributes={{
           VCC: { requiresPower: true, mustBeConnected: true },
           GND: { requiresGround: true },
-          VOUT: { providesPower: true, providesVoltage: 3.3 },
+          VOUT: {
+            providesPower: true,
+            providesVoltage: 3.3,
+            capabilities: ["i2c_sda", "spi_mosi", "uart_tx"],
+            activeCapabilities: ["i2c_sda", "uart_tx"],
+          },
+          SCK: {
+            capabilities: ["spi_sck"],
+            activeCapability: "spi_sck",
+          },
         }}
       />
     </board>,
@@ -30,4 +44,11 @@ test("chip pinAttributes are copied onto source_port records", async () => {
   expect(getPort("GND")?.requires_ground).toBe(true)
   expect(getPort("VOUT")?.provides_power).toBe(true)
   expect(getPort("VOUT")?.provides_voltage).toBe(3.3)
+  expect(getPort("VOUT")?.supports_i2c_sda).toBe(true)
+  expect(getPort("VOUT")?.supports_spi_mosi).toBe(true)
+  expect(getPort("VOUT")?.supports_uart_tx).toBe(true)
+  expect(getPort("VOUT")?.is_configured_for_i2c_sda).toBe(true)
+  expect(getPort("VOUT")?.is_configured_for_uart_tx).toBe(true)
+  expect(getPort("SCK")?.supports_spi_sck).toBe(true)
+  expect(getPort("SCK")?.is_configured_for_spi_sck).toBe(true)
 })


### PR DESCRIPTION
## Summary

- explicitly map every `PinCapability` to its canonical Circuit JSON `supports_*` source-port field
- explicitly map `activeCapabilities` and `activeCapability` to the corresponding `is_configured_for_*` fields
- type the serialization boundary as `SourcePinAttributes` and test all eight supported capabilities

## Why

Core already copied electrical and pull-mode pin attributes to `source_port`, but it dropped capability metadata. As a result, model-specific components could describe RP2040 I2C/SPI/UART mux support in TSX while the generated Circuit JSON lost it.

Each capability now uses an exhaustive switch with a direct, named property assignment. This avoids computed string keys, checks every assignment against `SourcePinAttributes`, and makes additions to the `PinCapability` union a compile-time exhaustiveness error until they are mapped deliberately.

## Scope note

`PinAttributeMap.isGpio` is not included because Circuit JSON does not currently define an `is_gpio` source-port field. Adding that requires a schema change in `tscircuit/circuit-json` before core can serialize it canonically.

## Validation

- `bun test tests/components/normal-components/chip-source-port-pin-attributes.test.tsx` — pass (21 assertions covering every capability field)
- `bunx tsc --noEmit` — pass
- `bun run build` — pass
- `git diff --check` — pass
- full `bun test` — 1300 pass, 31 skip, 1 unrelated failure in `tests/fixtures/fetch-blocking.test.tsx`; the local blocked-network error did not contain the fixture's expected registry URL text
