### PR TITLE
Update capacity autorouter to 0.0.757

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
-    "@tscircuit/capacity-autorouter": "^0.0.756",
+    "@tscircuit/capacity-autorouter": "^0.0.757",
     "@tscircuit/checks": "0.0.151",
     "@tscircuit/circuit-json-util": "^0.0.104",
     "@tscircuit/common": "^0.0.20",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
-    "@tscircuit/capacity-autorouter": "^0.0.750",
+    "@tscircuit/capacity-autorouter": "^0.0.756",
     "@tscircuit/checks": "0.0.151",
     "@tscircuit/circuit-json-util": "^0.0.104",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

- update `@tscircuit/capacity-autorouter` from `^0.0.750` to `^0.0.757`
- keep core on the latest published capacity autorouter release

## Included autorouter changes

The releases from `0.0.751` through `0.0.757` include these merged commits:

- [`8f2ac3de`](https://github.com/tscircuit/tscircuit-autorouter/commit/8f2ac3dec7546778aa3f5a9373ae11a914bcc7ab) / [#1927](https://github.com/tscircuit/tscircuit-autorouter/pull/1927) — track generated stitches during clearance-aware routing, prefer collision-free stitches, and validate stitch segments against existing route geometry
- [`ea90b17d`](https://github.com/tscircuit/tscircuit-autorouter/commit/ea90b17d) / [#1933](https://github.com/tscircuit/tscircuit-autorouter/pull/1933) — add an F1C100S breakout routing regression fixture
- [`ec0ad383`](https://github.com/tscircuit/tscircuit-autorouter/commit/ec0ad383) / [#1937](https://github.com/tscircuit/tscircuit-autorouter/pull/1937) — validate shared-via-site repair in Pipeline 7 and increase broad repair iterations from 8 to 12
- [`e439ba70`](https://github.com/tscircuit/tscircuit-autorouter/commit/e439ba70) / [#1941](https://github.com/tscircuit/tscircuit-autorouter/pull/1941) — pin the SMT-pad layer-escape repair revision
- [`9b2e6cb2`](https://github.com/tscircuit/tscircuit-autorouter/commit/9b2e6cb2) / [#1947](https://github.com/tscircuit/tscircuit-autorouter/pull/1947) — update the bugreport66 fixture and snapshot
- [`3fcc66cc`](https://github.com/tscircuit/tscircuit-autorouter/commit/3fcc66cc) / [#1953](https://github.com/tscircuit/tscircuit-autorouter/pull/1953) — add a strict board-outline DRC regression for bugreport84
- [`4f40eb72`](https://github.com/tscircuit/tscircuit-autorouter/commit/4f40eb72a9548cc83e877e12f0e34d70ec1072a6) / [#1974](https://github.com/tscircuit/tscircuit-autorouter/pull/1974) — update the length-matching solver to include the asymmetric-terminal fix while retaining backward-compatible non-ideal post-processing output

Release commits: [#1930](https://github.com/tscircuit/tscircuit-autorouter/pull/1930), [#1936](https://github.com/tscircuit/tscircuit-autorouter/pull/1936), [#1943](https://github.com/tscircuit/tscircuit-autorouter/pull/1943), [#1948](https://github.com/tscircuit/tscircuit-autorouter/pull/1948), [#1965](https://github.com/tscircuit/tscircuit-autorouter/pull/1965), [#1973](https://github.com/tscircuit/tscircuit-autorouter/pull/1973), and [#1975](https://github.com/tscircuit/tscircuit-autorouter/pull/1975).

## Impact

Core installations now resolve the latest capacity autorouter fixes, routing behavior, length-matching update, and regression coverage.

## Validation

- `bun test tests/utils/autorouting/capacity-mesh-autorouter tests/features/capacity-mesh-autorouting1.test.tsx`
- `bunx tsc --noEmit`