### PR TITLE
Fix validation for invalid capacitor capacitance

### DIFF
--- a/lib/components/normal-components/Capacitor.ts
+++ b/lib/components/normal-components/Capacitor.ts
@@ -1,17 +1,23 @@
 import { capacitorProps } from "@tscircuit/props"
 import type { SourceSimpleCapacitorInput } from "circuit-json"
+import { formatSiUnit } from "format-si-unit"
 import {
-  FTYPE,
   type BaseSymbolName,
+  FTYPE,
   type PolarizedPassivePorts,
 } from "lib/utils/constants"
+import { z } from "zod"
 import { NormalComponent } from "../base-components/NormalComponent/NormalComponent"
 import { Trace } from "../primitive-components/Trace/Trace"
 import { Capacitor_getAutomaticMaxDecouplingTraceLength } from "./Capacitor_getAutomaticMaxDecouplingTraceLength"
-import { formatSiUnit } from "format-si-unit"
+
+const capacitorPropsWithFiniteCapacitance = capacitorProps.extend({
+  // Unit parsing is a transform, so validate its numeric output as well.
+  capacitance: capacitorProps.shape.capacitance.pipe(z.number().finite()),
+})
 
 export class Capacitor extends NormalComponent<
-  typeof capacitorProps,
+  typeof capacitorPropsWithFiniteCapacitance,
   PolarizedPassivePorts
 > {
   _adjustSilkscreenTextAutomatically = true
@@ -21,7 +27,7 @@ export class Capacitor extends NormalComponent<
       schematicSymbolName: this.props.polarized
         ? "capacitor_polarized"
         : (this.props.symbolName ?? ("capacitor" as BaseSymbolName)),
-      zodProps: capacitorProps,
+      zodProps: capacitorPropsWithFiniteCapacitance,
       sourceFtype: FTYPE.simple_capacitor,
     }
   }
@@ -41,21 +47,11 @@ export class Capacitor extends NormalComponent<
     }
   }
 
-  _getSchematicSymbolDisplayValue(): string | undefined {
-    const inputCapacitance = this.props.capacitance
-    let capacitanceDisplay: string | undefined
-
-    if (
-      this._parsedProps.capacitance !== undefined &&
-      !isNaN(this._parsedProps.capacitance)
-    ) {
-      capacitanceDisplay =
-        typeof inputCapacitance === "string"
-          ? inputCapacitance
-          : `${formatSiUnit(this._parsedProps.capacitance)}F`
-    } else {
-      capacitanceDisplay = `${formatSiUnit(this._parsedProps.capacitance)}F`
-    }
+  _getSchematicSymbolDisplayValue(): string {
+    const capacitanceDisplay =
+      typeof this.props.capacitance === "string"
+        ? this.props.capacitance
+        : `${formatSiUnit(this._parsedProps.capacitance)}F`
 
     if (
       this._parsedProps.schShowRatings &&

--- a/tests/components/normal-components/capacitor-display-value.test.tsx
+++ b/tests/components/normal-components/capacitor-display-value.test.tsx
@@ -172,31 +172,3 @@ test("capacitor with numeric values handles display correctly", () => {
     import.meta.path + "-capacitor-numeric-values",
   )
 })
-
-test("capacitor with invalid capacitance string outputs NaNpF display_capacitance", () => {
-  const { project } = getTestFixture()
-
-  project.add(
-    <board width="10mm" height="10mm">
-      <capacitor
-        name="C1"
-        capacitance="lijF"
-        footprint="0402"
-        pcbX={0}
-        pcbY={0}
-      />
-    </board>,
-  )
-
-  project.render()
-
-  const capacitors = project.db.source_component.list({
-    ftype: "simple_capacitor",
-  }) as Array<{
-    ftype: "simple_capacitor"
-    display_capacitance?: string
-  }>
-
-  expect(capacitors).toHaveLength(1)
-  expect(capacitors[0].display_capacitance).toBe("NaNpF")
-})

--- a/tests/components/normal-components/capacitor-invalid-capacitance.test.tsx
+++ b/tests/components/normal-components/capacitor-invalid-capacitance.test.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("capacitor with invalid capacitance produces a validation error", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board routingDisabled>
+      <capacitor name="C1" capacitance="not-a-capacitance" footprint="0402" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(
+    circuit.db.source_component.list({ ftype: "simple_capacitor" }),
+  ).toHaveLength(0)
+  expect(
+    circuit.db.source_failed_to_create_component_error.list(),
+  ).toMatchObject([
+    {
+      component_name: "C1",
+      message: expect.stringContaining(
+        'Invalid props for capacitor "C1": capacitance',
+      ),
+    },
+  ])
+})


### PR DESCRIPTION
Fixes https://github.com/0hmX/capacitor-invalid-capacitance
## Summary

- Reject capacitor capacitance values that do not parse to finite numbers
- Prevent invalid Circuit JSON values such as `null` and display values such as `NaNpF`
- Keep validation at the standard component prop boundary
- Replace the previous `NaNpF` expectation with a validation-error regression test
- Preserve automatic decoupling trace-length behavior

## Testing

- Added invalid capacitance regression coverage
- Verified capacitor display-value tests
- Verified automatic decoupling tests
- 10 related tests pass
- Biome and conflict-marker checks pass