### PR TITLE
feat: infer decoupling capacitors from chip power connectivity

### DIFF
--- a/lib/components/normal-components/Capacitor.ts
+++ b/lib/components/normal-components/Capacitor.ts
@@ -8,6 +8,7 @@ import {
 import { NormalComponent } from "../base-components/NormalComponent/NormalComponent"
 import { Trace } from "../primitive-components/Trace/Trace"
 import { formatSiUnit } from "format-si-unit"
+import { getAutomaticMaxDecouplingTraceLength } from "./Capacitor/get-automatic-max-decoupling-trace-length"
 
 export class Capacitor extends NormalComponent<
   typeof capacitorProps,
@@ -108,5 +109,18 @@ export class Capacitor extends NormalComponent<
     } as SourceSimpleCapacitorInput)
 
     this.source_component_id = source_component.source_component_id
+  }
+
+  doInitialSourceParentAttachment(): void {
+    super.doInitialSourceParentAttachment()
+
+    const maxDecouplingTraceLength =
+      this._parsedProps.maxDecouplingTraceLength ??
+      getAutomaticMaxDecouplingTraceLength(this)
+    if (maxDecouplingTraceLength === undefined) return
+
+    this.root!.db.source_component.update(this.source_component_id!, {
+      max_decoupling_trace_length: maxDecouplingTraceLength,
+    })
   }
 }

--- a/lib/components/normal-components/Capacitor/get-automatic-max-decoupling-trace-length.ts
+++ b/lib/components/normal-components/Capacitor/get-automatic-max-decoupling-trace-length.ts
@@ -1,0 +1,117 @@
+import type { CircuitJsonUtilObjects } from "@tscircuit/circuit-json-util"
+import {
+  GROUND_NET_REGEX,
+  POWER_NET_REGEX,
+} from "lib/utils/gnd-power-net-regex"
+import type { Net } from "../../primitive-components/Net"
+import type { Port } from "../../primitive-components/Port"
+import type { Trace } from "../../primitive-components/Trace/Trace"
+import type { Capacitor } from "../Capacitor"
+
+const DEFAULT_MAX_DECOUPLING_TRACE_LENGTH = 1
+
+const isEligibleChipPowerInputPort = (
+  port: Port,
+  db: CircuitJsonUtilObjects,
+): boolean => {
+  if (port.getParentNormalComponent()?.componentName !== "Chip") return false
+
+  const sourcePort = db.source_port.get(port.source_port_id!)
+  if (sourcePort?.should_have_decoupling_capacitor !== undefined) {
+    return sourcePort.should_have_decoupling_capacitor
+  }
+  if (sourcePort?.provides_power === true) return false
+  if (sourcePort?.requires_power !== undefined) {
+    return sourcePort.requires_power
+  }
+
+  return port.getNameAndAliases().some((name) => POWER_NET_REGEX.test(name))
+}
+
+const isGroundPort = (port: Port, db: CircuitJsonUtilObjects): boolean => {
+  const sourcePort = db.source_port.get(port.source_port_id!)
+  if (sourcePort?.requires_ground === true) return true
+  if (sourcePort?.provides_ground === true) return true
+
+  return port.getNameAndAliases().some((name) => GROUND_NET_REGEX.test(name))
+}
+
+const isGroundNet = (net: Net, db: CircuitJsonUtilObjects): boolean => {
+  const sourceNet = db.source_net.get(net.source_net_id!)
+  return sourceNet?.is_ground === true || GROUND_NET_REGEX.test(net.props.name)
+}
+
+const getDirectlyConnectedTraces = (
+  capacitor: Capacitor,
+  capacitorPort: Port,
+): Trace[] => {
+  const traces = capacitor.getSubcircuit().selectAll("trace") as Trace[]
+
+  return traces.filter((trace) => {
+    try {
+      const connectedPorts = trace._findConnectedPorts()
+      return (
+        connectedPorts.allPortsFound &&
+        connectedPorts.ports.includes(capacitorPort)
+      )
+    } catch {
+      return false
+    }
+  })
+}
+
+const hasDirectChipPowerConnection = (
+  capacitor: Capacitor,
+  capacitorPort: Port,
+  db: CircuitJsonUtilObjects,
+): boolean =>
+  getDirectlyConnectedTraces(capacitor, capacitorPort).some((trace) => {
+    const connectedPorts = trace._findConnectedPorts()
+    return (
+      connectedPorts.allPortsFound &&
+      connectedPorts.ports.some(
+        (port) =>
+          port !== capacitorPort && isEligibleChipPowerInputPort(port, db),
+      )
+    )
+  })
+
+const hasDirectGroundConnection = (
+  capacitor: Capacitor,
+  capacitorPort: Port,
+  db: CircuitJsonUtilObjects,
+): boolean =>
+  getDirectlyConnectedTraces(capacitor, capacitorPort).some((trace) => {
+    const connectedPorts = trace._findConnectedPorts()
+    if (
+      connectedPorts.allPortsFound &&
+      connectedPorts.ports.some(
+        (port) => port !== capacitorPort && isGroundPort(port, db),
+      )
+    ) {
+      return true
+    }
+
+    return trace._findConnectedNets().nets.some((net) => isGroundNet(net, db))
+  })
+
+export const getAutomaticMaxDecouplingTraceLength = (
+  capacitor: Capacitor,
+): number | undefined => {
+  const ports = capacitor.children.filter(
+    (child): child is Port => child.componentName === "Port",
+  )
+  if (ports.length !== 2) return undefined
+
+  const { db } = capacitor.root!
+  const [firstPort, secondPort] = ports
+  const isAutomaticallyDecoupled =
+    (hasDirectChipPowerConnection(capacitor, firstPort, db) &&
+      hasDirectGroundConnection(capacitor, secondPort, db)) ||
+    (hasDirectChipPowerConnection(capacitor, secondPort, db) &&
+      hasDirectGroundConnection(capacitor, firstPort, db))
+
+  return isAutomaticallyDecoupled
+    ? DEFAULT_MAX_DECOUPLING_TRACE_LENGTH
+    : undefined
+}

