### PR TITLE
Fix breakout decoupling fixture metadata

### DIFF
--- a/tests/breakout/breakout-sot23-regulator-power-rail.test.tsx
+++ b/tests/breakout/breakout-sot23-regulator-power-rail.test.tsx
@@ -17,6 +17,10 @@ test("breakout routes sot23 regulator power rail parts without breakoutpoints", 
             pin2: "GND",
             pin3: "VOUT",
           }}
+          pinAttributes={{
+            VIN: { shouldHaveDecouplingCapacitor: false },
+            VOUT: { providesPower: true },
+          }}
           pcbX={0}
           pcbY={0}
         />

--- a/tests/breakout/fanout-soic8-sensor-to-i2c-header.test.tsx
+++ b/tests/breakout/fanout-soic8-sensor-to-i2c-header.test.tsx
@@ -24,6 +24,9 @@ test("fanout routes soic8 sensor support parts to an i2c header without fanoutpo
             pin7: "NC2",
             pin8: "VCC",
           }}
+          pinAttributes={{
+            VCC: { shouldHaveDecouplingCapacitor: false },
+          }}
           pcbX={0}
           pcbY={0}
         />


### PR DESCRIPTION
## Summary

- opt the synthetic sensor VCC pin out of automatic decoupling enforcement
- opt the regulator VIN fixture pin out and mark VOUT as a power-providing output
- preserve the existing routing, DRC, PCB snapshot, and autorouting snapshot assertions

## Root cause

Automatic decoupling detection now assigns a 1 mm maximum trace length to capacitors connected between inferred chip power and ground pins. These breakout-focused fixtures intentionally place their support capacitors farther away, so trace-length preflight skips the entire subcircuit autorouter and leaves `pcb_trace` empty.

The fixture metadata now states the intended pin semantics directly. This avoids skipped tests, relaxed assertions, inflated trace-length limits, or snapshot churn.

## Impact

The two breakout regressions route again while the automatic decoupling behavior remains covered by its dedicated tests.

## Validation

- `bun test tests/breakout/fanout-soic8-sensor-to-i2c-header.test.tsx tests/breakout/breakout-sot23-regulator-power-rail.test.tsx`
- `bun test tests/breakout` — 13 passed, 2 intentionally skipped, 0 failed
- `bunx tsc --noEmit`
- `bunx biome check tests/breakout/fanout-soic8-sensor-to-i2c-header.test.tsx tests/breakout/breakout-sot23-regulator-power-rail.test.tsx`
- `git diff --check`
