### PR TITLE
Document parsed props immutability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,5 +152,8 @@ circuit.selectOne("resistor") // Find first resistor
 
 ## IMPORTANT REVIEW RULES
 
-- Do not assign/change to _parsedProps or props
+- Treat `_parsedProps` and `props` as immutable user input. `_parsedProps` cannot
+  be modified inside a constructor or anywhere else. Use `resolve*`-style
+  functions for derived, normalized, or default values without modifying the
+  user input.
 - Do not add a ton of instance methods to classes, especially large classes like NormalComponent


### PR DESCRIPTION
## Summary

- clarify that `_parsedProps` and `props` are immutable user input
- explicitly forbid modifying `_parsedProps` in constructors or elsewhere
- recommend `resolve*`-style functions for derived, normalized, and default values

## Why

The existing review rule prohibited changing parsed props, but it did not call out constructor-time mutation or document the preferred pattern for resolving derived values. This makes that guidance explicit so user input remains unchanged.

## Impact

Documentation-only contributor guidance; there are no runtime behavior changes.

## Validation

- `git diff --check`