### PR TITLE
Clarify differential pair ambiguity warnings

### DIFF
--- a/lib/components/primitive-components/DifferentialPair_doInitialSourceDesignRuleChecks.ts
+++ b/lib/components/primitive-components/DifferentialPair_doInitialSourceDesignRuleChecks.ts
@@ -7,7 +7,7 @@ type SourceComponentId = NonNullable<SourcePort["source_component_id"]>
 
 type ResolvedPointToPointConnection = {
   sourcePorts: SourcePort[]
-  referenceKind: "trace" | "selector"
+  sourceTraceName?: string
 }
 
 const resolvePointToPointConnection = (
@@ -54,10 +54,10 @@ const resolvePointToPointConnection = (
       (sourcePort) =>
         sourcePort.subcircuit_connectivity_map_key === connectivityMapKey,
     )
-
   return {
     sourcePorts,
-    referenceKind: matchingSourceTraces.length > 0 ? "trace" : "selector",
+    sourceTraceName:
+      matchingSourceTraces.length > 0 ? connectionSelector : undefined,
   }
 }
 
@@ -88,22 +88,23 @@ const getPointToPointWarningMessage = ({
   differentialPairName,
   connectionPolarity,
   connectionSelector,
-  referenceKind,
+  sourceTraceName,
   terminalPinSelectors,
 }: {
   differentialPairName: string
   connectionPolarity: ConnectionPolarity
   connectionSelector: string
-  referenceKind: ResolvedPointToPointConnection["referenceKind"]
+  sourceTraceName?: string
   terminalPinSelectors: string[]
 }): string => {
-  const terminalCount = terminalPinSelectors.length
-  const pinOrPins = terminalCount === 1 ? "terminal pin" : "terminal pins"
   const terminalList = formatTerminalPinList(terminalPinSelectors)
   const terminalListDescription = terminalList ? `: ${terminalList}` : ""
-  const problem = terminalCount > 2 ? "ambiguous" : "not point-to-point"
 
-  return `Differential pair "${differentialPairName}" ${connectionPolarity}Connection references ${referenceKind} "${connectionSelector}", which is ${problem} because it connects to ${terminalCount} ${pinOrPins}${terminalListDescription}.`
+  if (sourceTraceName && terminalPinSelectors.length > 2) {
+    return `Differential pair "${differentialPairName}" ${connectionPolarity}Connection uses the ambiguous trace name "${sourceTraceName}": its connection has more than 2 terminal pins${terminalListDescription}.`
+  }
+
+  return `Differential pair "${differentialPairName}" ${connectionPolarity}Connection="${connectionSelector}" is not point-to-point: expected exactly 2 terminal pins, found ${terminalPinSelectors.length}${terminalListDescription}.`
 }
 
 export const DifferentialPair_doInitialSourceDesignRuleChecks = (
@@ -156,7 +157,7 @@ export const DifferentialPair_doInitialSourceDesignRuleChecks = (
         differentialPairName: differentialPair.name,
         connectionPolarity,
         connectionSelector,
-        referenceKind: resolvedConnection.referenceKind,
+        sourceTraceName: resolvedConnection.sourceTraceName,
         terminalPinSelectors,
       }),
       subcircuit_id:

--- a/lib/components/primitive-components/DifferentialPair_doInitialSourceDesignRuleChecks.ts
+++ b/lib/components/primitive-components/DifferentialPair_doInitialSourceDesignRuleChecks.ts
@@ -7,7 +7,7 @@ type SourceComponentId = NonNullable<SourcePort["source_component_id"]>
 
 type ResolvedPointToPointConnection = {
   sourcePorts: SourcePort[]
-  sourceNetName?: string
+  referenceKind: "trace" | "selector"
 }
 
 const resolvePointToPointConnection = (
@@ -54,16 +54,10 @@ const resolvePointToPointConnection = (
       (sourcePort) =>
         sourcePort.subcircuit_connectivity_map_key === connectivityMapKey,
     )
-  const sourceNet = db.source_net
-    .list()
-    .find(
-      (sourceNet) =>
-        sourceNet.subcircuit_connectivity_map_key === connectivityMapKey,
-    )
 
   return {
     sourcePorts,
-    sourceNetName: sourceNet?.name,
+    referenceKind: matchingSourceTraces.length > 0 ? "trace" : "selector",
   }
 }
 