--- a/tests/breakout/breakout-sot23-regulator-power-rail.test.tsx
+++ b/tests/breakout/breakout-sot23-regulator-power-rail.test.tsx
@@ -17,6 +17,10 @@ test("breakout routes sot23 regulator power rail parts without breakoutpoints", 
             pin2: "GND",
             pin3: "VOUT",
           }}
+          pinAttributes={{
+            VIN: { shouldHaveDecouplingCapacitor: false },
+            VOUT: { providesPower: true },
+          }}
           pcbX={0}
           pcbY={0}
         />

--- a/tests/breakout/fanout-soic8-sensor-to-i2c-header.test.tsx
+++ b/tests/breakout/fanout-soic8-sensor-to-i2c-header.test.tsx
@@ -24,6 +24,9 @@ test("fanout routes soic8 sensor support parts to an i2c header without fanoutpo
             pin7: "NC2",
             pin8: "VCC",
           }}
+          pinAttributes={{
+            VCC: { shouldHaveDecouplingCapacitor: false },
+          }}
           pcbX={0}
           pcbY={0}
         />

--- a/tests/features/automatic-decoupling-detection/autorouting-distance-violation.test.tsx
+++ b/tests/features/automatic-decoupling-detection/autorouting-distance-violation.test.tsx
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("an impossible inferred limit uses the existing autorouting error path", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board
+      width="10mm"
+      height="6mm"
+      autorouter={{ local: true, groupMode: "subcircuit" }}
+    >
+      <chip
+        name="U1"
+        pcbX={-2}
+        pinLabels={{ pin1: "VCC" }}
+        footprint={
+          <footprint>
+            <smtpad
+              shape="rect"
+              width="0.5mm"
+              height="0.5mm"
+              portHints={["pin1"]}
+            />
+          </footprint>
+        }
+      />
+      <capacitor
+        name="C1"
+        capacitance="100nF"
+        pcbX={2}
+        footprint={
+          <footprint>
+            <smtpad
+              shape="rect"
+              width="0.5mm"
+              height="0.5mm"
+              pcbX={-0.5}
+              portHints={["pin1"]}
+            />
+            <smtpad
+              shape="rect"
+              width="0.5mm"
+              height="0.5mm"
+              pcbX={0.5}
+              portHints={["pin2"]}
+            />
+          </footprint>
+        }
+      />
+      <trace from=".U1 > .VCC" to=".C1 > .1" />
+      <trace from=".C1 > .2" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_trace.list()[0].max_length).toBe(1)
+  expect(circuit.db.pcb_trace.list()).toHaveLength(0)
+  expect(circuit.db.pcb_trace_too_long_warning.list()).toHaveLength(0)
+  const errors = circuit.db.pcb_autorouting_error.list()
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toContain("cannot be satisfied")
+})

