### PR TITLE
fix: report empty connections targets instead of crashing the render (#2865)

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -163,6 +163,7 @@ export class NormalComponent<
   _hasStartedSupplierFootprintMismatchWarningCheck = false
   _hasInflatedCircuitJsonSymbol = false
   private _invalidFootprintPropMessages: string[] = []
+  private _invalidConnectionsPropMessages: string[] = []
 
   _invalidPinLabelMessages: string[] = []
   _impliedFootprintPinLabels?: Record<string, string | string[]>
@@ -2125,15 +2126,35 @@ export class NormalComponent<
       for (const [pinName, target] of Object.entries(props.connections)) {
         const targets = Array.isArray(target) ? target : [target]
         for (const targetPath of targets) {
+          const selector = String(targetPath)
+          if (selector.trim() === "") {
+            const message = `${this.getString()} has an empty connections target for pin "${pinName}". Provide a selector such as ".R1 > .pin1" or "net.VCC", or remove the entry.`
+            if (!this._invalidConnectionsPropMessages.includes(message)) {
+              this._invalidConnectionsPropMessages.push(message)
+            }
+            continue
+          }
           this.add(
             new Trace({
               from: `.${this.name} > .${pinName}`,
-              to: String(targetPath),
+              to: selector,
             }),
           )
         }
       }
     }
+  }
+
+  private _insertInvalidConnectionsPropErrors(): void {
+    for (const message of this._invalidConnectionsPropMessages) {
+      this.root!.db.source_invalid_component_property_error.insert({
+        source_component_id: this.source_component_id || "",
+        property_name: "connections",
+        message,
+        error_type: "source_invalid_component_property_error",
+      })
+    }
+    this._invalidConnectionsPropMessages = []
   }
 
   doInitialSourceDesignRuleChecks(): void {
@@ -2142,6 +2163,7 @@ export class NormalComponent<
 
   doInitialSourceComponentPropertyValidation(): void {
     this._insertInvalidFootprintPropErrors()
+    this._insertInvalidConnectionsPropErrors()
   }
 
   doInitialValidatePcbCoordinates(): void {

--- a/tests/components/normal-components/empty-connections-target.test.tsx
+++ b/tests/components/normal-components/empty-connections-target.test.tsx
@@ -1,0 +1,121 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("empty connections target reports an error instead of crashing the render", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <capacitor
+        name="C1"
+        capacitance="1uF"
+        footprint="0402"
+        connections={{ pin1: "", pin2: ".R1 > .pin1" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_invalid_component_property_error
+    .list()
+    .filter((e) => e.property_name === "connections")
+
+  // NOTE: the component id in getString() comes from a process-global counter
+  // (see tscircuit/core#2848), so assert on the message content rather than
+  // snapshotting it.
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toContain('name=".C1"')
+  expect(errors[0].message).toContain(
+    'has an empty connections target for pin "pin1"',
+  )
+  expect(errors[0].message).toContain(
+    'Provide a selector such as ".R1 > .pin1" or "net.VCC", or remove the entry.',
+  )
+
+  // the rest of the board still renders
+  expect(circuit.db.source_component.list().map((c) => c.name)).toEqual([
+    "R1",
+    "C1",
+  ])
+
+  // the sibling valid connection still produces its trace
+  expect(circuit.db.source_trace.list()).toHaveLength(1)
+})
+
+test("whitespace-only connections target is treated as empty", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <capacitor
+        name="C1"
+        capacitance="1uF"
+        footprint="0402"
+        connections={{ pin1: "   " }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_invalid_component_property_error
+    .list()
+    .filter((e) => e.property_name === "connections")
+
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toContain('empty connections target for pin "pin1"')
+})
+
+test("an empty entry in an array connections target is reported", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <capacitor
+        name="C1"
+        capacitance="1uF"
+        footprint="0402"
+        connections={{ pin1: [".R1 > .pin1", ""] }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_invalid_component_property_error
+    .list()
+    .filter((e) => e.property_name === "connections")
+
+  expect(errors).toHaveLength(1)
+  // the valid entry in the same array still connects
+  expect(circuit.db.source_trace.list()).toHaveLength(1)
+})
+
+test("valid connections are unaffected", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <capacitor
+        name="C1"
+        capacitance="1uF"
+        footprint="0402"
+        connections={{ pin1: ".R1 > .pin2", pin2: ".R1 > .pin1" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(
+    circuit.db.source_invalid_component_property_error
+      .list()
+      .filter((e) => e.property_name === "connections"),
+  ).toHaveLength(0)
+  expect(circuit.db.source_trace.list()).toHaveLength(2)
+})


### PR DESCRIPTION
Fixes #2865

### Problem

An empty string in `connections` aborted the **entire render** with a raw CSS-parser error that named neither the component nor the pin:

```tsx
<capacitor
  name="C1"
  capacitance="1uF"
  footprint="0402"
  connections={{ pin1: "", pin2: ".R1 > .pin1" }}
/>
```

```
error: Expected name, found .
  at getName (node_modules/css-what/lib/commonjs/parse.js:95:23)
  at selectOne (lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts:1257:18)
  at resolveImplicitSinglePort (lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts:29:47)
```

Two things were wrong:

1. **The message wasn't actionable.** `Expected name, found .` is `css-what` internals. Reading it, the natural guess is that `.R1 > .pin1` — the one target that is actually fine — is malformed.
2. **It took the whole board down.** Because it was a thrown exception rather than a recorded error, the sibling valid connection, the other components and every downstream phase never ran. One typo in one prop produced zero output.

### Cause

`_createTracesFromConnectionsProp()` forwarded every entry of `props.connections` straight into a `Trace`'s `to`. An empty string isn't a selector, but nothing rejected it, so `to: ""` reached `selectOne` and `css-what` threw several layers below the prop the user actually wrote.

### Change

Skip empty and whitespace-only targets, and record a `source_invalid_component_property_error` naming the component and the pin:

```
<capacitor#13 name=".C1" /> has an empty connections target for pin "pin1".
Provide a selector such as ".R1 > .pin1" or "net.VCC", or remove the entry.
```

This follows the existing `_insertInvalidFootprintPropErrors` pattern: the message is collected during `CreateTracesFromProps` and inserted during `SourceComponentPropertyValidation`, because `source_component_id` does not exist yet at the earlier phase (phase 24 vs 32).

After the change, the board renders, both components appear, and the sibling `pin2` connection still produces its `source_trace`.

### Scope

- Only **empty and whitespace-only** targets are treated as misconfigured. A non-empty but unresolvable selector (e.g. `".R9 > .pin1"` where R9 doesn't exist) already has its own downstream handling and is deliberately untouched.
- The check sits in `_createTracesFromConnectionsProp`, so it covers both the string and array forms of a `connections` entry.
- Rejecting `""` at the props-schema level in `tscircuit/props` would catch it earlier, but that's a cross-repo change with a wider blast radius. Happy to follow up there if you'd prefer that instead.

### Regression risk

Low by construction: the only behaviour that changes is for input that **previously threw**, so no existing passing test could have depended on it.

### Verification

- New `tests/components/normal-components/empty-connections-target.test.tsx` — 4 tests covering the empty string, whitespace-only, an empty entry inside an array target, and valid connections being unaffected
- `bun test connections` — 22 pass / 0 fail
- `bun test tests/components/trace` — 14 pass / 0 fail
- `bun run format` — clean

The assertions deliberately avoid snapshotting the component id, since `getString()` embeds a process-global counter (#2848).