### PR TITLE
fix(fanout): explain how to fix a breakout that has no room to escape

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -29,6 +29,7 @@ import type { GraphicsObject } from "graphics-debug"
 import type { PrimitiveComponent } from "lib/components/base-components/PrimitiveComponent"
 import { AutorouterError } from "lib/errors/AutorouterError"
 import type { AutorouterOptions } from "lib/utils/autorouting/CapacityMeshAutorouter"
+import { getPcbComponentNamesById } from "lib/utils/autorouting/get-pcb-component-names-by-id"
 import { FanoutAutorouter } from "lib/utils/autorouting/FanoutAutorouter"
 import type { GenericLocalAutorouter } from "lib/utils/autorouting/GenericLocalAutorouter"
 import type { SimplifiedPcbTrace } from "lib/utils/autorouting/SimpleRouteJson"
@@ -1328,6 +1329,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
               busFanoutDirections: routingPhasePlan.busFanoutDirections,
               fanoutBounds: routingPhasePlan.fanoutBounds,
               fanoutRoutingLayers: routingPhasePlan.fanoutRoutingLayers,
+              componentNamesById: getPcbComponentNamesById(db),
             })
           }
 

--- a/lib/utils/autorouting/FanoutAutorouter.ts
+++ b/lib/utils/autorouting/FanoutAutorouter.ts
@@ -25,6 +25,7 @@ import type {
   SimplifiedPcbTrace,
 } from "./SimpleRouteJson"
 import { getFanoutSharedBoundary } from "./get-fanout-shared-boundary"
+import { getFanoutSpaceErrorMessage } from "./get-fanout-space-error-message"
 
 export type FanoutAutorouterMode = "single_layer_fanout" | "fanout"
 
@@ -33,6 +34,8 @@ export interface FanoutAutorouterOptions {
   busFanoutDirections?: Readonly<Record<string, BusFanoutDirection>>
   fanoutBounds?: SimpleRouteBounds
   fanoutRoutingLayers?: string[]
+  /** Used to name components in fanout failure messages. */
+  componentNamesById?: ReadonlyMap<string, string>
 }
 
 export interface ResolveFanoutBoundsOptions extends FanoutAutorouterOptions {
@@ -423,7 +426,18 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
     )
     fanoutSolver.solve()
     if (fanoutSolver.failed) {
-      throw new Error(fanoutSolver.error ?? "Fanout routing failed")
+      throw new Error(
+        getFanoutSpaceErrorMessage({
+          input: this.input,
+          solverError: fanoutSolver.error,
+          componentIds: new Set(
+            fanoutSolver.preparedBuses.map((bus) => bus.componentId),
+          ),
+          sharedBoundary:
+            this.options.fanoutBounds ?? fanoutSolverOptions.sharedBoundary,
+          componentNamesById: this.options.componentNamesById,
+        }),
+      )
     }
     const output = fanoutSolver.getOutput()
     const fanoutSimpleRouteJson =

