### PR TITLE
Follow insertion_direction rename to top/bottom

### DIFF
--- a/lib/utils/pcb/transform-footprint-insertion-direction.ts
+++ b/lib/utils/pcb/transform-footprint-insertion-direction.ts
@@ -5,6 +5,13 @@ import {
   type LayerRef,
   insertionDirectionToCanonical,
 } from "circuit-json"
+import {
+  applyToPoint,
+  compose,
+  flipY,
+  identity,
+  rotate,
+} from "transformation-matrix"
 
 /**
  * Unit vectors for the directions that lie in the board plane. The Z-axis
@@ -45,33 +52,48 @@ export const transformFootprintInsertionDirection = (params: {
 
   if (!insertionDirection) return undefined
 
+  // Circuit JSON accepts deprecated and Cartesian direction names at input,
+  // but pcb_component.insertion_direction is written with the canonical names.
   const direction = insertionDirectionToCanonical[insertionDirection]
 
-  // Rotating a footprint within the board plane leaves a Z-axis insertion
-  // pointing along Z, but moving the part to the other layer means the mating
-  // part now approaches the board from the opposite side.
+  // A footprint moved to the other layer is rotated 180 degrees about the
+  // board's Y axis, so an insertion along Z now points the opposite way.
   if (direction === "from_above" || direction === "from_below") {
     if (!isFlipped) return direction
     return direction === "from_above" ? "from_below" : "from_above"
   }
 
-  const baseVector = inPlaneDirectionToVector[direction]
-  const angleRadians = (normalizeDegrees(rotationDegrees) * Math.PI) / 180
-  const rotatedVector = {
-    x:
-      baseVector.x * Math.cos(angleRadians) -
-      baseVector.y * Math.sin(angleRadians),
-    y:
-      baseVector.x * Math.sin(angleRadians) +
-      baseVector.y * Math.cos(angleRadians),
-  }
-  const finalVector = isFlipped
-    ? { x: rotatedVector.x, y: -rotatedVector.y }
-    : rotatedVector
+  // Reuse the transform PrimitiveComponent applies to the footprint's own
+  // geometry, so this direction cannot drift from where the pads land. From
+  // PrimitiveComponent._computePcbGlobalTransformBeforeLayout, the
+  // `isPcbPrimitive && isFlipped` branch:
+  //
+  //   compose(
+  //     this.parent?._computePcbGlobalTransformBeforeLayout() ?? identity(),
+  //     flipY(),
+  //     this.computePcbPropsTransform(),
+  //   )
+  //
+  // compose() applies right to left, so the footprint is flipped in its own
+  // frame and the component's rotation is applied after. flipY() mirrors on
+  // the y-axis, which negates X and leaves Y alone.
+  const transform = compose(
+    rotate((normalizeDegrees(rotationDegrees) * Math.PI) / 180),
+    isFlipped ? flipY() : identity(),
+  )
+  const finalVector = applyToPoint(
+    transform,
+    inPlaneDirectionToVector[direction],
+  )
 
   if (Math.abs(finalVector.x) >= Math.abs(finalVector.y)) {
     return finalVector.x >= 0 ? "from_right" : "from_left"
   }
 
+  // `from_top` and `from_bottom` are canonical Circuit JSON values. props types
+  // the prop with the wide input union (InsertionDirectionInput, which also
+  // admits the Cartesian and deprecated spellings), while
+  // pcb_component.insertion_direction is the narrow six-name InsertionDirection
+  // union returned here.
   return finalVector.y >= 0 ? "from_top" : "from_bottom"
 }

--- a/lib/utils/pcb/transform-footprint-insertion-direction.ts
+++ b/lib/utils/pcb/transform-footprint-insertion-direction.ts
@@ -1,45 +1,24 @@
 import { normalizeDegrees } from "@tscircuit/math-utils"
 import type { FootprintInsertionDirection } from "@tscircuit/props"
-import type { LayerRef, PcbComponent } from "circuit-json"
+import {
+  type InsertionDirection,
+  type LayerRef,
+  insertionDirectionToCanonical,
+} from "circuit-json"
 
-type CanonicalInsertionDirection =
-  | "from_left"
-  | "from_right"
-  | "from_top"
-  | "from_bottom"
-  | "from_above"
-  | "from_below"
-
-const insertionDirectionToCanonical: Record<
-  FootprintInsertionDirection,
-  CanonicalInsertionDirection
+/**
+ * Unit vectors for the directions that lie in the board plane. The Z-axis
+ * directions are handled separately because rotating a footprint within the
+ * board plane cannot change them.
+ */
+const inPlaneDirectionToVector: Record<
+  Exclude<InsertionDirection, "from_above" | "from_below">,
+  { x: number; y: number }
 > = {
-  from_left: "from_left",
-  from_right: "from_right",
-  from_top: "from_top",
-  from_bottom: "from_bottom",
-  from_below: "from_below",
-  from_front: "from_top",
-  from_back: "from_bottom",
-  from_above: "from_above",
-  from_x_neg: "from_left",
-  from_x_pos: "from_right",
-  from_y_pos: "from_top",
-  from_y_neg: "from_bottom",
-  from_z_pos: "from_above",
-  from_z_neg: "from_below",
-}
-
-const insertionDirectionToVector: Record<
-  CanonicalInsertionDirection,
-  { x: number; y: number; z: number }
-> = {
-  from_left: { x: -1, y: 0, z: 0 },
-  from_right: { x: 1, y: 0, z: 0 },
-  from_top: { x: 0, y: 1, z: 0 },
-  from_bottom: { x: 0, y: -1, z: 0 },
-  from_above: { x: 0, y: 0, z: 1 },
-  from_below: { x: 0, y: 0, z: -1 },
+  from_left: { x: -1, y: 0 },
+  from_right: { x: 1, y: 0 },
+  from_top: { x: 0, y: 1 },
+  from_bottom: { x: 0, y: -1 },
 }
 
 export const isFootprintFlipped = (params: {
@@ -50,26 +29,33 @@ export const isFootprintFlipped = (params: {
   return (componentLayer === "bottom") !== (originalLayer === "bottom")
 }
 
+/**
+ * Converts a footprint-frame insertion direction into board coordinates by
+ * applying the component's rotation and layer.
+ *
+ * Accepts either spelling the props enum allows and always returns one of the
+ * six canonical named directions.
+ */
 export const transformFootprintInsertionDirection = (params: {
   insertionDirection?: FootprintInsertionDirection
   rotationDegrees?: number
   isFlipped?: boolean
-}): PcbComponent["insertion_direction"] | undefined => {
+}): InsertionDirection | undefined => {
   const { insertionDirection, rotationDegrees = 0, isFlipped = false } = params
 
   if (!insertionDirection) return undefined
 
-  // Circuit JSON accepts deprecated direction names at input, but
-  // pcb_component.insertion_direction is written with the canonical names.
-  const canonicalDirection = insertionDirectionToCanonical[insertionDirection]
-  const baseVector = insertionDirectionToVector[canonicalDirection]
+  const direction = insertionDirectionToCanonical[insertionDirection]
 
-  // Z-axis insertion directions do not change when a footprint is rotated or
-  // mirrored in the PCB plane.
-  if (baseVector.z !== 0) {
-    return canonicalDirection
+  // Rotating a footprint within the board plane leaves a Z-axis insertion
+  // pointing along Z, but moving the part to the other layer means the mating
+  // part now approaches the board from the opposite side.
+  if (direction === "from_above" || direction === "from_below") {
+    if (!isFlipped) return direction
+    return direction === "from_above" ? "from_below" : "from_above"
   }
 
+  const baseVector = inPlaneDirectionToVector[direction]
   const angleRadians = (normalizeDegrees(rotationDegrees) * Math.PI) / 180
   const rotatedVector = {
     x:
@@ -87,8 +73,5 @@ export const transformFootprintInsertionDirection = (params: {
     return finalVector.x >= 0 ? "from_right" : "from_left"
   }
 
-  // `from_top` and `from_bottom` are canonical Circuit JSON values. The
-  // props package still types this field with the deprecated union, so the
-  // boundary cast keeps source compatibility while emitting the new values.
   return finalVector.y >= 0 ? "from_top" : "from_bottom"
 }

--- a/tests/components/normal-components/connector-accessible-orientation-warning.test.tsx
+++ b/tests/components/normal-components/connector-accessible-orientation-warning.test.tsx
@@ -16,7 +16,7 @@ test("connector emits accessible orientation warning when facing away from neare
           pin2: ["B"],
         }}
         footprint={
-          <footprint insertionDirection="from_back">
+          <footprint insertionDirection="from_bottom">
             <smtpad
               portHints={["pin1"]}
               pcbX={-1}

--- a/tests/components/normal-components/footprint-insertion-direction-bottom-layer-in-plane.test.tsx
+++ b/tests/components/normal-components/footprint-insertion-direction-bottom-layer-in-plane.test.tsx
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const inPlaneFootprint = (insertionDirection: any) => (
+  <footprint insertionDirection={insertionDirection}>
+    <smtpad
+      shape="rect"
+      portHints={["pin1"]}
+      pcbX={-1}
+      pcbY={0}
+      width={1}
+      height={1}
+    />
+    <smtpad
+      shape="rect"
+      portHints={["pin2"]}
+      pcbX={1}
+      pcbY={0}
+      width={1}
+      height={1}
+    />
+  </footprint>
+)
+
+test("bottom layer mirrors in-plane insertion directions across the X axis", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="60mm" height="20mm">
+      <chip
+        name="U1"
+        pcbX={-20}
+        pcbY={0}
+        layer="bottom"
+        footprint={inPlaneFootprint("from_left") as any}
+      />
+      <chip
+        name="U2"
+        pcbX={-5}
+        pcbY={0}
+        layer="bottom"
+        footprint={inPlaneFootprint("from_right") as any}
+      />
+      <chip
+        name="U3"
+        pcbX={10}
+        pcbY={0}
+        layer="bottom"
+        footprint={inPlaneFootprint("from_top") as any}
+      />
+      <chip
+        name="U4"
+        pcbX={22}
+        pcbY={0}
+        layer="bottom"
+        footprint={inPlaneFootprint("from_bottom") as any}
+      />
+    </board>,
+  )
+
+  circuit.render()
+  const circuitJson = circuit.getCircuitJson()
+
+  const getInsertionDirection = (name: string) => {
+    const sourceComponent = circuitJson.find(
+      (element: any) =>
+        element.type === "source_component" && element.name === name,
+    ) as any
+    const pcbComponent = circuitJson.find(
+      (element: any) =>
+        element.type === "pcb_component" &&
+        element.source_component_id === sourceComponent.source_component_id,
+    ) as any
+    return pcbComponent.insertion_direction
+  }
+
+  // Moving a footprint to the bottom layer mirrors it across the X axis, so
+  // the X-facing directions swap while the Y-facing directions are unchanged.
+  expect(getInsertionDirection("U1")).toBe("from_right")
+  expect(getInsertionDirection("U2")).toBe("from_left")
+  expect(getInsertionDirection("U3")).toBe("from_top")
+  expect(getInsertionDirection("U4")).toBe("from_bottom")
+})

--- a/tests/components/normal-components/footprint-insertion-direction-bottom-layer-z-axis.test.tsx
+++ b/tests/components/normal-components/footprint-insertion-direction-bottom-layer-z-axis.test.tsx
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const verticalFootprint = (insertionDirection: any) => (
+  <footprint insertionDirection={insertionDirection}>
+    <smtpad
+      shape="rect"
+      portHints={["pin1"]}
+      pcbX={-1}
+      pcbY={0}
+      width={1}
+      height={1}
+    />
+    <smtpad
+      shape="rect"
+      portHints={["pin2"]}
+      pcbX={1}
+      pcbY={0}
+      width={1}
+      height={1}
+    />
+  </footprint>
+)
+
+test("bottom layer inverts Z axis insertion directions", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="60mm" height="20mm">
+      <chip
+        name="U1"
+        pcbX={-15}
+        pcbY={0}
+        footprint={verticalFootprint("from_above") as any}
+      />
+      <chip
+        name="U2"
+        pcbX={0}
+        pcbY={0}
+        layer="bottom"
+        footprint={verticalFootprint("from_above") as any}
+      />
+      <chip
+        name="U3"
+        pcbX={15}
+        pcbY={0}
+        layer="bottom"
+        footprint={verticalFootprint("from_below") as any}
+      />
+    </board>,
+  )
+
+  circuit.render()
+  const circuitJson = circuit.getCircuitJson()
+
+  const getInsertionDirection = (name: string) => {
+    const sourceComponent = circuitJson.find(
+      (element: any) =>
+        element.type === "source_component" && element.name === name,
+    ) as any
+    const pcbComponent = circuitJson.find(
+      (element: any) =>
+        element.type === "pcb_component" &&
+        element.source_component_id === sourceComponent.source_component_id,
+    ) as any
+    return pcbComponent.insertion_direction
+  }
+
+  // A part on the bottom layer is rotated 180 degrees about the board's Y
+  // axis, so a mating part that approached from +Z now approaches from -Z.
+  expect(getInsertionDirection("U1")).toBe("from_above")
+  expect(getInsertionDirection("U2")).toBe("from_below")
+  expect(getInsertionDirection("U3")).toBe("from_above")
+})

--- a/tests/components/normal-components/footprint-insertion-direction-pcb-component.test.tsx
+++ b/tests/components/normal-components/footprint-insertion-direction-pcb-component.test.tsx
@@ -161,7 +161,9 @@ test("footprint insertionDirection populates pcb_component post-transform proper
 
   expect(getInsertionDirection("R1")).toBe("from_top")
   expect(getInsertionDirection("R2")).toBe("from_left")
-  expect(getInsertionDirection("R3")).toBe("from_bottom")
+  // R3 sits on the bottom layer with no rotation. Flipping mirrors the
+  // footprint across its X axis, which leaves a +Y insertion pointing at +Y.
+  expect(getInsertionDirection("R3")).toBe("from_top")
   expect(getInsertionDirection("R4")).toBe("from_left")
   expect(getInsertionDirection("J1")).toBe("from_top")
 })