@@ -94,44 +88,22 @@ const getPointToPointWarningMessage = ({
   differentialPairName,
   connectionPolarity,
   connectionSelector,
-  sourceNetName,
+  referenceKind,
   terminalPinSelectors,
 }: {
   differentialPairName: string
   connectionPolarity: ConnectionPolarity
   connectionSelector: string
-  sourceNetName?: string
+  referenceKind: ResolvedPointToPointConnection["referenceKind"]
   terminalPinSelectors: string[]
 }): string => {
-  let resolvedConnectionName = `"${connectionSelector}"`
-  if (sourceNetName) {
-    resolvedConnectionName = `net.${sourceNetName}`
-  }
   const terminalCount = terminalPinSelectors.length
-  let pinOrPins = "pins"
-  if (terminalCount === 1) {
-    pinOrPins = "pin"
-  }
+  const pinOrPins = terminalCount === 1 ? "terminal pin" : "terminal pins"
   const terminalList = formatTerminalPinList(terminalPinSelectors)
-  const suggestedSelector = terminalPinSelectors[0]
-  let correction = "Connect exactly two terminal pins"
-  if (terminalCount > 2) {
-    correction = "Remove the extra connection"
-  }
-  let selectorRecommendation = ""
-  if (suggestedSelector) {
-    selectorRecommendation = ` and prefer a pin selector such as ${connectionPolarity}Connection="${suggestedSelector}"`
-  }
-  let terminalListDescription = ""
-  if (terminalList) {
-    terminalListDescription = `: ${terminalList}`
-  }
+  const terminalListDescription = terminalList ? `: ${terminalList}` : ""
+  const problem = terminalCount > 2 ? "ambiguous" : "not point-to-point"
 
-  return (
-    `Differential pair "${differentialPairName}" ${connectionPolarity}Connection resolves to ${resolvedConnectionName}, which is not point-to-point. ` +
-    `It connects to ${terminalCount} ${pinOrPins}${terminalListDescription}. ` +
-    `${correction}${selectorRecommendation}.`
-  )
+  return `Differential pair "${differentialPairName}" ${connectionPolarity}Connection references ${referenceKind} "${connectionSelector}", which is ${problem} because it connects to ${terminalCount} ${pinOrPins}${terminalListDescription}.`
 }
 
 export const DifferentialPair_doInitialSourceDesignRuleChecks = (
@@ -184,7 +156,7 @@ export const DifferentialPair_doInitialSourceDesignRuleChecks = (
         differentialPairName: differentialPair.name,
         connectionPolarity,
         connectionSelector,
-        sourceNetName: resolvedConnection.sourceNetName,
+        referenceKind: resolvedConnection.referenceKind,
         terminalPinSelectors,
       }),
       subcircuit_id:

--- a/tests/components/primitive-components/differential-pair/failure-tests/port-selector-multiple-traces-warning.test.tsx
+++ b/tests/components/primitive-components/differential-pair/failure-tests/port-selector-multiple-traces-warning.test.tsx
@@ -40,6 +40,10 @@ test("stores a warning when a differential pair port selector matches multiple t
     property_name: "positiveConnection",
   })
   expect(pointToPointWarning?.message).toContain(
-    'positiveConnection references selector ".R1 > .pin1", which is ambiguous because it connects to 3 terminal pins',
+    'positiveConnection=".R1 > .pin1" is not point-to-point: expected exactly 2 terminal pins, found 3',
   )
+  expect(pointToPointWarning?.message).not.toContain(
+    "Remove the extra connection",
+  )
+  expect(pointToPointWarning?.message).not.toContain("prefer a pin selector")
 })

--- a/tests/components/primitive-components/differential-pair/failure-tests/port-selector-multiple-traces-warning.test.tsx
+++ b/tests/components/primitive-components/differential-pair/failure-tests/port-selector-multiple-traces-warning.test.tsx
@@ -40,6 +40,6 @@ test("stores a warning when a differential pair port selector matches multiple t
     property_name: "positiveConnection",
   })
   expect(pointToPointWarning?.message).toContain(
-    'positiveConnection resolves to ".R1 > .pin1", which is not point-to-point',
+    'positiveConnection references selector ".R1 > .pin1", which is ambiguous because it connects to 3 terminal pins',
   )
 })

