### PR TITLE
fix: normalize bounds Y axis when checking pcb primitive overlap

### DIFF
--- a/lib/components/primitive-components/Port/areAllPcbPrimitivesOverlapping.ts
+++ b/lib/components/primitive-components/Port/areAllPcbPrimitivesOverlapping.ts
@@ -5,14 +5,21 @@ export const areAllPcbPrimitivesOverlapping = (
 ): boolean => {
   if (pcbPrimitives.length <= 1) return true
 
-  // Get bounds of all primitives
+  // Get bounds of all primitives.
+  //
+  // `_getPcbCircuitJsonBounds()` is implemented with two opposite Y
+  // conventions across the codebase: Cutout, PlatedHole and SmtPad's
+  // rect/polygon shapes return top > bottom, while Via, PcbVia, Hole and
+  // SmtPad's circle/pill/rotated_* shapes return top < bottom. The overlap
+  // test below only holds for the first convention, so the axes are
+  // normalised here rather than assumed.
   const bounds = pcbPrimitives.map((p) => {
     const circuitBounds = p._getPcbCircuitJsonBounds()
     return {
-      left: circuitBounds.bounds.left,
-      right: circuitBounds.bounds.right,
-      top: circuitBounds.bounds.top,
-      bottom: circuitBounds.bounds.bottom,
+      left: Math.min(circuitBounds.bounds.left, circuitBounds.bounds.right),
+      right: Math.max(circuitBounds.bounds.left, circuitBounds.bounds.right),
+      top: Math.max(circuitBounds.bounds.top, circuitBounds.bounds.bottom),
+      bottom: Math.min(circuitBounds.bounds.top, circuitBounds.bounds.bottom),
     }
   })
 

--- a/tests/repros/repro169-circle-smtpad-overlap-y-convention.test.tsx
+++ b/tests/repros/repro169-circle-smtpad-overlap-y-convention.test.tsx
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("repro169: concentric circle pads sharing a portHint are treated as overlapping", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        pinLabels={{ pin1: "SIG" }}
+        footprint={
+          <footprint>
+            <smtpad
+              portHints={["pin1"]}
+              pcbX="0mm"
+              pcbY="0mm"
+              radius="0.5mm"
+              shape="circle"
+              layer="top"
+            />
+            <smtpad
+              portHints={["pin1"]}
+              pcbX="0mm"
+              pcbY="0mm"
+              radius="0.5mm"
+              shape="circle"
+              layer="bottom"
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  // The two pads are identical and concentric, so they cannot be
+  // "non-overlapping". Reporting them as such leaves the pin unroutable.
+  expect(circuit.db.source_ambiguous_port_reference.list()).toHaveLength(0)
+  expect(circuit.db.pcb_port.list()).toHaveLength(1)
+})


### PR DESCRIPTION
A `<chip>` whose footprint has two concentric `<smtpad shape="circle">` sharing a
`portHints` gets no `pcb_port` and emits a `source_ambiguous_port_reference`:

```
U1.pin1 is ambiguous: U1.pin1 references multiple non-overlapping pads
```

The two pads are identical and at the same coordinates, so "non-overlapping" cannot be
right. The pin ends up unroutable on the PCB.

### Cause

`_getPcbCircuitJsonBounds()` is implemented with two opposite Y conventions, and the split
runs across the codebase rather than within one component:

| `top > bottom` (Y up) | `top < bottom` (Y down) |
|---|---|
| `Cutout` — carries the comment `// Assuming Y is up` | `Via` |
| `PlatedHole` | `PcbVia` |
| `SmtPad` — `rect`, `polygon` | `Hole` |
| | `SmtPad` — `circle`, `pill`, `rotated_rect`, `rotated_pill` |

`areAllPcbPrimitivesOverlapping` assumes the first:

```ts
overlaps[i][j] = !(
  a.right < b.left ||
  a.left > b.right ||
  a.bottom > b.top ||   // needs bottom <= top
  a.top < b.bottom      // needs top >= bottom
)
```

For a Y-down primitive those two conditions cannot both be satisfied. Taking two identical
circles of radius `r` at the same point: `top = y − r`, `bottom = y + r`, so
`a.bottom > b.top` reduces to `y + r > y − r`, which is true for any positive radius. The
negation makes `overlaps` **false for a primitive compared against a copy of itself**.

So this is not specific to circular pads — it applies to any port whose primitives use the
Y-down convention, which includes `Via`, `PcbVia` and `Hole`.

### Fix

Normalizing the axes in the consumer rather than in one producer, since seven primitive
shapes across four files are affected and the ordering was never part of the contract:

```ts
left: Math.min(circuitBounds.bounds.left, circuitBounds.bounds.right),
right: Math.max(circuitBounds.bounds.left, circuitBounds.bounds.right),
top: Math.max(circuitBounds.bounds.top, circuitBounds.bounds.bottom),
bottom: Math.min(circuitBounds.bounds.top, circuitBounds.bounds.bottom),
```

I did consider flipping `SmtPad`'s four shapes to the Y-up convention instead. It is the
tidier change in isolation, but it would leave `Via`, `PcbVia` and `Hole` still broken for
this consumer, and `_getPcbCircuitJsonBounds()` has many other callers
(`NormalComponent_doInitialSilkscreenOverlapAdjustment`, `Footprint`, `CadModel`,
`getCenterOfPcbPrimitives`) that would need auditing before changing what those shapes
return. Happy to do that as a follow-up if you would rather converge on one convention —
this PR is scoped to stop the incorrect result.

### Verification

On `34ad34f` (v0.0.1581), before the change, with a parametrised version of the new test:

```
rect    -> pcb_port=1  ambiguous=0   (passes)
circle  -> pcb_port=0  ambiguous=1   (fails)
pill    -> pcb_port=0  ambiguous=1   (fails)
```

After the change:

- `tests/repros/repro169-circle-smtpad-overlap-y-convention.test.tsx` — new, passes
- `tests/repros/repro109-non-overlapping-composite-pin-ambiguous.test.tsx` and `tests/drc/`
  — 20 pass, 0 fail
- `bunx tsc --noEmit` — 0 errors
- `biome format` with the repo's pinned 1.9.4 — no fixes needed on either file

One note in case it saves someone else the detour: `bun run format` reformatted 1,629 files
here, including `biome.json`. `bunx biome` resolves to a newer Biome than the 1.9.4 in
`node_modules`. I reverted all of it and formatted only the two files with the pinned
binary, so this diff is just the change.

---

<sub>Written with AI assistance (Claude Opus 5 via Claude Code). I reproduced the failure
and ran the tests, typecheck and formatter myself, and I am responsible for the change as
submitted.</sub>
