### PR TITLE
Update calculate-packing to 0.0.86

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@flatten-js/core": "^1.6.2",
     "@lume/kiwi": "^0.4.3",
     "calculate-cell-boundaries": "^0.0.13",
-    "calculate-packing": "^0.0.82",
+    "calculate-packing": "^0.0.86",
     "css-select": "5.1.0",
     "format-si-unit": "^0.0.7",
     "nanoid": "^5.0.7",


### PR DESCRIPTION
## Summary

- update `calculate-packing` from `^0.0.82` to the latest published `^0.0.86`
- adopt the weighted-connection lookup indexing included in the latest release

## Why

The newer package avoids repeatedly scanning the full weighted-connections list during PCB packing. This reduces layout time for boards with many explicit traces while preserving packing behavior.

## Validation

- confirmed npm `latest` is `0.0.86`
- confirmed the installed dependency resolves to `calculate-packing@0.0.86`
- `bunx tsc --noEmit`
- `bun run build`
- PCB packing-focused tests: 20 pass, 0 fail
  - 19 passed in the grouped run
  - one Xiao-board test hit its 5-second timeout on the cold grouped run, then passed alone in 2.87 seconds
- `git diff --check`

This repository disables lockfile generation, so the dependency declaration is the only changed file.
