### PR TITLE
fix: write group anchor_alignment and subcircuit_id as undefined

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -533,7 +533,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             trace_clearance: props.autorouter.traceClearance,
           }
         : undefined,
-      anchor_alignment: props.pcbAnchorAlignment ?? null,
+      anchor_alignment: props.pcbAnchorAlignment ?? undefined,
     })
     this.pcb_group_id = pcb_group.pcb_group_id
 
@@ -1893,7 +1893,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     const { _parsedProps: props } = this
     const schematic_group = db.schematic_group.insert({
       is_subcircuit: this.isSubcircuit,
-      subcircuit_id: this.subcircuit_id!,
+      subcircuit_id: this.subcircuit_id ?? undefined,
       name: this.name,
       center: this._getGlobalSchematicPositionBeforeLayout(),
       width: 0,

--- a/tests/components/primitive-components/group-subcircuit-id.test.tsx
+++ b/tests/components/primitive-components/group-subcircuit-id.test.tsx
@@ -34,7 +34,7 @@ test("Subcircuit group should have subcircuit_id", async () => {
   expect(circuit.db.pcb_group.list()).toMatchInlineSnapshot(`
 [
   {
-    "anchor_alignment": null,
+    "anchor_alignment": undefined,
     "anchor_position": {
       "x": 0,
       "y": 0,

--- a/tests/groups/group-outline.test.tsx
+++ b/tests/groups/group-outline.test.tsx
@@ -26,7 +26,7 @@ test("group with outline specified", async () => {
   expect(pcb_groups).toMatchInlineSnapshot(`
     [
       {
-        "anchor_alignment": null,
+        "anchor_alignment": undefined,
         "anchor_position": {
           "x": 0,
           "y": 0,

--- a/tests/groups/group-schema-null-fields.test.tsx
+++ b/tests/groups/group-schema-null-fields.test.tsx
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { pcb_group, schematic_group } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("group emits schema-valid anchor_alignment and subcircuit_id", () => {
+  const { circuit } = getTestFixture()
+  // A plain group inside a board: not a subcircuit, no explicit pcb anchor.
+  circuit.add(
+    <board width="30mm" height="30mm">
+      <group name="G1">
+        <resistor name="R1" resistance="1k" footprint="0402" />
+      </group>
+    </board>,
+  )
+  circuit.render()
+
+  const pcbGroup = circuit.db.pcb_group.list().find((g) => g.name === "G1")
+  const schematicGroup = circuit.db.schematic_group
+    .list()
+    .find((g) => g.name === "G1")
+
+  expect(pcbGroup).toBeDefined()
+  expect(schematicGroup).toBeDefined()
+
+  // A plain group used to write null into both of these fields. circuit-json
+  // rejects null for both (anchor_alignment is an enum with a "center" default,
+  // subcircuit_id is an optional string), so the emitted elements failed to parse.
+  expect(pcbGroup!.anchor_alignment).not.toBeNull()
+  expect(schematicGroup!.subcircuit_id).not.toBeNull()
+
+  // Both elements now validate against their circuit-json schemas.
+  expect(() => pcb_group.parse(pcbGroup)).not.toThrow()
+  expect(() => schematic_group.parse(schematicGroup)).not.toThrow()
+
+  // anchor_alignment is omitted, so the schema's own "center" default applies.
+  expect(pcb_group.parse(pcbGroup).anchor_alignment).toBe("center")
+
+  // A group placed outside any subcircuit legitimately has no subcircuit_id.
+  expect(schematicGroup!.subcircuit_id).toBeUndefined()
+})

--- a/tests/groups/group-schematic-box.test.tsx
+++ b/tests/groups/group-schematic-box.test.tsx
@@ -33,7 +33,7 @@ test("group schematic box", () => {
         "schematic_group_id": "schematic_group_0",
         "show_as_schematic_box": true,
         "source_group_id": "source_group_0",
-        "subcircuit_id": null,
+        "subcircuit_id": undefined,
         "type": "schematic_group",
         "width": 0.4,
       },

--- a/tests/repros/repro158-pcb-group-size.test.tsx
+++ b/tests/repros/repro158-pcb-group-size.test.tsx
@@ -20,7 +20,7 @@ test("repro158: PCB group size", async () => {
   expect(pcb_groups).toMatchInlineSnapshot(`
     [
       {
-        "anchor_alignment": null,
+        "anchor_alignment": undefined,
         "anchor_position": {
           "x": 0,
           "y": 0,


### PR DESCRIPTION
Closes #2845

A plain `<group>` writes `null` into two fields that circuit-json does not allow to be null, so the emitted `pcb_group` and `schematic_group` fail schema validation:

```tsx
<board width="30mm" height="30mm">
  <group name="G1">
    <resistor name="R1" resistance="1k" footprint="0402" />
  </group>
</board>
```

```
pcb_group        anchor_alignment: Expected 'top_left' | 'top_center' | ... | 'bottom_right', received null
schematic_group  subcircuit_id: Expected string, received null
```

## Cause

Two insert sites in `Group.ts` write an explicit `null`:

```ts
// doInitialPcbComponentRender, the pcb_group insert
anchor_alignment: props.pcbAnchorAlignment ?? null,

// doInitialSchematicComponentRender, the schematic_group insert
subcircuit_id: this.subcircuit_id!,   // this.subcircuit_id is `string | null`, null for a non-subcircuit group
```

The matching schemas do not accept `null`:

```ts
pcb_group.anchor_alignment       ninePointAnchor.default("center")
schematic_group.subcircuit_id    z.string().optional()
```

`this.subcircuit_id` is only set for a group that is itself a subcircuit. For a plain group it stays `null`. The `!` non-null assertion just hid that a `null` was being written. `anchor_alignment` is `null` whenever `pcbAnchorAlignment` is not passed.

## The change

Write `undefined` instead of `null` at both sites:

```ts
anchor_alignment: props.pcbAnchorAlignment ?? undefined,
subcircuit_id: this.subcircuit_id ?? undefined,
```

`undefined` is correct for both. `subcircuit_id` is an optional string, so omitting it is valid for a group that lives outside any subcircuit. For `anchor_alignment` omitting it is strictly better than `null`: the schema's own `.default("center")` applies on parse instead of a value the schema rejects. The `?? undefined` form also matches how the codebase already emits a nullable `subcircuit_id` elsewhere (for example `NormalComponent_doInitialSourceDesignRuleChecks.ts` uses `... ?? undefined`).

## Failing before, passing after

`tests/groups/group-schema-null-fields.test.tsx` renders a plain group inside a board, then parses the emitted `pcb_group` and `schematic_group` against their circuit-json schemas.

On `main` it fails: the raw `anchor_alignment` is `null`.

```
28 |   expect(pcbGroup!.anchor_alignment).not.toBeNull()
                                              ^
error: expect(received).not.toBeNull()
Received: null
 0 pass
 1 fail
```

With the change both elements parse, the `anchor_alignment` default resolves to `"center"` and the group's `subcircuit_id` is absent rather than `null`.

```
 1 pass
 0 fail
 8 expect() calls
```

## Snapshots moved

Four existing inline snapshots recorded the invalid values, which is why nothing caught this. Each moves by one line, `null` to `undefined`, nothing else:

- `tests/groups/group-outline.test.tsx` (`anchor_alignment`)
- `tests/components/primitive-components/group-subcircuit-id.test.tsx` (`anchor_alignment`)
- `tests/repros/repro158-pcb-group-size.test.tsx` (`anchor_alignment`)
- `tests/groups/group-schematic-box.test.tsx` (`subcircuit_id`)

## Scope

- Only the two `null` writes change. A subcircuit group still gets its real `subcircuit_id`. A group with an explicit `pcbAnchorAlignment` still gets that value.
- The schematic_group keeps `undefined` rather than inheriting the enclosing subcircuit's id. That matches what #2845 asks for and is the smaller change. The pcb_group already inherits it, so I can align the schematic side too if you would rather they match.
- A group that sets `pcbX`/`pcbY` still emits `display_offset_x`/`_y` as numbers, which is the separate #2841. That is out of scope here, so the new test uses a group without explicit pcb position to isolate #2845.

## Regression risk

Low. The only values that change are two that were `null` and rejected by the schema, so no valid consumer could have relied on them. Targeted `bun test group subcircuit` is green.

## Verification

Ubuntu, bun 1.3.14, node 22.22.2.

- `bun test tests/groups/group-schema-null-fields.test.tsx`: 1 pass / 0 fail.
- `bun test group subcircuit`: 146 pass / 4 skip / 0 fail.
- `bun test` (whole suite, run in the same shards CI uses via `scripts/generate-test-plan.ts`): 1346 pass / 37 skip / 3 fail across 1386 tests. Two fails are the pre-existing `tests/breakout` cases (`fanout-soic8-sensor-to-i2c-header`, `breakout-sot23-regulator-power-rail`). They fail the same way on a clean `main` with this change stashed, from the external capacity-autorouter returning no traces. The third, `repro156-ti-multisheet-autolayout`, timed out at 38s under local load (CI `--timeout 30000`) and passes on its own with room to run. None of the three touch groups.
- `bunx tsc --noEmit`: no output, exit 0.
- `bunx @biomejs/biome format .`: no fixes applied.

This change was developed with AI assistance (Claude, Anthropic). Verified locally before submitting: the gates above. I am the author, I own the change and can explain it and answer questions.