--- a/tests/features/automatic-decoupling-detection/existing-decoupling-props.test.tsx
+++ b/tests/features/automatic-decoupling-detection/existing-decoupling-props.test.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSourceCapacitor } from "./test-utils"
+
+test("existing decouplingFor and decouplingTo props keep working", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip name="U1" footprint="soic8" pinLabels={{ pin1: "PWR" }} />
+      <capacitor
+        name="C1"
+        capacitance="100nF"
+        footprint="0402"
+        decouplingFor=".U1 > .PWR"
+        decouplingTo="net.GND"
+        maxDecouplingTraceLength={2}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_trace.list()).toHaveLength(2)
+  expect(
+    circuit.db.source_trace.list().map((trace) => trace.max_length),
+  ).toEqual([2, 2])
+  expect(getSourceCapacitor(circuit, "C1")?.max_decoupling_trace_length).toBe(2)
+})

--- a/tests/features/automatic-decoupling-detection/explicit-maximum-override.test.tsx
+++ b/tests/features/automatic-decoupling-detection/explicit-maximum-override.test.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSourceCapacitor } from "./test-utils"
+
+test("explicit maxDecouplingTraceLength overrides the inferred default", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip name="U1" footprint="soic8" pinLabels={{ pin1: "VCORE" }} />
+      <capacitor
+        name="C1"
+        capacitance="100nF"
+        footprint="0402"
+        maxDecouplingTraceLength={2}
+      />
+      <trace from=".U1 > .VCORE" to=".C1 > .1" />
+      <trace from=".C1 > .2" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(getSourceCapacitor(circuit, "C1")?.max_decoupling_trace_length).toBe(2)
+  expect(
+    circuit.db.source_trace.list().map((trace) => trace.max_length),
+  ).toEqual([2, 2])
+})

--- a/tests/features/automatic-decoupling-detection/explicit-opt-in.test.tsx
+++ b/tests/features/automatic-decoupling-detection/explicit-opt-in.test.tsx
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSourceCapacitor } from "./test-utils"
+
+test("shouldHaveDecouplingCapacitor true opts in a nonstandard pin", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "SUPPLY_INPUT", pin4: "GND" }}
+        pinAttributes={{
+          SUPPLY_INPUT: { shouldHaveDecouplingCapacitor: true },
+        }}
+      />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 > .SUPPLY_INPUT" to=".C1 > .1" />
+      <trace from=".C1 > .2" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(
+    circuit.db.source_port.list().find((port) => port.name === "SUPPLY_INPUT")
+      ?.should_have_decoupling_capacitor,
+  ).toBe(true)
+  expect(getSourceCapacitor(circuit, "C1")?.max_decoupling_trace_length).toBe(1)
+})

--- a/tests/features/automatic-decoupling-detection/explicit-opt-out.test.tsx
+++ b/tests/features/automatic-decoupling-detection/explicit-opt-out.test.tsx
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSourceCapacitor } from "./test-utils"
+
+test("shouldHaveDecouplingCapacitor false opts out", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VBAT", pin4: "GND" }}
+        pinAttributes={{
+          VBAT: {
+            requiresPower: true,
+            shouldHaveDecouplingCapacitor: false,
+          },
+        }}
+      />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 > .VBAT" to=".C1 > .1" />
+      <trace from=".C1 > .2" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(
+    circuit.db.source_port.list().find((port) => port.name === "VBAT")
+      ?.should_have_decoupling_capacitor,
+  ).toBe(false)
+  expect(
+    getSourceCapacitor(circuit, "C1")?.max_decoupling_trace_length,
+  ).toBeUndefined()
+  expect(
+    circuit.db.source_trace
+      .list()
+      .every((trace) => trace.max_length === undefined),
+  ).toBe(true)
+})

