### PR TITLE
fix: layer-blind endpoint attribution stamps routed traces with wrong source_trace_id

### DIFF
--- a/lib/components/primitive-components/Group/get-source-trace-id-for-routed-trace.ts
+++ b/lib/components/primitive-components/Group/get-source-trace-id-for-routed-trace.ts
@@ -1,12 +1,12 @@
 import type { CircuitJsonUtilObjects } from "@tscircuit/circuit-json-util"
 import { distance, pointToSegmentDistance } from "@tscircuit/math-utils"
-import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type {
   PcbPlatedHole,
   PcbSmtPad,
   PcbTrace,
   SourceTrace,
 } from "circuit-json"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type { SimplifiedPcbTrace } from "lib/utils/autorouting/SimpleRouteJson"
 
 type RoutedTrace = (PcbTrace | SimplifiedPcbTrace) & {
@@ -18,6 +18,7 @@ type RoutePointWithPortIds = {
   x?: number
   y?: number
   width?: number
+  layer?: string
   start_pcb_port_id?: string
   end_pcb_port_id?: string
 }
@@ -101,6 +102,12 @@ function getEndpointSourcePortIdsFromGeometry(
   for (const endpoint of endpoints) {
     for (const pcbPort of db.pcb_port.list()) {
       if (!pcbPort.source_port_id) continue
+      if (
+        endpoint.layer &&
+        pcbPort.layers &&
+        !pcbPort.layers.includes(endpoint.layer as any)
+      )
+        continue
       if (distance(endpoint, pcbPort) <= 0.01) {
         sourcePortIds.add(pcbPort.source_port_id)
       }
@@ -108,6 +115,7 @@ function getEndpointSourcePortIdsFromGeometry(
 
     for (const smtpad of db.pcb_smtpad.list()) {
       if (!smtpad.pcb_port_id) continue
+      if (endpoint.layer && smtpad.layer !== endpoint.layer) continue
       if (
         !isPointInSmtPad({
           point: endpoint,

--- a/tests/repros/repro-routed-trace-attribution-ignores-opposite-layer-pad.test.tsx
+++ b/tests/repros/repro-routed-trace-attribution-ignores-opposite-layer-pad.test.tsx
@@ -1,0 +1,88 @@
+import { expect, test } from "bun:test"
+import { getSourceTraceIdForRoutedTrace } from "lib/components/primitive-components/Group/get-source-trace-id-for-routed-trace"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("routed trace endpoints over a large opposite-layer pad are attributed to the correct source trace", async () => {
+  const { circuit } = getTestFixture()
+
+  // BAT is declared first so its GND source trace is first in db order: with
+  // layer-blind endpoint attribution, every top-layer endpoint over BAT's
+  // giant bottom pad picks up a phantom BAT.pin1 port, the exact source-trace
+  // match fails, and the fallback returns the GND trace for signal traces.
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <chip
+        name="BAT"
+        pcbX={0}
+        pcbY={0}
+        footprint={
+          <footprint>
+            <smtpad
+              shape="rect"
+              width="10mm"
+              height="10mm"
+              layer="bottom"
+              portHints={["pin1"]}
+            />
+          </footprint>
+        }
+      />
+      <chip
+        name="U1"
+        pcbX={0}
+        pcbY={0}
+        footprint={
+          <footprint>
+            <smtpad
+              shape="rect"
+              width="1mm"
+              height="1mm"
+              layer="top"
+              portHints={["pin1"]}
+              pcbX={-3}
+              pcbY={0}
+            />
+            <smtpad
+              shape="rect"
+              width="1mm"
+              height="1mm"
+              layer="top"
+              portHints={["pin2"]}
+              pcbX={3}
+              pcbY={0}
+            />
+          </footprint>
+        }
+      />
+      <trace from="BAT.pin1" to="net.GND" />
+      <trace from="U1.pin1" to="U1.pin2" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+  const db = circuit.db
+
+  const signalSourceTrace = db.source_trace
+    .list()
+    .find((sourceTrace) => sourceTrace.display_name?.includes("U1"))
+  expect(signalSourceTrace).toBeDefined()
+
+  // Simulate an autorouted top-layer trace between U1.pin1 and U1.pin2. The
+  // autorouter emits wire points without pcb_port ids, so the source trace
+  // must be recovered from endpoint geometry.
+  const routedTrace = {
+    type: "pcb_trace" as const,
+    pcb_trace_id: "synthetic_routed_trace",
+    route: [
+      { route_type: "wire" as const, x: -3, y: 0, width: 0.15, layer: "top" },
+      { route_type: "wire" as const, x: 3, y: 0, width: 0.15, layer: "top" },
+    ],
+  }
+
+  const attributedSourceTraceId = getSourceTraceIdForRoutedTrace({
+    db,
+    trace: routedTrace as any,
+  })
+
+  expect(attributedSourceTraceId).toBe(signalSourceTrace!.source_trace_id)
+})


### PR DESCRIPTION
## Problem

`getSourceTraceIdForRoutedTrace` recovers the `source_trace_id` for autorouted traces (whose route points carry no `pcb_port_id`s) by testing route endpoints against pads geometrically — **without comparing layers**.

On [tscircuit/nrf52810](https://github.com/tscircuit/nrf52810), the CR2032 holder's `VBAT_N` (GND) terminal is a 10×10mm pad on the **bottom** layer covering much of the board interior. Every **top**-layer routed endpoint above that footprint also "hit" the battery pad, adding a phantom GND port to the endpoint set. That made the exact source-trace match (`sourcePortIds.every(...)`) fail, and the net-based fallback ended in `candidates[0]` — the first source trace in db order across *any* endpoint's net, which was GND's first trace (`.BT1 > .VBAT_N to net.GND`). 27 pcb_traces got stamped with that GND `source_trace_id`, including both 32.768 kHz crystal-pin traces and the antenna node trace.

## Downstream effect: DRC and check-shorts blinded to real shorts

`circuit-json-to-connectivity-map` unions `[pcb_trace_id, source_trace_id]`, so all mis-stamped traces merged with GND into one connectivity group. As a result, two **genuine same-layer trace crossings** produced by the autorouter went undetected:

- X2 crystal `OSC1` × `OSC2` traces crossing at (-1.86, 5.52), top layer
- `U1.ANT` antenna feed × GND trace crossing at (6.02, 3.11), top layer

`checkEachPcbTraceNonOverlapping` skips pairs where `connMap.areIdsConnected(...)` → 0 DRC errors. `tsci check shorts` defines a short as one pixel owned by two connectivity groups → "No shorts detected". The PCB viewer's hover highlight showed the merged group, which is how the short was noticed by a human.

## Fix

Endpoint-geometry attribution now only matches pads and ports on the endpoint's own layer (when the endpoint carries a `layer`). Plated holes still match regardless of layer since they span all layers. Endpoints without layer info keep the old behavior.

## Test

`tests/repros/repro-routed-trace-attribution-ignores-opposite-layer-pad.test.tsx` reproduces the nRF52810 scenario minimally: a large bottom-layer GND pad under two small top-layer pads connected by a signal trace. Without the fix the synthetic routed trace is attributed to the GND source trace; with the fix it resolves to the correct signal trace. Verified red on `main`, green with the fix; `tests/repros`, `tests/features`, `tests/components`, and `tsc --noEmit` all pass.

## Possible follow-ups (not in this PR)

- The autorouter's `pcb_trace_id` already encodes the true connection (`source_trace_51__source_trace_53_mst1_0`, `source_net_1_mst15_0`); resolving attribution from the connection name would avoid geometry entirely.
- The `candidates[0]` fallback can still pick a trace from a different net when endpoint ports span multiple nets; requiring the net to be common to all endpoints would be safer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)