### PR TITLE
Speed up CI test plan

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node: [1, 2, 3, 4]
+        node: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:
       - name: Checkout code
@@ -27,6 +27,8 @@ jobs:
         run: bun install
 
       - name: Generate test plans
+        env:
+          TEST_PLAN_NODE_COUNT: ${{ strategy.job-total }}
         run: bun run scripts/generate-test-plan.ts
 
       - name: Run tests for node ${{ matrix.node }}

--- a/scripts/generate-test-plan.ts
+++ b/scripts/generate-test-plan.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { writeFileSync, mkdirSync } from "fs"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { Glob } from "bun"
 
 interface TestMatrix {
@@ -8,9 +8,26 @@ interface TestMatrix {
   globPatterns: string[]
 }
 
+const DEFAULT_NODE_COUNT = 4
+const TEST_PLAN_DIRECTORY = ".github/test-plans"
+
+function getNodeCount(): number {
+  const configuredNodeCount = process.env.TEST_PLAN_NODE_COUNT
+  if (!configuredNodeCount) return DEFAULT_NODE_COUNT
+
+  const nodeCount = Number(configuredNodeCount)
+  if (!Number.isInteger(nodeCount) || nodeCount < 1) {
+    throw new Error(
+      `TEST_PLAN_NODE_COUNT must be a positive integer, received: ${configuredNodeCount}`,
+    )
+  }
+
+  return nodeCount
+}
+
 // Configuration for test matrix
 const TEST_MATRIX: TestMatrix = {
-  nodeCount: 4,
+  nodeCount: getNodeCount(),
   globPatterns: [
     "tests/components/normal-components/**/*.test.tsx",
     "tests/components/primitive-components/**/*.test.tsx",
@@ -79,9 +96,10 @@ function generateTestPlans() {
 
   // Write test plans to files
   console.log(`\n📝 Writing test plans for ${TEST_MATRIX.nodeCount} nodes...`)
-  mkdirSync(".github/test-plans", { recursive: true })
+  rmSync(TEST_PLAN_DIRECTORY, { recursive: true, force: true })
+  mkdirSync(TEST_PLAN_DIRECTORY, { recursive: true })
   for (let i = 0; i < TEST_MATRIX.nodeCount; i++) {
-    const planFile = `.github/test-plans/node${i + 1}-testplan.txt`
+    const planFile = `${TEST_PLAN_DIRECTORY}/node${i + 1}-testplan.txt`
     const content = nodePlans[i].join("\n")
     writeFileSync(planFile, content, "utf8")
     console.log(`  ${planFile}: ${nodePlans[i].length} tests`)


### PR DESCRIPTION
## Summary

- expand the Bun test matrix from 4 to 10 parallel shards
- derive the generated test-plan count from GitHub's matrix job total
- preserve the existing 4-shard default for snapshot workflows
- validate configured shard counts and remove stale generated plans before regeneration

## Why

The test suite has grown to 1,117 files. Recent CI runs spend roughly 192 seconds in the slowest 4-shard test job, while checkout and dependency installation take only about 10–15 seconds per runner.

Replaying the current test timings through the existing planner showed a critical test time of about 80 seconds with 10 shards. This is the practical cost/runtime knee: roughly 55% lower end-to-end latency for about 15% more aggregate runner time. Moving from 10 to 12 shards only saved about another 8 seconds.

## Impact

PR and main-branch test feedback should arrive substantially sooner. Snapshot update workflows continue using their existing 4-way behavior unless they explicitly configure another node count.

## Validation

- generated 10 plans covering all 1,117 test files exactly once
- confirmed the default still generates 4 plans
- confirmed invalid node counts are rejected
- parsed the updated workflow as YAML
- ran the repository's pinned Biome formatter
- ran `git diff --check`