--- a/lib/utils/autorouting/get-fanout-space-error-message.ts
+++ b/lib/utils/autorouting/get-fanout-space-error-message.ts
@@ -1,0 +1,97 @@
+import type { SimpleRouteBounds, SimpleRouteJson } from "./SimpleRouteJson"
+
+/**
+ * The fanout solver reports a bare routed/total count when it cannot escape a
+ * package. On a board that reads as "0/27 connections" with no indication of
+ * what to change, so translate it into the two things that actually fix it:
+ * widen the breakout, or pull the surrounding parts inside it.
+ */
+
+const roundMm = (value: number) => Math.round(value * 1000) / 1000
+
+const getPadBoundsForComponents = (
+  input: SimpleRouteJson,
+  componentIds: ReadonlySet<string>,
+): SimpleRouteBounds | undefined => {
+  let bounds: SimpleRouteBounds | undefined
+  for (const obstacle of input.obstacles) {
+    if (!obstacle.componentId || !componentIds.has(obstacle.componentId)) {
+      continue
+    }
+    const minX = obstacle.center.x - obstacle.width / 2
+    const maxX = obstacle.center.x + obstacle.width / 2
+    const minY = obstacle.center.y - obstacle.height / 2
+    const maxY = obstacle.center.y + obstacle.height / 2
+    bounds = bounds
+      ? {
+          minX: Math.min(bounds.minX, minX),
+          maxX: Math.max(bounds.maxX, maxX),
+          minY: Math.min(bounds.minY, minY),
+          maxY: Math.max(bounds.maxY, maxY),
+        }
+      : { minX, maxX, minY, maxY }
+  }
+  return bounds
+}
+
+/**
+ * Narrowest gap between the fanned-out pads and the boundary they must reach.
+ * This is the space every escape has to share, so it is the number worth
+ * quoting back to the user.
+ */
+const getNarrowestGap = (
+  padBounds: SimpleRouteBounds,
+  boundary: SimpleRouteBounds,
+): number =>
+  Math.min(
+    padBounds.minX - boundary.minX,
+    boundary.maxX - padBounds.maxX,
+    padBounds.minY - boundary.minY,
+    boundary.maxY - padBounds.maxY,
+  )
+
+export const getFanoutSpaceErrorMessage = ({
+  input,
+  solverError,
+  componentIds,
+  sharedBoundary,
+  componentNamesById,
+}: {
+  input: SimpleRouteJson
+  solverError: string | null | undefined
+  componentIds: ReadonlySet<string>
+  sharedBoundary: SimpleRouteBounds | undefined
+  componentNamesById?: ReadonlyMap<string, string>
+}): string => {
+  const routedMatch = solverError?.match(/routed (\d+)\/(\d+) connections/)
+  const routedCount = routedMatch ? Number(routedMatch[1]) : undefined
+  const connectionCount = routedMatch
+    ? Number(routedMatch[2])
+    : input.connections.length
+
+  const componentLabels = [...componentIds]
+    .map((componentId) => componentNamesById?.get(componentId) ?? componentId)
+    .sort()
+  const componentSummary =
+    componentLabels.length > 0 ? ` for ${componentLabels.join(", ")}` : ""
+
+  const lines: string[] = [
+    routedCount === undefined
+      ? `Fanout failed${componentSummary}: ${solverError ?? "the fanout solver did not report a reason"}.`
+      : `Fanout failed${componentSummary}: only ${routedCount} of ${connectionCount} connections could escape to the breakout boundary.`,
+  ]
+
+  const padBounds = getPadBoundsForComponents(input, componentIds)
+  if (padBounds && sharedBoundary) {
+    const gap = getNarrowestGap(padBounds, sharedBoundary)
+    lines.push(
+      `The breakout boundary is ${roundMm(gap)}mm from the pads at its narrowest point, which all ${connectionCount} escapes have to share.`,
+    )
+  }
+
+  lines.push(
+    "Give the fanout more room by increasing the breakout's padding, or by extending the breakout to include the parts crowding it (decoupling capacitors, series resistors) so their pads sit inside the boundary instead of against it.",
+  )
+
+  return lines.join(" ")
+}

--- a/lib/utils/autorouting/get-pcb-component-names-by-id.ts
+++ b/lib/utils/autorouting/get-pcb-component-names-by-id.ts
@@ -1,0 +1,21 @@
+import type { CircuitJsonUtilObjects } from "@tscircuit/circuit-json-util"
+
+/**
+ * Maps pcb_component_id (what SimpleRouteJson obstacles carry as componentId)
+ * to the source component name, so autorouting messages can say "U_MCU"
+ * instead of "pcb_component_0".
+ */
+export const getPcbComponentNamesById = (
+  db: CircuitJsonUtilObjects,
+): ReadonlyMap<string, string> => {
+  const namesById = new Map<string, string>()
+  for (const pcbComponent of db.pcb_component.list()) {
+    const sourceComponent = db.source_component.get(
+      pcbComponent.source_component_id,
+    )
+    if (sourceComponent?.name) {
+      namesById.set(pcbComponent.pcb_component_id, sourceComponent.name)
+    }
+  }
+  return namesById
+}

--- a/lib/utils/autorouting/localAutorouterStrategies.ts
+++ b/lib/utils/autorouting/localAutorouterStrategies.ts
@@ -21,6 +21,7 @@ export interface LocalAutorouterStrategyContext {
   busFanoutDirections?: AutoroutingPhaseProps["busFanoutDirections"]
   fanoutBounds?: SimpleRouteBounds
   fanoutRoutingLayers?: string[]
+  componentNamesById?: ReadonlyMap<string, string>
 }
 
 export interface LocalAutorouterStrategy {
@@ -51,12 +52,14 @@ const createFanoutAutorouterStrategy = (
     busFanoutDirections,
     fanoutBounds,
     fanoutRoutingLayers,
+    componentNamesById,
   }) =>
     new FanoutAutorouter(simpleRouteJson, {
       mode,
       busFanoutDirections,
       fanoutBounds,
       fanoutRoutingLayers,
+      componentNamesById,
     }),
 })
 

