### PR TITLE
Update autorouter to v0.0.750

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
-    "@tscircuit/capacity-autorouter": "^0.0.748",
+    "@tscircuit/capacity-autorouter": "^0.0.750",
     "@tscircuit/checks": "0.0.151",
     "@tscircuit/circuit-json-util": "^0.0.104",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## What changed

- Bump `@tscircuit/capacity-autorouter` from `^0.0.748` to `^0.0.750`.

## Why

Version 0.0.750 includes the post-processing solver fallback update, allowing the autorouter to preserve non-ideal fallback output when post-processing cannot produce the ideal route.

## Impact

Core consumers now use the latest autorouter behavior without any Circuit JSON snapshot changes in the existing suite.

## Validation

- `bun test` — 1,335 passed, 37 skipped, 0 failed
- `bunx tsc --noEmit`
- `bun run build`