--- a/tests/features/automatic-decoupling-detection/explicit-requires-power-false.test.tsx
+++ b/tests/features/automatic-decoupling-detection/explicit-requires-power-false.test.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSourceCapacitor } from "./test-utils"
+
+test("requiresPower false overrides power-name inference", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin4: "GND" }}
+        pinAttributes={{ VCC: { requiresPower: false } }}
+      />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 > .VCC" to=".C1 > .1" />
+      <trace from=".C1 > .2" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(
+    getSourceCapacitor(circuit, "C1")?.max_decoupling_trace_length,
+  ).toBeUndefined()
+})

--- a/tests/features/automatic-decoupling-detection/explicit-requires-power.test.tsx
+++ b/tests/features/automatic-decoupling-detection/explicit-requires-power.test.tsx
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSourceCapacitor } from "./test-utils"
+
+test("infers decoupling for a nonstandard pin with requiresPower", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VBAT", pin4: "GND" }}
+        pinAttributes={{ VBAT: { requiresPower: true } }}
+      />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 > .VBAT" to=".C1 > .1" />
+      <trace from=".C1 > .2" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(
+    circuit.db.source_port.list().find((port) => port.name === "VBAT")
+      ?.requires_power,
+  ).toBe(true)
+  expect(getSourceCapacitor(circuit, "C1")?.max_decoupling_trace_length).toBe(1)
+  expect(
+    circuit.db.source_trace.list().map((trace) => trace.max_length),
+  ).toEqual([1, 1])
+})

--- a/tests/features/automatic-decoupling-detection/inferred-vcc-decoupling.test.tsx
+++ b/tests/features/automatic-decoupling-detection/inferred-vcc-decoupling.test.tsx
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSourceCapacitor } from "./test-utils"
+
+test("infers a 1mm decoupling limit from direct VCC and ground traces", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin4: "GND" }}
+      />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 > .VCC" to=".C1 > .1" />
+      <trace from=".C1 > .1" to="net.VCC" />
+      <trace from=".C1 > .2" to="net.GND" />
+      <trace from=".U1 > .GND" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const capacitor = getSourceCapacitor(circuit, "C1")
+  expect(capacitor?.max_decoupling_trace_length).toBe(1)
+
+  const capacitorPortIds = new Set(
+    circuit.db.source_port
+      .list()
+      .filter(
+        (port) => port.source_component_id === capacitor?.source_component_id,
+      )
+      .map((port) => port.source_port_id),
+  )
+  const capacitorTraces = circuit.db.source_trace
+    .list()
+    .filter((trace) =>
+      trace.connected_source_port_ids.some((portId) =>
+        capacitorPortIds.has(portId),
+      ),
+    )
+
+  expect(capacitorTraces).toHaveLength(3)
+  expect(capacitorTraces.every((trace) => trace.max_length === 1)).toBe(true)
+  expect(
+    capacitorTraces.some(
+      (trace) =>
+        trace.connected_source_port_ids.length === 2 &&
+        trace.connected_source_net_ids.length === 0,
+    ),
+  ).toBe(true)
+  expect(
+    capacitorTraces.some(
+      (trace) =>
+        trace.connected_source_port_ids.length === 1 &&
+        trace.connected_source_net_ids.length === 1,
+    ),
+  ).toBe(true)
+})

--- a/tests/features/automatic-decoupling-detection/not-grounded.test.tsx
+++ b/tests/features/automatic-decoupling-detection/not-grounded.test.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSourceCapacitor } from "./test-utils"
+
+test("does not infer decoupling when the other capacitor pin is a signal", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip name="U1" footprint="soic8" pinLabels={{ pin1: "VCC" }} />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 > .VCC" to=".C1 > .1" />
+      <trace from=".C1 > .2" to="net.SIGNAL" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(
+    getSourceCapacitor(circuit, "C1")?.max_decoupling_trace_length,
+  ).toBeUndefined()
+})

