### PR TITLE
Categorize differential-pair warnings

### DIFF
--- a/lib/components/primitive-components/DifferentialPair_doInitialSourceDesignRuleChecks.ts
+++ b/lib/components/primitive-components/DifferentialPair_doInitialSourceDesignRuleChecks.ts
@@ -152,6 +152,7 @@ export const DifferentialPair_doInitialSourceDesignRuleChecks = (
     db.source_property_ignored_warning.insert({
       source_component_id: warningSourceComponentId,
       property_name: `${connectionPolarity}Connection`,
+      drc_category: "netlist",
       error_type: "source_property_ignored_warning",
       message: getPointToPointWarningMessage({
         differentialPairName: differentialPair.name,

--- a/tests/components/primitive-components/differential-pair/failure-tests/port-selector-multiple-traces-warning.test.tsx
+++ b/tests/components/primitive-components/differential-pair/failure-tests/port-selector-multiple-traces-warning.test.tsx
@@ -38,6 +38,7 @@ test("stores a warning when a differential pair port selector matches multiple t
     type: "source_property_ignored_warning",
     error_type: "source_property_ignored_warning",
     property_name: "positiveConnection",
+    drc_category: "netlist",
   })
   expect(pointToPointWarning?.message).toContain(
     'positiveConnection=".R1 > .pin1" is not point-to-point: expected exactly 2 terminal pins, found 3',

--- a/tests/components/primitive-components/differential-pair/point-to-point-warning-circuit-json.test.tsx
+++ b/tests/components/primitive-components/differential-pair/point-to-point-warning-circuit-json.test.tsx
@@ -29,6 +29,7 @@ test("stores a property warning for a branched differential pair", (): void => {
     type: "source_property_ignored_warning",
     error_type: "source_property_ignored_warning",
     property_name: "positiveConnection",
+    drc_category: "netlist",
   })
   expect(pointToPointWarnings[0]?.source_component_id).toBeDefined()
   expect(pointToPointWarnings[0]?.message).toBe(

--- a/tests/components/primitive-components/differential-pair/zero-terminal-point-to-point-warning.test.tsx
+++ b/tests/components/primitive-components/differential-pair/zero-terminal-point-to-point-warning.test.tsx
@@ -28,6 +28,7 @@ test("stores a warning for a differential-pair connection with no terminal pins"
     source_component_id: "",
     error_type: "source_property_ignored_warning",
     property_name: "positiveConnection",
+    drc_category: "netlist",
   })
   expect(warning?.message).toBe(
     'Differential pair "USB_DATA" positiveConnection="DP_EMPTY" is not point-to-point: expected exactly 2 terminal pins, found 0.',

--- a/tests/components/primitive-components/schematic-symbol-chipref-without-connections-warning.test.tsx
+++ b/tests/components/primitive-components/schematic-symbol-chipref-without-connections-warning.test.tsx
@@ -30,6 +30,9 @@ test("schematicsymbol ignores chipRef without connections", async () => {
       ),
     }),
   ])
+  expect(
+    circuit.db.source_property_ignored_warning.list()[0]?.drc_category,
+  ).toBeUndefined()
 
   await expect(circuit).toMatchSchematicSnapshot(import.meta.path)
 })


### PR DESCRIPTION
## What changed

- mark differential-pair `source_property_ignored_warning` records with `drc_category: "netlist"`
- verify branched, ambiguous-selector, and zero-terminal warnings retain their existing property names and messages while carrying the category
- verify an unrelated `chipRef` source-property warning remains uncategorized

## Why

Core is the diagnostic producer and already knows that these warnings describe netlist topology. Carrying the category on the Circuit JSON record preserves that semantic fact without creating a differential-pair-specific diagnostic type and without requiring downstream property-name or message-text matching.

No warning wording or differential-pair validation logic changed. No unrelated property-warning producer was annotated.

## Validation

Validated locally against the built tarball from `tscircuit/circuit-json#691`:

- four focused warning tests — 4 passed
- `bunx tsc --noEmit`
- `bun run build`
- `bun run smoke-test:dist`
- `bun test` — 1,342 passed, 37 existing skips, 0 failed
- focused Biome formatting and `git diff --check`

## Dependency blocker

This draft depends on `tscircuit/circuit-json#691`. Circuit JSON does not currently publish a PR package preview, and `^0.0.x` ranges do not accept the next patch automatically. The branch intentionally does not commit a local tarball, raw GitHub dependency, or unreleased version. After the schema PR is merged and released, this PR must bump the `circuit-json` dev dependency and override to the released patch and rerun the same validation in CI.

## Downstream

The metadata is consumed generically by `tscircuit/circuit-json-util#113` and then by `tscircuit/cli#4042`. `@tscircuit/checks` is not involved.