--- a/tests/breakout/breakout-insufficient-fanout-space-error.test.tsx
+++ b/tests/breakout/breakout-insufficient-fanout-space-error.test.tsx
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const qfnFootprint =
+  "qfn56_w7.8_h7.8_p0.4mm_pw0.23mm_pl0.8mm_thermalpad3.2x3.2" as const
+
+/**
+ * A breakout that hugs a fine-pitch QFN cannot fan out: the escapes have no
+ * room between the pads and the boundary. The failure should say so, and say
+ * what to change, rather than surfacing the solver's bare routed/total count.
+ */
+test("a breakout with too little room reports how to give the fanout space", async () => {
+  const { circuit } = getTestFixture({
+    platform: { placementDrcChecksDisabled: true },
+  })
+
+  const pins = Array.from({ length: 24 }, (_, index) => index + 1)
+
+  circuit.add(
+    <board width="30mm" height="30mm" layers={4}>
+      <breakout name="TIGHT" padding="0.05mm">
+        <chip name="U1" footprint={qfnFootprint} pcbX={0} pcbY={0} />
+      </breakout>
+      {pins.map((pin) => (
+        <resistor
+          key={String(pin)}
+          name={`R${pin}`}
+          resistance="1k"
+          footprint="0402"
+          pcbX={-12 + (pin % 12) * 2}
+          pcbY={pin < 13 ? 12 : -12}
+        />
+      ))}
+      {pins.map((pin) => (
+        <trace
+          key={String(pin)}
+          name={`T${pin}`}
+          from={`.U1 > .pin${pin}`}
+          to={`.R${pin} > .pin1`}
+        />
+      ))}
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const autoroutingErrors = circuitJson.filter(
+    (element) => element.type === "pcb_autorouting_error",
+  ) as Array<{ message: string }>
+
+  expect(autoroutingErrors.length).toBeGreaterThan(0)
+  const message = autoroutingErrors.map((error) => error.message).join("\n")
+
+  // Names the component rather than a pcb_component_id.
+  expect(message).toContain("U1")
+  // Says what went wrong in board terms.
+  expect(message).toContain("escape to the breakout boundary")
+  // Says what to do about it -- both remedies.
+  expect(message).toContain("padding")
+  expect(message).toContain("decoupling capacitors")
+  // Does not leak the raw solver phrasing.
+  expect(message).not.toContain("best layer assignment")
+})


### PR DESCRIPTION
## Problem

When a `<breakout>` hugs a fine-pitch package there is genuinely not enough room to escape its pins, and the solver correctly refuses. But `FanoutAutorouter.solveFanout` rethrew the solver's internal phrasing verbatim:

```
FanoutSolver: best layer assignment routed 0/27 connections
```

Nothing there tells a board author what to change — it reads like a solver defect rather than a design constraint. I chased it as a solver bug and got as far as opening a reproduction against tscircuit/fanout-solver before realising the fanout simply needed more space.

## Fix

Translate the failure into board terms at the point where core owns the context:

```
Fanout failed for U1: only 2 of 24 connections could escape to the breakout
boundary. The breakout boundary is 0.05mm from the pads at its narrowest point,
which all 24 escapes have to share. Give the fanout more room by increasing the
breakout's padding, or by extending the breakout to include the parts crowding
it (decoupling capacitors, series resistors) so their pads sit inside the
boundary instead of against it.
```

Three things it adds over the old message:

1. **Names the component.** `componentNamesById` is plumbed from `Group` through the local-autorouter strategy, so obstacles' `pcb_component_id` values are resolved to source names — `U1`, not `pcb_component_0`.
2. **Quotes the number that matters.** The narrowest gap between the fanned-out pads and the boundary is the space every escape shares, so that is what gets measured and reported.
3. **Names both remedies**, because which one is right depends on the layout: widen the breakout, or pull the crowding parts inside it so the boundary sits outside them rather than between them.

New files are small and single-purpose: `get-fanout-space-error-message.ts` builds the message, `get-pcb-component-names-by-id.ts` does the id → name lookup.

## Tests

`tests/breakout/breakout-insufficient-fanout-space-error.test.tsx` — a QFN56 in a `padding="0.05mm"` breakout with 24 pins escaping. Asserts the `pcb_autorouting_error` names `U1`, explains the failure, names both remedies, and no longer leaks `best layer assignment`.

Typecheck clean. `tests/breakout` is 12 pass / 2 skip / 2 fail, and both failures (`fanout-soic8-sensor-to-i2c-header`, `breakout-sot23-regulator-power-rail`) reproduce unchanged on a clean checkout of this branch point — they are not from this change.

## Note

The gap is only reported when a shared boundary is available. Worth a separate look: for a `<breakout>` core currently passes neither `sharedBoundary` nor `componentBounds` to the solver — `solverOptions` is just `{ borderDistribution, compactBusTracks }` — which sits awkwardly against the fanout solver's "all footprints in one problem escape through the same shared boundary" invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)