### PR TITLE
fix: report a trace that connects a port to itself (#2859)

### DIFF
--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -268,6 +268,20 @@ export class Trace
 
     if (!allPortsFound) return
 
+    const distinctPortIds = new Set(ports.map((p) => p.port.source_port_id))
+    if (ports.length > 1 && distinctPortIds.size === 1) {
+      const subcircuit = this.getSubcircuit()
+      db.source_trace_not_connected_error.insert({
+        error_type: "source_trace_not_connected_error",
+        message: `${this.getString()} connects a port to itself; both ends resolve to the same port. Did you mean to connect two different pins?`,
+        subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
+        source_group_id: subcircuit?.getGroup()?.source_group_id ?? undefined,
+        selectors_not_found: [],
+      })
+      this._couldNotFindPort = true
+      return
+    }
+
     this._traceConnectionHash = this._computeTraceConnectionHash()
 
     const existingTraces = db.source_trace.list()

--- a/tests/components/trace/self-connecting-trace.test.tsx
+++ b/tests/components/trace/self-connecting-trace.test.tsx
@@ -1,0 +1,73 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("a trace connecting a port to itself reports an error", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <trace from=".R1 > .pin1" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_trace_not_connected_error.list()
+  expect(errors).toHaveLength(1)
+  // the component id embeds a process-global counter (#2848), so match on content
+  expect(errors[0].message).toContain("connects a port to itself")
+  expect(errors[0].message).toContain("both ends resolve to the same port")
+
+  // no duplicate-port source_trace is emitted
+  expect(circuit.db.source_trace.list()).toHaveLength(0)
+})
+
+test("a trace between two different pins of the same component is unaffected", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <trace from=".R1 > .pin1" to=".R1 > .pin2" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_trace_not_connected_error.list()).toHaveLength(0)
+  expect(circuit.db.source_trace.list()).toHaveLength(1)
+})
+
+test("a normal trace between two components is unaffected", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-4} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={4} />
+      <trace from=".R1 > .pin1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_trace_not_connected_error.list()).toHaveLength(0)
+  expect(circuit.db.source_trace.list()).toHaveLength(1)
+})
+
+test("a trace from a port to a net is unaffected", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <trace from=".R1 > .pin1" to="net.VCC" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_trace_not_connected_error.list()).toHaveLength(0)
+  expect(circuit.db.source_trace.list()).toHaveLength(1)
+})


### PR DESCRIPTION
Fixes #2859

### Problem

A trace whose two ends resolve to the **same port** was accepted silently:

```tsx
<resistor name="R1" resistance="1k" footprint="0402" />
<trace from=".R1 > .pin1" to=".R1 > .pin1" />
```

```
source_trace.connected_source_port_ids  ["source_port_0", "source_port_0"]
errors                                   0
```

The trace connects nothing, but still produced a `source_trace` listing the same port twice — a connection record that can never be routed and can't mean anything electrically.

The only feedback was a `source_pin_missing_trace_warning` for the *other* pin, which actively points away from the real mistake.

`from=".R1 > .pin1" to=".R1 > .pin1"` is a copy-paste slip — you edit one selector and forget the other. It looks connected in the source and renders without complaint, so the missing connection only surfaces much later.

Every neighbouring case is already diagnosed properly:

- unknown component → `Could not find port for selector ...`
- unknown pin → `... does not have pin "NOPE"`
- unnamed trace → `... is missing a name`

A self-connection was the one malformed trace with no message.

### Change

In `doInitialSourceTraceRender`, after the ports resolve, detect when more than one selector resolved to a single distinct `source_port_id` and emit the existing `source_trace_not_connected_error`:

```
<trace#13(from:.R1 > .pin1 to:.R1 > .pin1) /> connects a port to itself;
both ends resolve to the same port. Did you mean to connect two different pins?
```

The duplicate-port `source_trace` is no longer inserted.

### Cases deliberately NOT flagged

Each of these is checked by a test in this PR:

- `<trace from=".R1 > .pin1" to="net.VCC" />` — resolves to one port plus a net, so the check can't fire. Normal.
- `<trace from=".R1 > .pin1" to=".R1 > .pin2" />` — two different pins of the same component. Normal.
- Both pins of a part joined to the same net — unusual but a real circuit (a jumper/link), and not reachable by this check.
- Duplicate identical traces — already deduplicated by the existing connection-hash lookup, which runs after this check.

### Verification

- New `tests/components/trace/self-connecting-trace.test.tsx` — 4 tests (the self-connection, plus the three non-cases above)
- `bun test` — **1338 pass / 0 fail** across 1375 tests, identical to `main`
- `bun test tests/components/trace` — 18 pass / 0 fail
- `bun test connections` — 18 pass / 0 fail
- `bunx tsc --noEmit` — clean
- `bun run format` — clean

The test asserts on message content rather than snapshotting, since `getString()` embeds a process-global counter (#2848).