### PR TITLE
fix: write net highlightColor through to pcb_trace.highlight_color

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -43,6 +43,7 @@ import {
 import { getLocalAutoroutingStages } from "lib/utils/autorouting/localAutorouterStrategies"
 import { shouldSkipAutoroutingBecauseOfPlacementErrors } from "lib/utils/autorouting/should-skip-autorouting-because-of-placement-errors"
 import { shouldSkipAutoroutingBecauseOfTraceLengthViolations } from "lib/utils/autorouting/should-skip-autorouting-because-of-trace-length-violations"
+import { getHighlightColorForRoutedTrace } from "lib/utils/get-highlight-color-for-routed-trace"
 import { getBoundsOfPcbComponents } from "lib/utils/get-bounds-of-pcb-components"
 import { getViaSpanLayers } from "lib/utils/getViaSpanLayers"
 import {
@@ -92,6 +93,7 @@ import {
 } from "./Group_phasedAutoroutingUtils"
 import { Group_syncFanoutExitsWithGlobalConnections } from "./Group_syncFanoutExitsWithGlobalConnections"
 import type { ISubcircuit } from "./Subcircuit/ISubcircuit"
+import type { Net } from "../Net"
 import { addPortIdsToTracesAtJumperPads } from "./add-port-ids-to-traces-at-jumper-pads"
 import { getSourceTraceIdForRoutedTrace } from "./get-source-trace-id-for-routed-trace"
 import { insertAutoplacedJumpers } from "./insert-autoplaced-jumpers"
@@ -1753,6 +1755,8 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       pcbTraceIdsToReplace: pcb_trace_ids_to_be_replaced,
     })
 
+    const netsForHighlightColor = this.selectAll<Net>("net")
+
     for (const pcb_trace of output_pcb_traces) {
       // vias can be included
       if (pcb_trace.type !== "pcb_trace") continue
@@ -1807,10 +1811,16 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             },
             subcircuit_id: this.subcircuit_id,
           })
+          const highlightColor = getHighlightColorForRoutedTrace({
+            db,
+            nets: netsForHighlightColor,
+            sourceTraceId,
+          })
           db.pcb_trace.insert({
             ...pcb_trace,
             source_trace_id: sourceTraceId,
             route: segment,
+            ...(highlightColor ? { highlight_color: highlightColor } : {}),
           })
         }
       }

--- a/lib/utils/get-highlight-color-for-routed-trace.ts
+++ b/lib/utils/get-highlight-color-for-routed-trace.ts
@@ -1,0 +1,43 @@
+import type { CircuitJsonUtilObjects } from "@tscircuit/circuit-json-util"
+
+interface NetWithHighlightColor {
+  source_net_id?: string
+  _parsedProps: { highlightColor?: string }
+}
+
+/**
+ * Resolve the highlight_color for a routed pcb_trace.
+ *
+ * A net's highlightColor lives on the Net component (props.highlightColor),
+ * not on source_net, which has no field for it. So given a routed trace's
+ * source_trace_id, we walk source_trace.connected_source_net_ids back to the
+ * matching Net component and return the first highlightColor found. If the id
+ * is itself a source_net_id (getSourceTraceIdForRoutedTrace can return one), we
+ * match that net directly.
+ */
+export function getHighlightColorForRoutedTrace({
+  db,
+  nets,
+  sourceTraceId,
+}: {
+  db: CircuitJsonUtilObjects
+  nets: NetWithHighlightColor[]
+  sourceTraceId: string | undefined
+}): string | undefined {
+  if (!sourceTraceId || nets.length === 0) return undefined
+
+  const sourceTrace = db.source_trace.get(sourceTraceId)
+  const connectedSourceNetIds = sourceTrace
+    ? sourceTrace.connected_source_net_ids
+    : db.source_net.get(sourceTraceId)
+      ? [sourceTraceId]
+      : []
+
+  for (const sourceNetId of connectedSourceNetIds ?? []) {
+    const net = nets.find((n) => n.source_net_id === sourceNetId)
+    const highlightColor = net?._parsedProps?.highlightColor
+    if (highlightColor) return highlightColor
+  }
+
+  return undefined
+}

--- a/tests/components/primitive-components/net-highlight-color-pcb-trace.test.tsx
+++ b/tests/components/primitive-components/net-highlight-color-pcb-trace.test.tsx
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("net highlightColor is written through to pcb_trace.highlight_color", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="10mm">
+      <net name="VCC" highlightColor="#ff0000" />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-6} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={6} />
+      <trace from=".R1 > .pin2" to="net.VCC" />
+      <trace from=".R2 > .pin2" to="net.VCC" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const pcbTraces = circuit.db.pcb_trace.list()
+
+  // The VCC net is routed, so at least one pcb_trace is emitted.
+  expect(pcbTraces.length).toBeGreaterThan(0)
+
+  // Every routed trace on the VCC net carries the net's highlightColor.
+  // Before the fix pcb_trace.highlight_color was always undefined, so this
+  // fails on main and passes with the wire-through.
+  for (const pcbTrace of pcbTraces) {
+    expect(pcbTrace.highlight_color).toBe("#ff0000")
+  }
+})