--- a/tests/components/normal-components/footprint-insertion-direction-pcb-component.test.tsx
+++ b/tests/components/normal-components/footprint-insertion-direction-pcb-component.test.tsx
@@ -12,7 +12,7 @@ test("footprint insertionDirection populates pcb_component post-transform proper
         pcbX={5}
         pcbY={5}
         footprint={
-          <footprint insertionDirection="from_front">
+          <footprint insertionDirection="from_top">
             <smtpad
               shape="rect"
               portHints={["pin1"]}
@@ -39,7 +39,7 @@ test("footprint insertionDirection populates pcb_component post-transform proper
         pcbY={5}
         pcbRotation={90}
         footprint={
-          <footprint insertionDirection="from_front">
+          <footprint insertionDirection="from_top">
             <smtpad
               shape="rect"
               portHints={["pin1"]}
@@ -66,7 +66,7 @@ test("footprint insertionDirection populates pcb_component post-transform proper
         pcbY={5}
         layer="bottom"
         footprint={
-          <footprint insertionDirection="from_front">
+          <footprint insertionDirection="from_top">
             <smtpad
               shape="rect"
               portHints={["pin1"]}
@@ -94,7 +94,7 @@ test("footprint insertionDirection populates pcb_component post-transform proper
         pcbRotation={90}
         layer="bottom"
         footprint={
-          <footprint insertionDirection="from_front">
+          <footprint insertionDirection="from_top">
             <smtpad
               shape="rect"
               portHints={["pin1"]}
@@ -122,7 +122,7 @@ test("footprint insertionDirection populates pcb_component post-transform proper
         manufacturerPartNumber="TEST"
         pinLabels={{ pin1: ["A"], pin2: ["B"] }}
         footprint={
-          <footprint insertionDirection="from_front" originalLayer="bottom">
+          <footprint insertionDirection="from_top" originalLayer="bottom">
             <smtpad
               shape="rect"
               portHints={["pin1"]}
@@ -159,9 +159,9 @@ test("footprint insertionDirection populates pcb_component post-transform proper
     return pcbComponent?.insertion_direction
   }
 
-  expect(getInsertionDirection("R1") as string).toBe("from_top")
+  expect(getInsertionDirection("R1")).toBe("from_top")
   expect(getInsertionDirection("R2")).toBe("from_left")
-  expect(getInsertionDirection("R3") as string).toBe("from_bottom")
+  expect(getInsertionDirection("R3")).toBe("from_bottom")
   expect(getInsertionDirection("R4")).toBe("from_left")
-  expect(getInsertionDirection("J1") as string).toBe("from_top")
+  expect(getInsertionDirection("J1")).toBe("from_top")
 })

--- a/tests/enclosure/enclosure-fdm-box-usb-cutout.test.tsx
+++ b/tests/enclosure/enclosure-fdm-box-usb-cutout.test.tsx
@@ -24,7 +24,7 @@ test("generates an FDM enclosure and USB-C aperture with the enclosure solver", 
           allowOffBoard
           pinLabels={{ pin1: ["VBUS"], pin2: ["GND"] }}
           footprint={
-            <footprint insertionDirection="from_front">
+            <footprint insertionDirection="from_top">
               <smtpad
                 portHints={["pin1"]}
                 pcbX="-1.5mm"


### PR DESCRIPTION
Circuit JSON and props renamed the +/-Y insertion directions from "from_front"/"from_back" to "from_top"/"from_bottom" and added "from_below" (-Z). transformFootprintInsertionDirection now accepts either the named or the Cartesian spelling from props and always returns one of the six canonical named directions, which is what pcb_component.insertion_direction stores.

Also fixes the Z axis under a layer flip. "from_above" was previously returned unchanged for a flipped footprint, which had no better answer available while "from_below" did not exist. A part whose mating connector approaches from above is approached from below once the part is moved to the other layer, so the direction is now inverted along with the layer.