--- a/tests/features/automatic-decoupling-detection/power-provider.test.tsx
+++ b/tests/features/automatic-decoupling-detection/power-provider.test.tsx
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSourceCapacitor } from "./test-utils"
+
+test("does not infer decoupling from a power-providing chip port", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="REG1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VOUT" }}
+        pinAttributes={{ VOUT: { providesPower: true } }}
+      />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".REG1 > .VOUT" to=".C1 > .1" />
+      <trace from=".C1 > .2" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(
+    circuit.db.source_port.list().find((port) => port.name === "VOUT")
+      ?.provides_power,
+  ).toBe(true)
+  expect(
+    getSourceCapacitor(circuit, "C1")?.max_decoupling_trace_length,
+  ).toBeUndefined()
+})

--- a/tests/features/automatic-decoupling-detection/routed-trace-too-long.test.tsx
+++ b/tests/features/automatic-decoupling-detection/routed-trace-too-long.test.tsx
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("a routed inferred decoupling trace emits the generic too-long warning", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="6mm">
+      <chip
+        name="U1"
+        pcbX={-2}
+        pinLabels={{ pin1: "VCC" }}
+        footprint={
+          <footprint>
+            <smtpad
+              shape="rect"
+              width="0.5mm"
+              height="0.5mm"
+              portHints={["pin1"]}
+            />
+          </footprint>
+        }
+      />
+      <capacitor
+        name="C1"
+        capacitance="100nF"
+        pcbX={2}
+        footprint={
+          <footprint>
+            <smtpad
+              shape="rect"
+              width="0.5mm"
+              height="0.5mm"
+              pcbX={-0.5}
+              portHints={["pin1"]}
+            />
+            <smtpad
+              shape="rect"
+              width="0.5mm"
+              height="0.5mm"
+              pcbX={0.5}
+              portHints={["pin2"]}
+            />
+          </footprint>
+        }
+      />
+      <trace from=".U1 > .VCC" to=".C1 > .1" pcbStraightLine />
+      <trace from=".C1 > .2" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.pcb_trace.list()).toHaveLength(1)
+  const warnings = circuit.db.pcb_trace_too_long_warning.list()
+  expect(warnings).toHaveLength(1)
+  expect(warnings[0].maximum_trace_length).toBe(1)
+  expect(warnings[0].actual_trace_length).toBeGreaterThan(1)
+})

--- a/tests/features/automatic-decoupling-detection/routed-trace-within-limit.test.tsx
+++ b/tests/features/automatic-decoupling-detection/routed-trace-within-limit.test.tsx
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("a routed inferred decoupling trace within 1mm emits no warning", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="6mm" height="6mm">
+      <chip
+        name="U1"
+        pcbX={-0.5}
+        pinLabels={{ pin1: "VCC" }}
+        footprint={
+          <footprint>
+            <smtpad
+              shape="rect"
+              width="0.5mm"
+              height="0.5mm"
+              portHints={["pin1"]}
+            />
+          </footprint>
+        }
+      />
+      <capacitor
+        name="C1"
+        capacitance="100nF"
+        pcbX={0.5}
+        footprint={
+          <footprint>
+            <smtpad
+              shape="rect"
+              width="0.5mm"
+              height="0.5mm"
+              pcbX={-0.25}
+              portHints={["pin1"]}
+            />
+            <smtpad
+              shape="rect"
+              width="0.5mm"
+              height="0.5mm"
+              pcbX={0.25}
+              portHints={["pin2"]}
+            />
+          </footprint>
+        }
+      />
+      <trace from=".U1 > .VCC" to=".C1 > .1" pcbStraightLine />
+      <trace from=".C1 > .2" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_trace.list()[0].max_length).toBe(1)
+  expect(circuit.db.pcb_trace.list()).toHaveLength(1)
+  expect(circuit.db.pcb_trace_too_long_warning.list()).toHaveLength(0)
+})

