### PR TITLE
Recommend idiomatic identifiers for invalid pin labels

### DIFF
--- a/lib/utils/filterPinLabels.ts
+++ b/lib/utils/filterPinLabels.ts
@@ -31,8 +31,12 @@ export function filterPinLabels(
       if (isValidPinLabel(pin, label)) {
         validLabels.push(label)
       } else {
+        const recommendation = getPinLabelRecommendation(label)
+        const recommendationMessage = recommendation
+          ? ` Try using "${recommendation}" instead.`
+          : ""
         invalidPinLabelsMessages.push(
-          `Invalid pin label: ${pin} = '${label}' - excluding from component. Pin labels can only contain letters, numbers and underscores.`,
+          `Invalid pin label: ${pin} = '${label}' - excluding from component. Pin labels can only contain letters, numbers and underscores.${recommendationMessage}`,
         )
       }
     }
@@ -58,4 +62,28 @@ export function filterPinLabels(
  */
 function isValidPinLabel(_pin: string, label: string): boolean {
   return /^[A-Za-z0-9_]+$/.test(label)
+}
+
+/**
+ * Returns the preferred identifier for common power-rail pin labels that use
+ * punctuation. Pin labels are identifiers, so voltage values are written as
+ * V3_3, V5, etc. rather than 3.3V or +5V.
+ */
+export function getPinLabelRecommendation(label: string): string | undefined {
+  const decimalVoltage = label.match(/^\+?(\d+)\.(\d+)V(_\d+)?$/i)
+  if (decimalVoltage) {
+    return `V${decimalVoltage[1]}_${decimalVoltage[2]}${decimalVoltage[3] ?? ""}`
+  }
+
+  const splitVoltage = label.match(/^\+?(\d+)V(\d+)(_\d+)?$/i)
+  if (splitVoltage) {
+    return `V${splitVoltage[1]}_${splitVoltage[2]}${splitVoltage[3] ?? ""}`
+  }
+
+  const wholeVoltage = label.match(/^\+?(\d+)V(_\d+)?$/i)
+  if (wholeVoltage) {
+    return `V${wholeVoltage[1]}${wholeVoltage[2] ?? ""}`
+  }
+
+  return undefined
 }

--- a/lib/utils/schematic/parsePinNumberFromLabelsOrThrow.ts
+++ b/lib/utils/schematic/parsePinNumberFromLabelsOrThrow.ts
@@ -1,4 +1,13 @@
 import { getPinNumberFromPinLabelsKey } from "./getPinNumberFromPinLabelsKey"
+import { getPinLabelRecommendation } from "../filterPinLabels"
+
+const getInvalidPinLabelMessage = (pinNumberOrLabel: string): string => {
+  const recommendation = getPinLabelRecommendation(pinNumberOrLabel)
+  const recommendationMessage = recommendation
+    ? ` Try using "${recommendation}" instead.`
+    : ""
+  return `No pin labels provided and pin number or label is not a number: "${pinNumberOrLabel}".${recommendationMessage}`
+}
 
 export const parsePinNumberFromLabelsOrThrow = (
   pinNumberOrLabel: string | number,
@@ -20,9 +29,7 @@ export const parsePinNumberFromLabelsOrThrow = (
   }
 
   if (!pinLabels) {
-    throw new Error(
-      `No pin labels provided and pin number or label is not a number: "${pinNumberOrLabel}"`,
-    )
+    throw new Error(getInvalidPinLabelMessage(pinNumberOrLabel))
   }
 
   for (const pinNumberKey in pinLabels) {
@@ -41,7 +48,5 @@ export const parsePinNumberFromLabelsOrThrow = (
     }
   }
 
-  throw new Error(
-    `No pin labels provided and pin number or label is not a number: "${pinNumberOrLabel}"`,
-  )
+  throw new Error(getInvalidPinLabelMessage(pinNumberOrLabel))
 }

--- a/tests/components/normal-components/chip-invalid-pin.test.tsx
+++ b/tests/components/normal-components/chip-invalid-pin.test.tsx
@@ -33,3 +33,64 @@ test("chip with invalid pin should be skipped", async () => {
 
   expect(circuit).toMatchSchematicSnapshot(import.meta.path)
 })
+
+test("chip invalid power labels recommend idiomatic identifiers", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{
+          pin1: "3.3V",
+          pin2: "+3V3",
+          pin3: "+5V",
+        }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const warnings = circuit
+    .getCircuitJson()
+    .filter((el) => el.type === "source_property_ignored_warning")
+
+  expect(warnings).toHaveLength(3)
+  expect(warnings.map((warning) => warning.message)).toEqual([
+    expect.stringContaining('Try using "V3_3" instead.'),
+    expect.stringContaining('Try using "V3_3" instead.'),
+    expect.stringContaining('Try using "V5" instead.'),
+  ])
+})
+
+test("schematic arrangements recommend idiomatic identifiers for invalid power labels", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{
+          pin1: "3.3V",
+          pin2: "GND",
+        }}
+        schPinArrangement={{
+          leftSide: ["3.3V"],
+          rightSide: ["GND"],
+        }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit
+    .getCircuitJson()
+    .filter((el) => el.type === "source_failed_to_create_component_error")
+
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toContain('Try using "V3_3" instead.')
+})


### PR DESCRIPTION
## Summary

- recommend idiomatic `V3_3`, `V5`, and related identifiers for common voltage pin labels such as `3.3V`, `+3V3`, and `+5V`
- include the recommendation in both ignored-property warnings and schematic pin-label parse errors
- add regression coverage for chip pin labels and schematic arrangements

## Why

tscircuit pin identifiers only support letters, numbers, and underscores. Common module labels containing `+` or `.` were filtered out, and schematic arrangements could then fail with an opaque error. This can produce empty/black footprint renders when the component never finishes creating.

The new guidance maps common voltage forms to exact idiomatic identifiers, for example:

- `3.3V` or `+3V3` -> `V3_3`
- `+5V` -> `V5`

The actual voltage metadata remains unchanged; only the pin identifier recommendation is normalized.

## Verification

- `bun test tests/components/normal-components/chip-invalid-pin.test.tsx`
- `bun run build`
- `bunx tsc --noEmit`
