### PR TITLE
Map via-in-pad board prop to circuit JSON

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -521,6 +521,9 @@ export class Board
         y: point.y + (props.outlineOffsetY ?? 0) + outlineTranslation.y,
       })),
       material: props.material,
+      ...(props.isViaInPadAllowed !== undefined && {
+        is_via_in_pad_allowed: props.isViaInPadAllowed,
+      }),
       ...(props.solderMaskColor !== undefined && {
         solder_mask_color: props.solderMaskColor,
       }),

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
-    "@tscircuit/props": "^0.0.604",
+    "@tscircuit/props": "^0.0.605",
     "@tscircuit/schematic-match-adapt": "^0.0.18",
     "@tscircuit/schematic-trace-solver": "^0.0.117",
     "@tscircuit/solver-utils": "^0.0.16",

--- a/tests/components/normal-components/board-via-in-pad-allowed.test.tsx
+++ b/tests/components/normal-components/board-via-in-pad-allowed.test.tsx
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("board isViaInPadAllowed reaches the pcb_board", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(<board width={20} height={20} isViaInPadAllowed />)
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.pcb_board.list()[0]).toMatchObject({
+    is_via_in_pad_allowed: true,
+  })
+})


### PR DESCRIPTION
## Summary

- update `@tscircuit/props` to `^0.0.605`
- map `<board isViaInPadAllowed />` to `pcb_board.is_via_in_pad_allowed`
- preserve explicit `false` while omitting the field when the prop is absent
- add focused circuit-json output coverage

## Why

This completes the via-in-pad intent path from TSX to circuit JSON. The merged `@tscircuit/checks` rule can now distinguish intentional via-in-pad designs from violations by reading the board-level flag.

This PR leaves the existing circuit-json dev dependency unchanged to avoid overlapping the separate insertion-direction migration in #2975; the board field is serialized and retained by the core database as covered by the test.

## Validation

- `bun test tests/components/normal-components/board-via-in-pad-allowed.test.tsx`
- board normal-component suite (22 passing)
- `bunx tsc --noEmit`
- Biome formatting on touched files
- `bun run build`
- `bun run smoke-test:dist`
- `bunx @tscircuit/dependency-check`
- `git diff --check`