### PR TITLE
fix(breakout): warn when `padding` is set but the fanout boundary is not

### DIFF
--- a/lib/components/primitive-components/Breakout/Breakout.ts
+++ b/lib/components/primitive-components/Breakout/Breakout.ts
@@ -6,6 +6,7 @@ import { BreakoutPoint } from "../BreakoutPoint"
 import type { Trace } from "../Trace/Trace"
 import type { Port } from "../Port"
 import { createBreakoutPointSolverInput } from "./createBreakoutPointSolverInput"
+import { Breakout_warnAboutIgnoredPadding } from "./Breakout_warnAboutIgnoredPadding"
 
 export class Breakout extends Group<typeof breakoutProps> {
   override get isRoutingDirective() {
@@ -17,6 +18,11 @@ export class Breakout extends Group<typeof breakoutProps> {
       ...super.config,
       zodProps: breakoutProps,
     }
+  }
+
+  override doInitialSourceRender(): void {
+    super.doInitialSourceRender()
+    Breakout_warnAboutIgnoredPadding(this)
   }
 
   /**

--- a/lib/components/primitive-components/Breakout/Breakout_warnAboutIgnoredPadding.ts
+++ b/lib/components/primitive-components/Breakout/Breakout_warnAboutIgnoredPadding.ts
@@ -1,0 +1,53 @@
+import type { Breakout } from "./Breakout"
+
+const PADDING_PROP_NAMES = [
+  "padding",
+  "paddingX",
+  "paddingY",
+  "paddingLeft",
+  "paddingRight",
+  "paddingTop",
+  "paddingBottom",
+] as const
+
+/**
+ * `<breakout padding>` pads the group's layout; it does not move the boundary
+ * the fanout escapes to. That only follows `fanoutBoundaryPadding`, so a
+ * breakout that sets padding alone silently gets the tight bounding box of its
+ * contents -- which reads as "I gave the fanout room and it still failed".
+ *
+ * Warn instead of quietly honouring `padding` as the fanout boundary: a wider
+ * boundary changes routing outcomes, so reinterpreting it would alter existing
+ * boards rather than just informing them.
+ */
+export const Breakout_warnAboutIgnoredPadding = (breakout: Breakout) => {
+  const { db } = breakout.root!
+  const props = breakout._parsedProps as Record<string, unknown>
+
+  if (props.fanoutBoundaryPadding !== undefined) return
+  // Explicit geometry already pins the boundary, so padding is not the knob
+  // the user is reaching for.
+  if (
+    props.width !== undefined ||
+    props.height !== undefined ||
+    (Array.isArray(props.outline) && props.outline.length > 0)
+  ) {
+    return
+  }
+
+  const setPaddingProps = PADDING_PROP_NAMES.filter(
+    (propName) => props[propName] !== undefined,
+  )
+  if (setPaddingProps.length === 0) return
+
+  db.source_property_ignored_warning.insert({
+    source_component_id: breakout.source_component_id ?? "",
+    property_name: setPaddingProps[0]!,
+    subcircuit_id: breakout.getSubcircuit().subcircuit_id ?? undefined,
+    error_type: "source_property_ignored_warning",
+    message:
+      `Breakout ${breakout.name} sets ${setPaddingProps.map((propName) => `"${propName}"`).join(", ")} but no "fanoutBoundaryPadding", ` +
+      "so the fanout still escapes to the tight bounding box of the breakout's contents. " +
+      'Padding props only pad the group\'s layout. Set "fanoutBoundaryPadding" to give the fanout room to escape into.',
+  })
+}

--- a/tests/breakout/breakout-padding-does-not-move-fanout-boundary1.test.tsx
+++ b/tests/breakout/breakout-padding-does-not-move-fanout-boundary1.test.tsx
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const qfnFootprint =
+  "qfn56_w7.8_h7.8_p0.4mm_pw0.23mm_pl0.8mm_thermalpad3.2x3.2" as const
+
+const getPropertyIgnoredWarnings = (circuit: any) =>
+  circuit
+    .getCircuitJson()
+    .filter(
+      (element: any) => element.type === "source_property_ignored_warning",
+    ) as Array<{ property_name: string; message: string }>
+
+const addBoard = (circuit: any, breakoutProps: Record<string, string>) => {
+  circuit.add(
+    <board width="30mm" height="30mm" layers={4}>
+      <breakout name="ESCAPE" {...breakoutProps}>
+        <chip name="U1" footprint={qfnFootprint} pcbX={0} pcbY={0} />
+      </breakout>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={10} pcbY={0} />
+      <trace name="T1" from=".U1 > .pin1" to=".R1 > .pin1" />
+    </board>,
+  )
+}
+
+test("padding alone on a breakout warns that it does not move the fanout boundary", async () => {
+  const { circuit } = getTestFixture({
+    platform: { placementDrcChecksDisabled: true },
+  })
+  addBoard(circuit, { padding: "1.2mm" })
+  await circuit.renderUntilSettled()
+
+  const warnings = getPropertyIgnoredWarnings(circuit)
+  expect(warnings).toHaveLength(1)
+  expect(warnings[0]!.property_name).toBe("padding")
+  expect(warnings[0]!.message).toContain("ESCAPE")
+  expect(warnings[0]!.message).toContain("fanoutBoundaryPadding")
+}, 60_000)

--- a/tests/breakout/breakout-padding-does-not-move-fanout-boundary2.test.tsx
+++ b/tests/breakout/breakout-padding-does-not-move-fanout-boundary2.test.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const qfnFootprint =
+  "qfn56_w7.8_h7.8_p0.4mm_pw0.23mm_pl0.8mm_thermalpad3.2x3.2" as const
+
+const getPropertyIgnoredWarnings = (circuit: any) =>
+  circuit
+    .getCircuitJson()
+    .filter(
+      (element: any) => element.type === "source_property_ignored_warning",
+    ) as Array<{ property_name: string; message: string }>
+
+const addBoard = (circuit: any, breakoutProps: Record<string, string>) => {
+  circuit.add(
+    <board width="30mm" height="30mm" layers={4}>
+      <breakout name="ESCAPE" {...breakoutProps}>
+        <chip name="U1" footprint={qfnFootprint} pcbX={0} pcbY={0} />
+      </breakout>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={10} pcbY={0} />
+      <trace name="T1" from=".U1 > .pin1" to=".R1 > .pin1" />
+    </board>,
+  )
+}
+
+test("no warning once fanoutBoundaryPadding is set", async () => {
+  const { circuit } = getTestFixture({
+    platform: { placementDrcChecksDisabled: true },
+  })
+  addBoard(circuit, { padding: "1.2mm", fanoutBoundaryPadding: "1.2mm" })
+  await circuit.renderUntilSettled()
+
+  expect(getPropertyIgnoredWarnings(circuit)).toHaveLength(0)
+}, 60_000)

--- a/tests/breakout/breakout-padding-does-not-move-fanout-boundary3.test.tsx
+++ b/tests/breakout/breakout-padding-does-not-move-fanout-boundary3.test.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const qfnFootprint =
+  "qfn56_w7.8_h7.8_p0.4mm_pw0.23mm_pl0.8mm_thermalpad3.2x3.2" as const
+
+const getPropertyIgnoredWarnings = (circuit: any) =>
+  circuit
+    .getCircuitJson()
+    .filter(
+      (element: any) => element.type === "source_property_ignored_warning",
+    ) as Array<{ property_name: string; message: string }>
+
+const addBoard = (circuit: any, breakoutProps: Record<string, string>) => {
+  circuit.add(
+    <board width="30mm" height="30mm" layers={4}>
+      <breakout name="ESCAPE" {...breakoutProps}>
+        <chip name="U1" footprint={qfnFootprint} pcbX={0} pcbY={0} />
+      </breakout>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={10} pcbY={0} />
+      <trace name="T1" from=".U1 > .pin1" to=".R1 > .pin1" />
+    </board>,
+  )
+}
+
+test("no warning when a breakout sets no padding at all", async () => {
+  const { circuit } = getTestFixture({
+    platform: { placementDrcChecksDisabled: true },
+  })
+  addBoard(circuit, {})
+  await circuit.renderUntilSettled()
+
+  expect(getPropertyIgnoredWarnings(circuit)).toHaveLength(0)
+}, 60_000)


### PR DESCRIPTION
## The trap

`<breakout padding="1.2mm">` reads like it gives the fanout room to escape into. It does not — `padding` pads the group's layout, and the fanout boundary follows `fanoutBoundaryPadding` alone. A breakout that sets only `padding` silently keeps the tight bounding box of its contents.

Verified by dumping the resolved `fanoutBounds` for the same board:

| breakout props | resolved fanoutBounds |
|---|---|
| `padding="1.2mm"` | `x -6.38..6.68, y -6.28..4.01` |
| `padding="4.5mm"` | `x -6.38..6.68, y -6.28..4.01` — byte-identical |
| `fanoutBoundaryPadding="1.2mm"` | grows by exactly 1.2mm on every side |

Note `maxY` in the first two: 4.0124mm, which is exactly the QFN's top pad edge. The boundary sits *on* the pads, and no amount of `padding` moves it.

This is easy to lose time to, because the failure it produces looks like a solver problem rather than a prop that did nothing. I hit it on a real board and spent a while on the wrong hypothesis before noticing the bounds were unchanged.

## The fix

Warn when a breakout sets any padding prop (`padding`, `paddingX/Y`, `paddingLeft/Right/Top/Bottom`) without `fanoutBoundaryPadding`:

```
Breakout ESCAPE sets "padding" but no "fanoutBoundaryPadding", so the fanout
still escapes to the tight bounding box of the breakout's contents. Padding
props only pad the group's layout. Set "fanoutBoundaryPadding" to give the
fanout room to escape into.
```

Emitted as `source_property_ignored_warning`, which is what core already uses for "you set this and it was ignored" (the deprecated-autorouter warning in `Group.doInitialSourceRender` is the precedent).

Suppressed when `fanoutBoundaryPadding` is set, and when the breakout has explicit `width`/`height`/`outline`, since geometry already pins the boundary and padding is not the knob being reached for.

### Why warn instead of honouring `padding`

Making `padding` feed the fanout boundary is the tempting fix, and arguably what the prop should have meant. I did not do it because a wider boundary changes routing outcomes — it is not a safe no-op. Concretely, widening the boundary on one real breakout takes it from 13/23 connections routed to 0/23 (tscircuit/fanout-solver#28), so silently reinterpreting the prop would change existing boards' routing, some of them for the worse. That is a deliberate call worth overriding if you would rather the prop just worked.

## Tests

Three files, one test each per the repo convention:

1. padding alone → exactly one warning, naming the breakout and `fanoutBoundaryPadding`
2. `padding` + `fanoutBoundaryPadding` → no warning
3. no padding at all → no warning

`tests/breakout` is 15 pass / 2 skip / 2 fail; both failures (`fanout-soic8-sensor-to-i2c-header`, `breakout-sot23-regulator-power-rail`) reproduce on a clean checkout of this branch point. Two typecheck errors about `pcbPackSolverTimeoutMs` are likewise pre-existing on `main` — a props version skew, unrelated to this change.

## Related

- tscircuit/core#3052 — makes the "no room to escape" failure say so in board terms, and points at `fanoutBoundaryPadding`
- tscircuit/fanout-solver#28 — the solver bug behind the 13/23 → 0/23 number above

🤖 Generated with [Claude Code](https://claude.com/claude-code)