--- a/tests/features/automatic-decoupling-detection/shared-power-net.test.tsx
+++ b/tests/features/automatic-decoupling-detection/shared-power-net.test.tsx
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSourceCapacitor } from "./test-utils"
+
+test("does not infer decoupling through a shared named power net", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "VCC", pin4: "GND" }}
+      />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 > .VCC" to="net.VCC" />
+      <trace from=".C1 > .1" to="net.VCC" />
+      <trace from=".C1 > .2" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(
+    getSourceCapacitor(circuit, "C1")?.max_decoupling_trace_length,
+  ).toBeUndefined()
+  expect(
+    circuit.db.source_trace
+      .list()
+      .every((trace) => trace.max_length === undefined),
+  ).toBe(true)
+})

--- a/tests/features/automatic-decoupling-detection/swapped-capacitor-ports.test.tsx
+++ b/tests/features/automatic-decoupling-detection/swapped-capacitor-ports.test.tsx
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { getSourceCapacitor } from "./test-utils"
+
+test("infers decoupling with swapped capacitor ports", async () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip name="U1" footprint="soic8" pinLabels={{ pin1: "VDD" }} />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 > .VDD" to=".C1 > .2" />
+      <trace from=".C1 > .1" to="net.GND" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(getSourceCapacitor(circuit, "C1")?.max_decoupling_trace_length).toBe(1)
+  expect(
+    circuit.db.source_trace.list().map((trace) => trace.max_length),
+  ).toEqual([1, 1])
+})

--- a/tests/features/automatic-decoupling-detection/test-utils.ts
+++ b/tests/features/automatic-decoupling-detection/test-utils.ts
@@ -1,0 +1,10 @@
+import type { SourceSimpleCapacitor } from "circuit-json"
+import type { RootCircuit } from "lib/RootCircuit"
+
+export const getSourceCapacitor = (circuit: RootCircuit, name: string) =>
+  circuit.db.source_component
+    .list()
+    .find(
+      (component): component is SourceSimpleCapacitor =>
+        component.ftype === "simple_capacitor" && component.name === name,
+    )


### PR DESCRIPTION
## Summary

- infer a 1 mm maximum decoupling trace length for two-pin capacitors directly traced between an eligible chip power-input pin and ground
- propagate the inferred source-component limit through the existing source-trace `max_length` and PCB trace-length checking path
- preserve explicit `maxDecouplingTraceLength` values with nullish override semantics
- honor explicit `shouldHaveDecouplingCapacitor` opt-in/opt-out, explicit `requiresPower`, power-name inference, and `providesPower` exclusions
- require a direct chip-to-capacitor source trace; capacitors that only share a named power net are intentionally not classified

## Detection rules

A capacitor qualifies only when it has exactly two ports, one port has a direct source trace to an eligible chip power-input port, and the other has a direct source trace to ground. Ground is recognized from ground nets, ground-like port names, or `requiresGround`/`providesGround` pin attributes.

Power eligibility uses this precedence:

1. explicit `shouldHaveDecouplingCapacitor`
2. exclusion for `providesPower: true`
3. explicit `requiresPower`
4. existing power-name inference such as VCC, VDD, VCORE, and voltage-style names

Shared named power nets do not qualify because they do not establish a direct association with a particular chip pin.

## Lifecycle

Inference runs during `SourceParentAttachment`: trace component instances and source port attributes already exist, while `SourceTraceRender` has not run yet. This lets the existing max-length propagation and PCB DRC paths consume the inferred value without a second decoupling-specific checker.

## Tests

Added focused coverage for inferred VCC decoupling, explicit power attributes and overrides, opt-in/opt-out, shared-net and non-ground negatives, swapped capacitor ports, power providers, existing decoupling props, routed over/under-length traces, and the early autorouting-error path.

Validation:

- `bun install --frozen-lockfile` — pass (Bun 1.2.21; peer-dependency warnings only)
- `bun test tests/features/automatic-decoupling-detection` — 14 pass
- targeted feature plus affected breakout regressions — 16 pass
- `bunx tsc --noEmit` — pass
- `bun run format` — pass, no remaining changes
- `bun run build` — pass
- `git diff --check` — pass
- initial full `bun test` — 1,356 pass, 37 skip, 2 affected breakout fixtures identified; both fixtures now explicitly opt out and their targeted rerun passes
