### PR TITLE
Fix four-pin crystal trace length propagation

### DIFF
--- a/lib/components/normal-components/Crystal.ts
+++ b/lib/components/normal-components/Crystal.ts
@@ -8,14 +8,13 @@ import { formatSiUnit } from "format-si-unit"
 import { type BaseSymbolName, type Ftype } from "lib/utils/constants"
 import { NormalComponent } from "../base-components/NormalComponent/NormalComponent"
 
-type CrystalPorts = CrystalPinLabels
+type CrystalPorts = CrystalPinLabels | "X1" | "X2"
 type SourcePortId = SourcePort["source_port_id"]
 type SubcircuitConnectivityMapKey = NonNullable<
   SourceTrace["subcircuit_connectivity_map_key"]
 >
 
 const DEFAULT_CRYSTAL_MAX_TRACE_LENGTH_MM = 10
-const CRYSTAL_SIGNAL_PORT_LABELS = new Set(["x1", "x2"])
 
 export class Crystal extends NormalComponent<
   typeof crystalProps,
@@ -94,14 +93,12 @@ export class Crystal extends NormalComponent<
     const crystalSignalConnectivityMapKeys =
       new Set<SubcircuitConnectivityMapKey>()
 
-    for (const sourcePort of db.source_port.list()) {
-      if (sourcePort.source_component_id !== this.source_component_id) continue
-      const isCrystalSignalPort = sourcePort.port_hints?.some((portLabel) =>
-        CRYSTAL_SIGNAL_PORT_LABELS.has(portLabel.toLowerCase()),
-      )
-      if (!isCrystalSignalPort) continue
+    for (const signalPort of [this.portMap.X1, this.portMap.X2]) {
+      if (!signalPort.source_port_id) continue
+      const sourcePort = db.source_port.get(signalPort.source_port_id)
+      if (!sourcePort) continue
 
-      crystalSignalSourcePortIds.add(sourcePort.source_port_id)
+      crystalSignalSourcePortIds.add(signalPort.source_port_id)
       if (sourcePort.subcircuit_connectivity_map_key) {
         crystalSignalConnectivityMapKeys.add(
           sourcePort.subcircuit_connectivity_map_key,

--- a/lib/components/normal-components/Crystal.ts
+++ b/lib/components/normal-components/Crystal.ts
@@ -89,15 +89,23 @@ export class Crystal extends NormalComponent<
     const { db } = this.root!
     const maximumTraceLength =
       this._parsedProps.maxTraceLength ?? DEFAULT_CRYSTAL_MAX_TRACE_LENGTH_MM
-    const crystalSourcePortIds = new Set<SourcePortId>()
-    const crystalConnectivityMapKeys = new Set<SubcircuitConnectivityMapKey>()
+    const crystalSignalSourcePortIds = new Set<SourcePortId>()
+    const crystalSignalConnectivityMapKeys =
+      new Set<SubcircuitConnectivityMapKey>()
 
     for (const sourcePort of db.source_port.list()) {
       if (sourcePort.source_component_id !== this.source_component_id) continue
+      if (
+        this._parsedProps.pinVariant === "four_pin" &&
+        sourcePort.pin_number !== 1 &&
+        sourcePort.pin_number !== 3
+      ) {
+        continue
+      }
 
-      crystalSourcePortIds.add(sourcePort.source_port_id)
+      crystalSignalSourcePortIds.add(sourcePort.source_port_id)
       if (sourcePort.subcircuit_connectivity_map_key) {
-        crystalConnectivityMapKeys.add(
+        crystalSignalConnectivityMapKeys.add(
           sourcePort.subcircuit_connectivity_map_key,
         )
       }
@@ -106,11 +114,11 @@ export class Crystal extends NormalComponent<
     for (const sourceTrace of db.source_trace.list()) {
       const isDirectlyConnectedToCrystal =
         sourceTrace.connected_source_port_ids.some((sourcePortId) =>
-          crystalSourcePortIds.has(sourcePortId),
+          crystalSignalSourcePortIds.has(sourcePortId),
         )
       const isOnCrystalNet =
         sourceTrace.subcircuit_connectivity_map_key !== undefined &&
-        crystalConnectivityMapKeys.has(
+        crystalSignalConnectivityMapKeys.has(
           sourceTrace.subcircuit_connectivity_map_key,
         )
 

--- a/lib/components/normal-components/Crystal.ts
+++ b/lib/components/normal-components/Crystal.ts
@@ -15,6 +15,7 @@ type SubcircuitConnectivityMapKey = NonNullable<
 >
 
 const DEFAULT_CRYSTAL_MAX_TRACE_LENGTH_MM = 10
+const CRYSTAL_SIGNAL_PORT_LABELS = new Set(["x1", "x2"])
 
 export class Crystal extends NormalComponent<
   typeof crystalProps,
@@ -39,14 +40,14 @@ export class Crystal extends NormalComponent<
     const additionalAliases: Record<`pin${number}`, string[]> =
       this.props.pinVariant === "four_pin"
         ? {
-            pin1: ["left1", "1"],
+            pin1: ["left1", "1", "X1"],
             pin2: ["top1", "2", "gnd1"],
-            pin3: ["right1", "3"],
+            pin3: ["right1", "3", "X2"],
             pin4: ["bottom1", "4", "gnd2"],
           }
         : {
-            pin1: ["pos", "left"],
-            pin2: ["neg", "right"],
+            pin1: ["pos", "left", "X1"],
+            pin2: ["neg", "right", "X2"],
           }
 
     super.initPorts({
@@ -95,13 +96,10 @@ export class Crystal extends NormalComponent<
 
     for (const sourcePort of db.source_port.list()) {
       if (sourcePort.source_component_id !== this.source_component_id) continue
-      if (
-        this._parsedProps.pinVariant === "four_pin" &&
-        sourcePort.pin_number !== 1 &&
-        sourcePort.pin_number !== 3
-      ) {
-        continue
-      }
+      const isCrystalSignalPort = sourcePort.port_hints?.some((portLabel) =>
+        CRYSTAL_SIGNAL_PORT_LABELS.has(portLabel.toLowerCase()),
+      )
+      if (!isCrystalSignalPort) continue
 
       crystalSignalSourcePortIds.add(sourcePort.source_port_id)
       if (sourcePort.subcircuit_connectivity_map_key) {

--- a/tests/components/normal-components/crystal-four-pin-trace-length.test.tsx
+++ b/tests/components/normal-components/crystal-four-pin-trace-length.test.tsx
@@ -37,8 +37,8 @@ test("four-pin crystal maximum trace length only applies to signal pins", async 
         pcbX={20}
         pcbY={0}
       />
-      <trace from=".Y1 > .pin1" to=".C_XIN > .pin1" />
-      <trace from=".Y1 > .pin3" to=".C_XOUT > .pin1" />
+      <trace from=".Y1 > .X1" to=".C_XIN > .pin1" />
+      <trace from=".Y1 > .X2" to=".C_XOUT > .pin1" />
       <trace from=".Y1 > .pin2" to="net.GND" />
       <trace from=".Y1 > .pin4" to="net.GND" />
       <trace from=".R_GND > .pin1" to="net.GND" />
@@ -54,8 +54,8 @@ test("four-pin crystal maximum trace length only applies to signal pins", async 
         .map((trace) => [trace.display_name, trace.max_length]),
     ),
   ).toEqual({
-    ".Y1 > .pin1 to .C_XIN > .pin1": 10,
-    ".Y1 > .pin3 to .C_XOUT > .pin1": 10,
+    ".Y1 > .X1 to .C_XIN > .pin1": 10,
+    ".Y1 > .X2 to .C_XOUT > .pin1": 10,
     ".Y1 > .pin2 to net.GND": undefined,
     ".Y1 > .pin4 to net.GND": undefined,
     ".R_GND > .pin1 to net.GND": undefined,

--- a/tests/components/normal-components/crystal-four-pin-trace-length.test.tsx
+++ b/tests/components/normal-components/crystal-four-pin-trace-length.test.tsx
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("four-pin crystal maximum trace length only applies to signal pins", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="50mm" height="20mm">
+      <net name="GND" isGroundNet />
+      <crystal
+        name="Y1"
+        frequency="12MHz"
+        loadCapacitance="10pF"
+        pinVariant="four_pin"
+        pcbX={0}
+        pcbY={0}
+        footprint="crystal"
+      />
+      <capacitor
+        name="C_XIN"
+        capacitance="10pF"
+        footprint="0402"
+        pcbX={-5}
+        pcbY={0}
+      />
+      <capacitor
+        name="C_XOUT"
+        capacitance="10pF"
+        footprint="0402"
+        pcbX={5}
+        pcbY={0}
+      />
+      <resistor
+        name="R_GND"
+        resistance="1k"
+        footprint="0402"
+        pcbX={20}
+        pcbY={0}
+      />
+      <trace from=".Y1 > .pin1" to=".C_XIN > .pin1" />
+      <trace from=".Y1 > .pin3" to=".C_XOUT > .pin1" />
+      <trace from=".Y1 > .pin2" to="net.GND" />
+      <trace from=".Y1 > .pin4" to="net.GND" />
+      <trace from=".R_GND > .pin1" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(
+    Object.fromEntries(
+      circuit.db.source_trace
+        .list()
+        .map((trace) => [trace.display_name, trace.max_length]),
+    ),
+  ).toEqual({
+    ".Y1 > .pin1 to .C_XIN > .pin1": 10,
+    ".Y1 > .pin3 to .C_XOUT > .pin1": 10,
+    ".Y1 > .pin2 to net.GND": undefined,
+    ".Y1 > .pin4 to net.GND": undefined,
+    ".R_GND > .pin1 to net.GND": undefined,
+  })
+
+  expect(circuit.db.pcb_trace.list()).toHaveLength(4)
+  expect(circuit.db.pcb_autorouting_error.list()).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary

- expose semantic `X1` and `X2` labels on crystal signal ports
- propagate a crystal's maximum trace length through those typed semantic ports
- keep GND-connected crystal ports and the wider ground network unconstrained
- add a routed regression test using the standard `footprint="crystal"`

## Root cause

`Crystal.doInitialSourceDesignRuleChecks` collected every source port belonging to a crystal. For a four-pin crystal, that included the two case/ground ports. Because those ports shared the board-wide GND connectivity map, the crystal's default 10 mm maximum trace length propagated to unrelated GND traces.

The autorouter's precheck then rejected otherwise valid boards whenever distant GND endpoints were more than 10 mm apart.

## Fix

Crystal signal ports carry the semantic labels `X1` and `X2`, included in the component's typed port map. Trace-length propagation now starts directly from `this.portMap.X1` and `this.portMap.X2`. It does not inspect physical pin numbers or scan raw port-hint strings.

Physical pin-to-role mapping remains only in `initPorts`, where a component's package pinout belongs. The design-rule behavior depends solely on the semantic signal roles.

## Impact

RP2040 and other designs using four-pin crystals can route normally without adding an artificial large `maxLength` workaround. The oscillator traces still retain the intended short-trace constraint.

## Validation

- focused four-pin crystal routing regression: pass
- all related crystal tests: 7 pass
- TypeScript `--noEmit`: pass
- Biome check: pass
- regression connects through `X1`/`X2`, asserts exactly 4 PCB traces, and asserts zero `pcb_autorouting_error` records