### PR DESCRIPTION
Closes #2839

A net's `highlightColor` prop was dropped. `NetProps.highlightColor` exists in `@tscircuit/props` and `pcb_trace.highlight_color` exists in the circuit-json schema, but nothing connected the two, so every routed `pcb_trace` came out with `highlight_color: undefined`.

```tsx
<board width="20mm" height="10mm">
  <net name="VCC" highlightColor="#ff0000" />
  <resistor name="R1" resistance="1k" footprint="0402" pcbX={-6} />
  <resistor name="R2" resistance="1k" footprint="0402" pcbX={6} />
  <trace from=".R1 > .pin2" to="net.VCC" />
  <trace from=".R2 > .pin2" to="net.VCC" />
</board>
```

A grep for either name across `lib/` returns nothing, so the prop was never read anywhere in core.

## Cause

The color has no home on `source_net`. That schema carries `is_power`, `is_ground` and the connectivity fields but no highlight field, so the value cannot ride on the net element. It has to be resolved from the `Net` component when a `pcb_trace` is written.

For a normal autorouted board the `pcb_trace` is written by the segment insert in `Group._updatePcbTraceRenderFromPcbTraces()`. That insert spread the routed trace and set `source_trace_id` plus `route`, but never looked up a highlight color, so the field stayed empty.

## The change

A small helper resolves the color from the routed trace's `source_trace_id`:

`source_trace.connected_source_net_ids` to the matching `Net` component to `net.highlightColor`.

The segment insert calls it and sets `highlight_color` only when a connected net defines one. The nets are collected once per render with `selectAll("net")`. If the id passed in is itself a `source_net_id` (which `getSourceTraceIdForRoutedTrace` can return), the helper matches that net directly.

```ts
// lib/utils/get-highlight-color-for-routed-trace.ts
for (const sourceNetId of connectedSourceNetIds) {
  const net = nets.find((n) => n.source_net_id === sourceNetId)
  if (net?._parsedProps?.highlightColor) return net._parsedProps.highlightColor
}
```

## Failing before, passing after

`tests/components/primitive-components/net-highlight-color-pcb-trace.test.tsx` is the repro above. It asserts every routed `pcb_trace` on the VCC net carries `highlight_color` equal to `"#ff0000"`.

On `main` it fails:

```
error: expect(received).toBe(expected)
Expected: "#ff0000"
Received: undefined
(fail) net highlightColor is written through to pcb_trace.highlight_color
 0 pass
 1 fail
```

With the change it passes.

## Scope

- The fix covers the autorouted path (the segment insert in `Group.ts`), which is the one that runs for a normal board and the site the issue points at.
- It is purely additive. `highlight_color` is set only when a connected net defines `highlightColor`. No net in the existing suite sets that prop, so no existing output changes and no snapshot moves.
- `source_net` is left untouched. The color lives on the `Net` component where the prop is declared, so it is resolved from there rather than mirrored onto the net element.

## Regression risk

Low. The only new output is a field that was always `undefined` before, written only for nets that opt in with `highlightColor`. `bun test net trace` stays green (176 pass, 0 fail).

## Verification

Ubuntu, bun 1.3.14, node 22.22.2.

- new test `net-highlight-color-pcb-trace.test.tsx`: 1 pass / 0 fail.
- `bun test net trace`: 176 pass / 5 skip / 0 fail, 4 snapshots.
- `bun test` (whole suite, `--timeout 30000` to match CI): 1344 pass / 37 skip / 5 fail across 1386 tests. None are caused by this change. It only adds `highlight_color` for a net that sets `highlightColor`. None of the 5 do. `tests/breakout/fanout-soic8-sensor-to-i2c-header` and `tests/breakout/breakout-sot23-regulator-power-rail` are the known external capacity-autorouter failures. `tests/repros/repro156-ti-multisheet-autolayout` and `tests/repros/repro116-arduino-uno-reroute` fail the same way on a clean `main` with this change stashed. `tests/repros/repro158-pcb-group-size` is a slow test that needs about 32s on this machine, so it trips the 30s timeout and passes with `--timeout 120000`.
- `bunx tsc --noEmit`: no output, exit 0.
- `bunx @biomejs/biome format .`: `Checked 1667 files. No fixes applied.`

AI assistance (Claude, Anthropic) was used in developing this change. Verified locally before submitting: the gates above. I am the author, I own the change and can explain it and answer questions.