--- a/tests/components/primitive-components/differential-pair/point-to-point-warning-circuit-json.test.tsx
+++ b/tests/components/primitive-components/differential-pair/point-to-point-warning-circuit-json.test.tsx
@@ -32,6 +32,6 @@ test("stores a property warning for a branched differential pair", (): void => {
   })
   expect(pointToPointWarnings[0]?.source_component_id).toBeDefined()
   expect(pointToPointWarnings[0]?.message).toBe(
-    'Differential pair "USB_DATA" positiveConnection resolves to net.DP, which is not point-to-point. It connects to 3 pins: .J1 > .pin1, .TP1 > .pin1, and .U1 > .pin1. Remove the extra connection and prefer a pin selector such as positiveConnection=".J1 > .pin1".',
+    'Differential pair "USB_DATA" positiveConnection references trace "DP_FROM_J1", which is ambiguous because it connects to 3 terminal pins: .J1 > .pin1, .TP1 > .pin1, and .U1 > .pin1.',
   )
 })

--- a/tests/components/primitive-components/differential-pair/point-to-point-warning-circuit-json.test.tsx
+++ b/tests/components/primitive-components/differential-pair/point-to-point-warning-circuit-json.test.tsx
@@ -32,6 +32,6 @@ test("stores a property warning for a branched differential pair", (): void => {
   })
   expect(pointToPointWarnings[0]?.source_component_id).toBeDefined()
   expect(pointToPointWarnings[0]?.message).toBe(
-    'Differential pair "USB_DATA" positiveConnection references trace "DP_FROM_J1", which is ambiguous because it connects to 3 terminal pins: .J1 > .pin1, .TP1 > .pin1, and .U1 > .pin1.',
+    'Differential pair "USB_DATA" positiveConnection uses the ambiguous trace name "DP_FROM_J1": its connection has more than 2 terminal pins: .J1 > .pin1, .TP1 > .pin1, and .U1 > .pin1.',
   )
 })

--- a/tests/components/primitive-components/differential-pair/zero-terminal-point-to-point-warning.test.tsx
+++ b/tests/components/primitive-components/differential-pair/zero-terminal-point-to-point-warning.test.tsx
@@ -30,6 +30,6 @@ test("stores a warning for a differential-pair connection with no terminal pins"
     property_name: "positiveConnection",
   })
   expect(warning?.message).toBe(
-    'Differential pair "USB_DATA" positiveConnection references trace "DP_EMPTY", which is not point-to-point because it connects to 0 terminal pins.',
+    'Differential pair "USB_DATA" positiveConnection="DP_EMPTY" is not point-to-point: expected exactly 2 terminal pins, found 0.',
   )
 })

--- a/tests/components/primitive-components/differential-pair/zero-terminal-point-to-point-warning.test.tsx
+++ b/tests/components/primitive-components/differential-pair/zero-terminal-point-to-point-warning.test.tsx
@@ -30,6 +30,6 @@ test("stores a warning for a differential-pair connection with no terminal pins"
     property_name: "positiveConnection",
   })
   expect(warning?.message).toBe(
-    'Differential pair "USB_DATA" positiveConnection resolves to net.DP, which is not point-to-point. It connects to 0 pins. Connect exactly two terminal pins.',
+    'Differential pair "USB_DATA" positiveConnection references trace "DP_EMPTY", which is not point-to-point because it connects to 0 terminal pins.',
   )
 })


### PR DESCRIPTION
Follow-up to #3011.

## What changed

- Report a named differential-pair trace with more than two terminal pins as an ambiguous trace name.
- Include the pair, connection property, trace name, and complete terminal-pin list.
- Report selector and incomplete-connection failures factually as `expected exactly 2 terminal pins, found N`.
- Remove all advice to delete connections or switch to a pin selector.
- Remove the unnecessary singular/plural message construction.

## Why

Core does not ignore or rewrite the differential-pair connection. The diagnostic should state the topology problem without prescribing a circuit or selector change. A named trace is ambiguous when its resolved connection contains more than two terminal pins; other invalid counts are simply not point-to-point.

## Developer impact

Users receive concise, non-prescriptive diagnostics that identify the actual connection problem and list the affected pins.

## Validation

- Focused differential-pair warning tests: 3 passing, 10 assertions
- `bunx tsc --noEmit`
- Biome checks on all changed files
- `git diff --check`
- Three independent review passes covering wording, edge cases, and minimal-diff quality