### PR TITLE
Carry Circuit JSON provenance in SRJ circuitJsonMetadata

### DIFF
--- a/lib/utils/autorouting/SimpleRouteJson.ts
+++ b/lib/utils/autorouting/SimpleRouteJson.ts
@@ -17,10 +17,45 @@ export type SimpleRouteBounds = {
 
 export type SimplifiedPcbTrace = Omit<
   AutorouterSimplifiedPcbTrace,
-  "connection_name" | "connectsTo"
+  "connection_name" | "route"
 > & {
+  type: "pcb_trace"
+  pcb_trace_id: string
   connection_name?: string
   connectsTo?: string[]
+  route: Array<
+    | {
+        route_type: "wire"
+        x: number
+        y: number
+        width: number
+        layer: string
+      }
+    | {
+        route_type: "via"
+        x: number
+        y: number
+        to_layer: string
+        from_layer: string
+        via_diameter?: number
+        via_hole_diameter?: number
+      }
+    | {
+        route_type: "jumper"
+        start: { x: number; y: number }
+        end: { x: number; y: number }
+        footprint: "0603" | "1206" | "1206x4_pair"
+        layer: string
+      }
+    | {
+        route_type: "through_obstacle"
+        start: { x: number; y: number }
+        end: { x: number; y: number }
+        from_layer: string
+        to_layer: string
+        width: number
+      }
+  >
 }
 
 /** A connection identifier in Simple Route JSON. */

--- a/lib/utils/autorouting/SimpleRouteJson.ts
+++ b/lib/utils/autorouting/SimpleRouteJson.ts
@@ -5,7 +5,7 @@ import type {
 import type { PcbGroup } from "circuit-json"
 import type { Obstacle } from "../obstacles/types"
 
-export type { Obstacle } from "../obstacles/types"
+export type { CircuitJsonMetadata, Obstacle } from "../obstacles/types"
 
 export type PcbGroupId = PcbGroup["pcb_group_id"]
 export type SimpleRouteBounds = {

--- a/lib/utils/autorouting/SimpleRouteJson.ts
+++ b/lib/utils/autorouting/SimpleRouteJson.ts
@@ -3,6 +3,9 @@ import type {
   SimplifiedPcbTrace as AutorouterSimplifiedPcbTrace,
 } from "@tscircuit/capacity-autorouter"
 import type { PcbGroup } from "circuit-json"
+import type { Obstacle } from "../obstacles/types"
+
+export type { Obstacle } from "../obstacles/types"
 
 export type PcbGroupId = PcbGroup["pcb_group_id"]
 export type SimpleRouteBounds = {
@@ -14,63 +17,10 @@ export type SimpleRouteBounds = {
 
 export type SimplifiedPcbTrace = Omit<
   AutorouterSimplifiedPcbTrace,
-  "connection_name" | "route"
+  "connection_name" | "connectsTo"
 > & {
-  type: "pcb_trace"
-  pcb_trace_id: string
   connection_name?: string
   connectsTo?: string[]
-  route: Array<
-    | {
-        route_type: "wire"
-        x: number
-        y: number
-        width: number
-        layer: string
-      }
-    | {
-        route_type: "via"
-        x: number
-        y: number
-        to_layer: string
-        from_layer: string
-        via_diameter?: number
-        via_hole_diameter?: number
-      }
-    | {
-        route_type: "jumper"
-        start: { x: number; y: number }
-        end: { x: number; y: number }
-        footprint: "0603" | "1206" | "1206x4_pair"
-        layer: string
-      }
-    | {
-        route_type: "through_obstacle"
-        start: { x: number; y: number }
-        end: { x: number; y: number }
-        from_layer: string
-        to_layer: string
-        width: number
-      }
-  >
-}
-
-export type Obstacle = {
-  obstacleId?: string
-  componentId?: string
-  // TODO include ovals
-  type: "rect"
-  shape?: "circle"
-  layers: string[]
-  zLayers?: number[]
-  center: { x: number; y: number }
-  width: number
-  height: number
-  ccwRotationDegrees?: number
-  connectedTo: string[]
-  isCopperPour?: boolean
-  netIsAssignable?: boolean
-  offBoardConnectsTo?: string[]
 }
 
 /** A connection identifier in Simple Route JSON. */

--- a/lib/utils/autorouting/getPreservedRoutedSubcircuitTraces.ts
+++ b/lib/utils/autorouting/getPreservedRoutedSubcircuitTraces.ts
@@ -1,26 +1,21 @@
 import type { CircuitJsonUtilObjects } from "@tscircuit/circuit-json-util"
+import type { LayerRef, PcbTrace } from "circuit-json"
 import type { SimplifiedPcbTrace } from "./SimpleRouteJson"
 
-type PreservedTraceRoutePoint = {
-  route_type?: string
-  start_pcb_port_id?: string
-  end_pcb_port_id?: string
-}
-
-type PreservedTrace = {
-  pcb_trace_id: string
-  source_trace_id?: string
+type PreservedTrace = PcbTrace & {
   connection_name?: string
   connectsTo?: string[]
-  route?: PreservedTraceRoutePoint[]
 }
+
+const getLayerName = (layer: LayerRef | { name: string }): string =>
+  typeof layer === "string" ? layer : layer.name
 
 const getPreservedTraceConnectionName = (trace: PreservedTrace) =>
   trace.source_trace_id ?? trace.connection_name ?? trace.pcb_trace_id
 
 const getPhysicalConnectionIdsForPreservedTrace = (trace: PreservedTrace) => {
   const physicallyConnectedIds = new Set(trace.connectsTo ?? [])
-  for (const routePoint of trace.route ?? []) {
+  for (const routePoint of trace.route) {
     if (routePoint.route_type !== "wire") continue
     for (const pcbPortId of [
       routePoint.start_pcb_port_id,
@@ -32,6 +27,46 @@ const getPhysicalConnectionIdsForPreservedTrace = (trace: PreservedTrace) => {
 
   return Array.from(physicallyConnectedIds)
 }
+
+const getSimpleRouteForPreservedTrace = (
+  trace: PreservedTrace,
+): SimplifiedPcbTrace["route"] =>
+  trace.route.map((routePoint) => {
+    if (routePoint.route_type === "wire") {
+      return {
+        route_type: "wire",
+        x: routePoint.x,
+        y: routePoint.y,
+        width: routePoint.width,
+        layer: getLayerName(routePoint.layer),
+      }
+    }
+
+    if (routePoint.route_type === "via") {
+      return {
+        route_type: "via",
+        x: routePoint.x,
+        y: routePoint.y,
+        from_layer: getLayerName(routePoint.from_layer),
+        to_layer: getLayerName(routePoint.to_layer),
+        ...(routePoint.outer_diameter !== undefined
+          ? { via_diameter: routePoint.outer_diameter }
+          : {}),
+        ...(routePoint.hole_diameter !== undefined
+          ? { via_hole_diameter: routePoint.hole_diameter }
+          : {}),
+      }
+    }
+
+    return {
+      route_type: "through_obstacle",
+      start: routePoint.start,
+      end: routePoint.end,
+      from_layer: getLayerName(routePoint.start_layer),
+      to_layer: getLayerName(routePoint.end_layer),
+      width: routePoint.width,
+    }
+  })
 
 /**
  * Converts already-routed child subcircuit pcb_traces into SRJ `traces`.
@@ -71,7 +106,7 @@ export const getPreservedRoutedSubcircuitTraces = ({
         source_trace_id: trace.source_trace_id,
         connection_name: connectionName,
         connectsTo: getPhysicalConnectionIdsForPreservedTrace(preservedTrace),
-        route: trace.route as SimplifiedPcbTrace["route"],
+        route: getSimpleRouteForPreservedTrace(preservedTrace),
       }
     })
     .filter((trace) => trace.route.length >= 2)

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -154,6 +154,9 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   const obstacles = getObstaclesFromCircuitJson(
     [
       ...(board ? [board] : []),
+      ...db.source_component.list(),
+      ...db.source_port.list(),
+      ...db.pcb_port.list(),
       ...db.pcb_component.list(),
       ...db.pcb_smtpad.list(),
       ...db.pcb_plated_hole.list(),

--- a/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
+++ b/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
@@ -6,7 +6,7 @@ import { fillPolygonWithRects } from "./fillPolygonWithRects"
 import { type RotatedRect } from "./generateApproximatingRects"
 import { getAxisAlignedRectFromPolygon } from "./getAxisAlignedRectFromPolygon"
 import { getObstaclesFromRoute } from "./getObstaclesFromRoute"
-import type { Obstacle } from "./types"
+import type { CircuitJsonMetadata, Obstacle } from "./types"
 
 const QUARTER_TURN_TOLERANCE_DEGREES = 0.01
 
@@ -48,6 +48,63 @@ export const getObstaclesFromCircuitJson = (
     | PcbBoard
     | undefined
   const everyLayer = getViaBoardLayers(board?.num_layers ?? 4)
+  const pcbComponentById = new Map(
+    circuitJson.flatMap((element) =>
+      element.type === "pcb_component"
+        ? [[element.pcb_component_id, element] as const]
+        : [],
+    ),
+  )
+  const pcbPortById = new Map(
+    circuitJson.flatMap((element) =>
+      element.type === "pcb_port"
+        ? [[element.pcb_port_id, element] as const]
+        : [],
+    ),
+  )
+  const sourceComponentById = new Map(
+    circuitJson.flatMap((element) =>
+      element.type === "source_component"
+        ? [[element.source_component_id, element] as const]
+        : [],
+    ),
+  )
+  const sourcePortById = new Map(
+    circuitJson.flatMap((element) =>
+      element.type === "source_port"
+        ? [[element.source_port_id, element] as const]
+        : [],
+    ),
+  )
+  const getReadableCircuitJsonMetadata = ({
+    pcbComponentId,
+    pcbPortId,
+  }: {
+    pcbComponentId?: string
+    pcbPortId?: string
+  }): Pick<
+    CircuitJsonMetadata,
+    "source_component_name" | "source_port_name"
+  > => {
+    const pcbPort = pcbPortId ? pcbPortById.get(pcbPortId) : undefined
+    const sourcePort = pcbPort
+      ? sourcePortById.get(pcbPort.source_port_id)
+      : undefined
+    const sourceComponentId =
+      (pcbComponentId
+        ? pcbComponentById.get(pcbComponentId)?.source_component_id
+        : undefined) ?? sourcePort?.source_component_id
+    const sourceComponent = sourceComponentId
+      ? sourceComponentById.get(sourceComponentId)
+      : undefined
+
+    return {
+      ...(sourceComponent?.name
+        ? { source_component_name: sourceComponent.name }
+        : {}),
+      ...(sourcePort?.name ? { source_port_name: sourcePort.name } : {}),
+    }
+  }
   const withNetId = (idList: string[]) =>
     connMap
       ? idList.concat(
@@ -60,13 +117,17 @@ export const getObstaclesFromCircuitJson = (
     const pcbComponentId = element.pcb_component_id ?? undefined
 
     if (element.type === "pcb_smtpad") {
-      const pcbSmtPadMetadata = {
+      const pcbSmtPadCircuitJsonMetadata: CircuitJsonMetadata = {
         pcb_smtpad_id: element.pcb_smtpad_id,
         pcb_port_id: element.pcb_port_id,
+        ...getReadableCircuitJsonMetadata({
+          pcbComponentId,
+          pcbPortId: element.pcb_port_id,
+        }),
       }
       if (element.shape === "circle") {
         obstacles.push({
-          metadata: pcbSmtPadMetadata,
+          circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
           componentId: pcbComponentId,
           type: "rect",
           shape: "circle",
@@ -81,7 +142,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "rect") {
         obstacles.push({
-          metadata: pcbSmtPadMetadata,
+          circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
           componentId: pcbComponentId,
           type: "rect",
           layers: [element.layer],
@@ -104,7 +165,7 @@ export const getObstaclesFromCircuitJson = (
         const rect = axisAlignedRect ?? rotatedRect
 
         obstacles.push({
-          metadata: pcbSmtPadMetadata,
+          circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
           componentId: pcbComponentId,
           type: "rect",
           layers: [element.layer],
@@ -118,7 +179,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "pill" || element.shape === "rotated_pill") {
         obstacles.push({
-          metadata: pcbSmtPadMetadata,
+          circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
           componentId: pcbComponentId,
           type: "rect",
           layers: [element.layer],
@@ -137,7 +198,7 @@ export const getObstaclesFromCircuitJson = (
         const axisAlignedRect = getAxisAlignedRectFromPolygon(element.points)
         if (axisAlignedRect) {
           obstacles.push({
-            metadata: pcbSmtPadMetadata,
+            circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
             componentId: pcbComponentId,
             type: "rect",
             layers: [element.layer],
@@ -153,7 +214,7 @@ export const getObstaclesFromCircuitJson = (
 
         for (const rect of approximatingRects) {
           obstacles.push({
-            metadata: pcbSmtPadMetadata,
+            circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
             componentId: pcbComponentId,
             type: "rect",
             layers: [element.layer],
@@ -323,13 +384,17 @@ export const getObstaclesFromCircuitJson = (
         })
       }
     } else if (element.type === "pcb_plated_hole") {
-      const pcbPlatedHoleMetadata = {
+      const pcbPlatedHoleCircuitJsonMetadata: CircuitJsonMetadata = {
         pcb_plated_hole_id: element.pcb_plated_hole_id,
         pcb_port_id: element.pcb_port_id,
+        ...getReadableCircuitJsonMetadata({
+          pcbComponentId,
+          pcbPortId: element.pcb_port_id,
+        }),
       }
       if (element.shape === "circle") {
         obstacles.push({
-          metadata: pcbPlatedHoleMetadata,
+          circuitJsonMetadata: pcbPlatedHoleCircuitJsonMetadata,
           componentId: pcbComponentId,
           // @ts-ignore
           type: "oval",
@@ -344,7 +409,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "circular_hole_with_rect_pad") {
         obstacles.push({
-          metadata: pcbPlatedHoleMetadata,
+          circuitJsonMetadata: pcbPlatedHoleCircuitJsonMetadata,
           componentId: pcbComponentId,
           // @ts-ignore
           type: "rect",
@@ -359,7 +424,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "oval") {
         obstacles.push({
-          metadata: pcbPlatedHoleMetadata,
+          circuitJsonMetadata: pcbPlatedHoleCircuitJsonMetadata,
           componentId: pcbComponentId,
           // @ts-ignore
           type: "oval",
@@ -374,7 +439,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "pill") {
         obstacles.push({
-          metadata: pcbPlatedHoleMetadata,
+          circuitJsonMetadata: pcbPlatedHoleCircuitJsonMetadata,
           componentId: pcbComponentId,
           type: "rect",
           layers: everyLayer,
@@ -403,7 +468,7 @@ export const getObstaclesFromCircuitJson = (
           const centerX = (minX + maxX) / 2
           const centerY = (minY + maxY) / 2
           obstacles.push({
-            metadata: pcbPlatedHoleMetadata,
+            circuitJsonMetadata: pcbPlatedHoleCircuitJsonMetadata,
             componentId: pcbComponentId,
             // @ts-ignore
             type: "rect",
@@ -457,7 +522,10 @@ export const getObstaclesFromCircuitJson = (
         (element as any).net_is_assignable ?? (element as any).netIsAssignable,
       )
       obstacles.push({
-        metadata: { pcb_via_id: element.pcb_via_id },
+        circuitJsonMetadata: {
+          pcb_via_id: element.pcb_via_id,
+          ...getReadableCircuitJsonMetadata({ pcbComponentId }),
+        },
         componentId: pcbComponentId,
         type: "rect",
         shape: "circle",

--- a/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
+++ b/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
@@ -60,13 +60,13 @@ export const getObstaclesFromCircuitJson = (
     const pcbComponentId = element.pcb_component_id ?? undefined
 
     if (element.type === "pcb_smtpad") {
-      const pcbSmtPadIdentity = {
+      const pcbSmtPadMetadata = {
         pcb_smtpad_id: element.pcb_smtpad_id,
         pcb_port_id: element.pcb_port_id,
       }
       if (element.shape === "circle") {
         obstacles.push({
-          ...pcbSmtPadIdentity,
+          metadata: pcbSmtPadMetadata,
           componentId: pcbComponentId,
           type: "rect",
           shape: "circle",
@@ -81,7 +81,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "rect") {
         obstacles.push({
-          ...pcbSmtPadIdentity,
+          metadata: pcbSmtPadMetadata,
           componentId: pcbComponentId,
           type: "rect",
           layers: [element.layer],
@@ -104,7 +104,7 @@ export const getObstaclesFromCircuitJson = (
         const rect = axisAlignedRect ?? rotatedRect
 
         obstacles.push({
-          ...pcbSmtPadIdentity,
+          metadata: pcbSmtPadMetadata,
           componentId: pcbComponentId,
           type: "rect",
           layers: [element.layer],
@@ -118,7 +118,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "pill" || element.shape === "rotated_pill") {
         obstacles.push({
-          ...pcbSmtPadIdentity,
+          metadata: pcbSmtPadMetadata,
           componentId: pcbComponentId,
           type: "rect",
           layers: [element.layer],
@@ -137,7 +137,7 @@ export const getObstaclesFromCircuitJson = (
         const axisAlignedRect = getAxisAlignedRectFromPolygon(element.points)
         if (axisAlignedRect) {
           obstacles.push({
-            ...pcbSmtPadIdentity,
+            metadata: pcbSmtPadMetadata,
             componentId: pcbComponentId,
             type: "rect",
             layers: [element.layer],
@@ -153,7 +153,7 @@ export const getObstaclesFromCircuitJson = (
 
         for (const rect of approximatingRects) {
           obstacles.push({
-            ...pcbSmtPadIdentity,
+            metadata: pcbSmtPadMetadata,
             componentId: pcbComponentId,
             type: "rect",
             layers: [element.layer],
@@ -323,13 +323,13 @@ export const getObstaclesFromCircuitJson = (
         })
       }
     } else if (element.type === "pcb_plated_hole") {
-      const pcbPlatedHoleIdentity = {
+      const pcbPlatedHoleMetadata = {
         pcb_plated_hole_id: element.pcb_plated_hole_id,
         pcb_port_id: element.pcb_port_id,
       }
       if (element.shape === "circle") {
         obstacles.push({
-          ...pcbPlatedHoleIdentity,
+          metadata: pcbPlatedHoleMetadata,
           componentId: pcbComponentId,
           // @ts-ignore
           type: "oval",
@@ -344,7 +344,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "circular_hole_with_rect_pad") {
         obstacles.push({
-          ...pcbPlatedHoleIdentity,
+          metadata: pcbPlatedHoleMetadata,
           componentId: pcbComponentId,
           // @ts-ignore
           type: "rect",
@@ -359,7 +359,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "oval") {
         obstacles.push({
-          ...pcbPlatedHoleIdentity,
+          metadata: pcbPlatedHoleMetadata,
           componentId: pcbComponentId,
           // @ts-ignore
           type: "oval",
@@ -374,7 +374,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "pill") {
         obstacles.push({
-          ...pcbPlatedHoleIdentity,
+          metadata: pcbPlatedHoleMetadata,
           componentId: pcbComponentId,
           type: "rect",
           layers: everyLayer,
@@ -403,7 +403,7 @@ export const getObstaclesFromCircuitJson = (
           const centerX = (minX + maxX) / 2
           const centerY = (minY + maxY) / 2
           obstacles.push({
-            ...pcbPlatedHoleIdentity,
+            metadata: pcbPlatedHoleMetadata,
             componentId: pcbComponentId,
             // @ts-ignore
             type: "rect",
@@ -457,7 +457,7 @@ export const getObstaclesFromCircuitJson = (
         (element as any).net_is_assignable ?? (element as any).netIsAssignable,
       )
       obstacles.push({
-        pcb_via_id: element.pcb_via_id,
+        metadata: { pcb_via_id: element.pcb_via_id },
         componentId: pcbComponentId,
         type: "rect",
         shape: "circle",

--- a/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
+++ b/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
@@ -60,8 +60,13 @@ export const getObstaclesFromCircuitJson = (
     const pcbComponentId = element.pcb_component_id ?? undefined
 
     if (element.type === "pcb_smtpad") {
+      const pcbSmtPadIdentity = {
+        pcb_smtpad_id: element.pcb_smtpad_id,
+        pcb_port_id: element.pcb_port_id,
+      }
       if (element.shape === "circle") {
         obstacles.push({
+          ...pcbSmtPadIdentity,
           componentId: pcbComponentId,
           type: "rect",
           shape: "circle",
@@ -76,6 +81,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "rect") {
         obstacles.push({
+          ...pcbSmtPadIdentity,
           componentId: pcbComponentId,
           type: "rect",
           layers: [element.layer],
@@ -98,6 +104,7 @@ export const getObstaclesFromCircuitJson = (
         const rect = axisAlignedRect ?? rotatedRect
 
         obstacles.push({
+          ...pcbSmtPadIdentity,
           componentId: pcbComponentId,
           type: "rect",
           layers: [element.layer],
@@ -111,6 +118,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "pill" || element.shape === "rotated_pill") {
         obstacles.push({
+          ...pcbSmtPadIdentity,
           componentId: pcbComponentId,
           type: "rect",
           layers: [element.layer],
@@ -129,6 +137,7 @@ export const getObstaclesFromCircuitJson = (
         const axisAlignedRect = getAxisAlignedRectFromPolygon(element.points)
         if (axisAlignedRect) {
           obstacles.push({
+            ...pcbSmtPadIdentity,
             componentId: pcbComponentId,
             type: "rect",
             layers: [element.layer],
@@ -144,6 +153,7 @@ export const getObstaclesFromCircuitJson = (
 
         for (const rect of approximatingRects) {
           obstacles.push({
+            ...pcbSmtPadIdentity,
             componentId: pcbComponentId,
             type: "rect",
             layers: [element.layer],
@@ -313,8 +323,13 @@ export const getObstaclesFromCircuitJson = (
         })
       }
     } else if (element.type === "pcb_plated_hole") {
+      const pcbPlatedHoleIdentity = {
+        pcb_plated_hole_id: element.pcb_plated_hole_id,
+        pcb_port_id: element.pcb_port_id,
+      }
       if (element.shape === "circle") {
         obstacles.push({
+          ...pcbPlatedHoleIdentity,
           componentId: pcbComponentId,
           // @ts-ignore
           type: "oval",
@@ -329,6 +344,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "circular_hole_with_rect_pad") {
         obstacles.push({
+          ...pcbPlatedHoleIdentity,
           componentId: pcbComponentId,
           // @ts-ignore
           type: "rect",
@@ -343,6 +359,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "oval") {
         obstacles.push({
+          ...pcbPlatedHoleIdentity,
           componentId: pcbComponentId,
           // @ts-ignore
           type: "oval",
@@ -357,6 +374,7 @@ export const getObstaclesFromCircuitJson = (
         })
       } else if (element.shape === "pill") {
         obstacles.push({
+          ...pcbPlatedHoleIdentity,
           componentId: pcbComponentId,
           type: "rect",
           layers: everyLayer,
@@ -385,6 +403,7 @@ export const getObstaclesFromCircuitJson = (
           const centerX = (minX + maxX) / 2
           const centerY = (minY + maxY) / 2
           obstacles.push({
+            ...pcbPlatedHoleIdentity,
             componentId: pcbComponentId,
             // @ts-ignore
             type: "rect",
@@ -438,6 +457,7 @@ export const getObstaclesFromCircuitJson = (
         (element as any).net_is_assignable ?? (element as any).netIsAssignable,
       )
       obstacles.push({
+        pcb_via_id: element.pcb_via_id,
         componentId: pcbComponentId,
         type: "rect",
         shape: "circle",

--- a/lib/utils/obstacles/types.ts
+++ b/lib/utils/obstacles/types.ts
@@ -1,13 +1,8 @@
-import type { PcbPlatedHole, PcbPort, PcbSmtPad, PcbVia } from "circuit-json"
-
 export type Obstacle = {
   obstacleId?: string
   componentId?: string
-  /** Circuit JSON identities represented by this obstacle. */
-  pcb_smtpad_id?: PcbSmtPad["pcb_smtpad_id"]
-  pcb_plated_hole_id?: PcbPlatedHole["pcb_plated_hole_id"]
-  pcb_port_id?: PcbPort["pcb_port_id"]
-  pcb_via_id?: PcbVia["pcb_via_id"]
+  /** Opaque producer metadata; autorouters must not use this for routing. */
+  metadata?: Record<string, unknown>
   shape?: "circle"
   type: "rect"
   layers: string[]

--- a/lib/utils/obstacles/types.ts
+++ b/lib/utils/obstacles/types.ts
@@ -1,5 +1,13 @@
+import type { PcbPlatedHole, PcbPort, PcbSmtPad, PcbVia } from "circuit-json"
+
 export type Obstacle = {
+  obstacleId?: string
   componentId?: string
+  /** Circuit JSON identities represented by this obstacle. */
+  pcb_smtpad_id?: PcbSmtPad["pcb_smtpad_id"]
+  pcb_plated_hole_id?: PcbPlatedHole["pcb_plated_hole_id"]
+  pcb_port_id?: PcbPort["pcb_port_id"]
+  pcb_via_id?: PcbVia["pcb_via_id"]
   shape?: "circle"
   type: "rect"
   layers: string[]

--- a/lib/utils/obstacles/types.ts
+++ b/lib/utils/obstacles/types.ts
@@ -1,8 +1,17 @@
+export type CircuitJsonMetadata = {
+  pcb_smtpad_id?: string
+  pcb_plated_hole_id?: string
+  pcb_port_id?: string
+  pcb_via_id?: string
+  source_component_name?: string
+  source_port_name?: string
+}
+
 export type Obstacle = {
   obstacleId?: string
   componentId?: string
-  /** Opaque producer metadata; autorouters must not use this for routing. */
-  metadata?: Record<string, unknown>
+  /** Circuit JSON provenance carried through SRJ but forbidden for routing. */
+  circuitJsonMetadata?: CircuitJsonMetadata
   shape?: "circle"
   type: "rect"
   layers: string[]

--- a/tests/repros/repro-simple-route-json-45-degree.test.tsx
+++ b/tests/repros/repro-simple-route-json-45-degree.test.tsx
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { getSimpleRouteJsonFromCircuitJson } from "lib/index"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
@@ -64,6 +64,12 @@ test("45 degree rects bug", () => {
           "center": {
             "x": 0,
             "y": 0,
+          },
+          "circuitJsonMetadata": {
+            "pcb_port_id": "pcb_port_0",
+            "pcb_smtpad_id": "pcb_smtpad_0",
+            "source_component_name": "45-degree-obs",
+            "source_port_name": "OBSTACLE",
           },
           "componentId": "pcb_component_0",
           "connectedTo": [

--- a/tests/utils/autorouting/obstacles-preserve-circuit-element-identities.test.ts
+++ b/tests/utils/autorouting/obstacles-preserve-circuit-element-identities.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getObstaclesFromCircuitJson } from "lib/utils/obstacles/getObstaclesFromCircuitJson"
+
+test("pad obstacles preserve opaque Circuit JSON identities", () => {
+  const circuitJson = [
+    {
+      type: "pcb_smtpad",
+      shape: "rect",
+      pcb_smtpad_id: "opaque-smt-pad",
+      pcb_port_id: "opaque-smt-port",
+      x: 1,
+      y: 2,
+      width: 0.8,
+      height: 0.4,
+      layer: "top",
+    },
+    {
+      type: "pcb_plated_hole",
+      shape: "circle",
+      pcb_plated_hole_id: "opaque-plated-hole",
+      pcb_port_id: "opaque-plated-hole-port",
+      x: 3,
+      y: 4,
+      outer_diameter: 1,
+      hole_diameter: 0.5,
+      layers: ["top", "bottom"],
+    },
+  ] as AnyCircuitElement[]
+
+  const [smtPadObstacle, platedHoleObstacle] =
+    getObstaclesFromCircuitJson(circuitJson)
+
+  expect(smtPadObstacle.pcb_smtpad_id).toBe("opaque-smt-pad")
+  expect(smtPadObstacle.pcb_port_id).toBe("opaque-smt-port")
+  expect(smtPadObstacle).toMatchObject({
+    connectedTo: ["opaque-smt-pad"],
+  })
+  expect(platedHoleObstacle.pcb_plated_hole_id).toBe("opaque-plated-hole")
+  expect(platedHoleObstacle.pcb_port_id).toBe("opaque-plated-hole-port")
+  expect(platedHoleObstacle).toMatchObject({
+    connectedTo: ["opaque-plated-hole"],
+  })
+})

--- a/tests/utils/autorouting/obstacles-preserve-circuit-element-identities.test.ts
+++ b/tests/utils/autorouting/obstacles-preserve-circuit-element-identities.test.ts
@@ -5,6 +5,40 @@ import { getObstaclesFromCircuitJson } from "lib/utils/obstacles/getObstaclesFro
 test("pad obstacles preserve opaque Circuit JSON identities", () => {
   const circuitJson = [
     {
+      type: "source_component",
+      source_component_id: "opaque-source-component",
+      name: "U_OPAQUE",
+    },
+    {
+      type: "source_port",
+      source_port_id: "opaque-source-port-1",
+      source_component_id: "opaque-source-component",
+      name: "DATA_IN",
+    },
+    {
+      type: "source_port",
+      source_port_id: "opaque-source-port-2",
+      source_component_id: "opaque-source-component",
+      name: "DATA_OUT",
+    },
+    {
+      type: "pcb_component",
+      pcb_component_id: "opaque-pcb-component",
+      source_component_id: "opaque-source-component",
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "opaque-smt-port",
+      source_port_id: "opaque-source-port-1",
+      pcb_component_id: "opaque-pcb-component",
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "opaque-plated-hole-port",
+      source_port_id: "opaque-source-port-2",
+      pcb_component_id: "opaque-pcb-component",
+    },
+    {
       type: "pcb_smtpad",
       shape: "rect",
       pcb_smtpad_id: "opaque-smt-pad",
@@ -14,6 +48,7 @@ test("pad obstacles preserve opaque Circuit JSON identities", () => {
       width: 0.8,
       height: 0.4,
       layer: "top",
+      pcb_component_id: "opaque-pcb-component",
     },
     {
       type: "pcb_plated_hole",
@@ -25,22 +60,27 @@ test("pad obstacles preserve opaque Circuit JSON identities", () => {
       outer_diameter: 1,
       hole_diameter: 0.5,
       layers: ["top", "bottom"],
+      pcb_component_id: "opaque-pcb-component",
     },
   ] as AnyCircuitElement[]
 
   const [smtPadObstacle, platedHoleObstacle] =
     getObstaclesFromCircuitJson(circuitJson)
 
-  expect(smtPadObstacle.metadata).toEqual({
+  expect(smtPadObstacle.circuitJsonMetadata).toEqual({
     pcb_smtpad_id: "opaque-smt-pad",
     pcb_port_id: "opaque-smt-port",
+    source_component_name: "U_OPAQUE",
+    source_port_name: "DATA_IN",
   })
   expect(smtPadObstacle).toMatchObject({
     connectedTo: ["opaque-smt-pad"],
   })
-  expect(platedHoleObstacle.metadata).toEqual({
+  expect(platedHoleObstacle.circuitJsonMetadata).toEqual({
     pcb_plated_hole_id: "opaque-plated-hole",
     pcb_port_id: "opaque-plated-hole-port",
+    source_component_name: "U_OPAQUE",
+    source_port_name: "DATA_OUT",
   })
   expect(platedHoleObstacle).toMatchObject({
     connectedTo: ["opaque-plated-hole"],

--- a/tests/utils/autorouting/obstacles-preserve-circuit-element-identities.test.ts
+++ b/tests/utils/autorouting/obstacles-preserve-circuit-element-identities.test.ts
@@ -31,13 +31,17 @@ test("pad obstacles preserve opaque Circuit JSON identities", () => {
   const [smtPadObstacle, platedHoleObstacle] =
     getObstaclesFromCircuitJson(circuitJson)
 
-  expect(smtPadObstacle.pcb_smtpad_id).toBe("opaque-smt-pad")
-  expect(smtPadObstacle.pcb_port_id).toBe("opaque-smt-port")
+  expect(smtPadObstacle.metadata).toEqual({
+    pcb_smtpad_id: "opaque-smt-pad",
+    pcb_port_id: "opaque-smt-port",
+  })
   expect(smtPadObstacle).toMatchObject({
     connectedTo: ["opaque-smt-pad"],
   })
-  expect(platedHoleObstacle.pcb_plated_hole_id).toBe("opaque-plated-hole")
-  expect(platedHoleObstacle.pcb_port_id).toBe("opaque-plated-hole-port")
+  expect(platedHoleObstacle.metadata).toEqual({
+    pcb_plated_hole_id: "opaque-plated-hole",
+    pcb_port_id: "opaque-plated-hole-port",
+  })
   expect(platedHoleObstacle).toMatchObject({
     connectedTo: ["opaque-plated-hole"],
   })

--- a/tests/utils/autorouting/simple-route-json-preserves-child-net-routing-state.test.ts
+++ b/tests/utils/autorouting/simple-route-json-preserves-child-net-routing-state.test.ts
@@ -108,16 +108,8 @@ test("board simple route json preserves child trace physical connectivity", () =
     }),
   ])
 
-  const [startRoutePoint, endRoutePoint] =
-    simpleRouteJson.traces?.[0]?.route ?? []
-  expect(startRoutePoint?.route_type).toBe("wire")
-  expect(endRoutePoint?.route_type).toBe("wire")
-  if (
-    startRoutePoint?.route_type !== "wire" ||
-    endRoutePoint?.route_type !== "wire"
-  ) {
-    throw new Error("Expected the preserved trace route to contain wire points")
-  }
-  expect(startRoutePoint.start_pcb_port_id).toBe("opaque-child-a")
-  expect(endRoutePoint.end_pcb_port_id).toBe("opaque-child-b")
+  expect(simpleRouteJson.traces?.[0]?.route).toEqual([
+    expect.not.objectContaining({ start_pcb_port_id: expect.anything() }),
+    expect.not.objectContaining({ end_pcb_port_id: expect.anything() }),
+  ])
 })

--- a/tests/utils/autorouting/simple-route-json-preserves-child-net-routing-state.test.ts
+++ b/tests/utils/autorouting/simple-route-json-preserves-child-net-routing-state.test.ts
@@ -32,9 +32,9 @@ test("board simple route json preserves child trace physical connectivity", () =
         }) as any,
     ),
     ...[
-      ["pcb_port_child_a", "source_port_child_a", -2, childSubcircuitId],
-      ["pcb_port_child_b", "source_port_child_b", 0, childSubcircuitId],
-      ["pcb_port_board", "source_port_board", 3, undefined],
+      ["opaque-child-a", "source_port_child_a", -2, childSubcircuitId],
+      ["opaque-child-b", "source_port_child_b", 0, childSubcircuitId],
+      ["opaque-board-port", "source_port_board", 3, undefined],
     ].map(
       ([pcb_port_id, source_port_id, x, subcircuit_id]) =>
         ({
@@ -69,7 +69,7 @@ test("board simple route json preserves child trace physical connectivity", () =
       pcb_trace_id: "pcb_trace_child_routed",
       source_trace_id: "source_trace_child_routed",
       subcircuit_id: childSubcircuitId,
-      connectsTo: ["pcb_port_child_a", "pcb_port_child_b"],
+      connectsTo: ["opaque-child-a", "opaque-child-b"],
       route: [
         {
           route_type: "wire",
@@ -77,7 +77,7 @@ test("board simple route json preserves child trace physical connectivity", () =
           y: 0,
           width: 0.1,
           layer: "top",
-          start_pcb_port_id: "pcb_port_child_a",
+          start_pcb_port_id: "opaque-child-a",
         },
         {
           route_type: "wire",
@@ -85,7 +85,7 @@ test("board simple route json preserves child trace physical connectivity", () =
           y: 0,
           width: 0.1,
           layer: "top",
-          end_pcb_port_id: "pcb_port_child_b",
+          end_pcb_port_id: "opaque-child-b",
         },
       ],
     } as any,
@@ -97,14 +97,27 @@ test("board simple route json preserves child trace physical connectivity", () =
   )
 
   expect(netConnection?.pointsToConnect.map((point) => point.pointId)).toEqual([
-    "pcb_port_child_a",
-    "pcb_port_child_b",
-    "pcb_port_board",
+    "opaque-child-a",
+    "opaque-child-b",
+    "opaque-board-port",
   ])
   expect(simpleRouteJson.traces).toEqual([
     expect.objectContaining({
       pcb_trace_id: "pcb_trace_child_routed",
-      connectsTo: ["pcb_port_child_a", "pcb_port_child_b"],
+      connectsTo: ["opaque-child-a", "opaque-child-b"],
     }),
   ])
+
+  const [startRoutePoint, endRoutePoint] =
+    simpleRouteJson.traces?.[0]?.route ?? []
+  expect(startRoutePoint?.route_type).toBe("wire")
+  expect(endRoutePoint?.route_type).toBe("wire")
+  if (
+    startRoutePoint?.route_type !== "wire" ||
+    endRoutePoint?.route_type !== "wire"
+  ) {
+    throw new Error("Expected the preserved trace route to contain wire points")
+  }
+  expect(startRoutePoint.start_pcb_port_id).toBe("opaque-child-a")
+  expect(endRoutePoint.end_pcb_port_id).toBe("opaque-child-b")
 })

--- a/tests/utils/autorouting/via-obstacles-are-circular.test.ts
+++ b/tests/utils/autorouting/via-obstacles-are-circular.test.ts
@@ -23,7 +23,7 @@ test("vias produce explicitly circular obstacles", () => {
     center: { x: 1, y: 2 },
     width: 0.6,
     height: 0.6,
-    pcb_via_id: "via_without_a_type_prefix",
+    metadata: { pcb_via_id: "via_without_a_type_prefix" },
     connectedTo: ["via_without_a_type_prefix"],
   })
 })

--- a/tests/utils/autorouting/via-obstacles-are-circular.test.ts
+++ b/tests/utils/autorouting/via-obstacles-are-circular.test.ts
@@ -23,7 +23,7 @@ test("vias produce explicitly circular obstacles", () => {
     center: { x: 1, y: 2 },
     width: 0.6,
     height: 0.6,
-    metadata: { pcb_via_id: "via_without_a_type_prefix" },
+    circuitJsonMetadata: { pcb_via_id: "via_without_a_type_prefix" },
     connectedTo: ["via_without_a_type_prefix"],
   })
 })

--- a/tests/utils/autorouting/via-obstacles-are-circular.test.ts
+++ b/tests/utils/autorouting/via-obstacles-are-circular.test.ts
@@ -23,6 +23,7 @@ test("vias produce explicitly circular obstacles", () => {
     center: { x: 1, y: 2 },
     width: 0.6,
     height: 0.6,
+    pcb_via_id: "via_without_a_type_prefix",
     connectedTo: ["via_without_a_type_prefix"],
   })
 })


### PR DESCRIPTION
## Summary

- add an optional, typed `circuitJsonMetadata` field to the shared Simple Route JSON obstacle type
- carry SMT-pad, plated-hole, port, and via IDs without adding Circuit JSON fields directly to the routing model
- include optional `source_component_name` and `source_port_name` labels to make serialized obstacles easier to inspect
- normalize preserved Circuit JSON trace routes into the small SRJ route union while retaining endpoint connectivity through `connectsTo`
- share one Core obstacle type between obstacle generation and Simple Route JSON
- cover the boundary with IDs that deliberately have no type prefix

## Why

Pipeline 9 imports pre-routed traces into its hypergraph so it can update them while routing new connections. Its Circuit JSON conversion adapter also needs enough provenance to reconstruct pad entities for DRC. Circuit JSON IDs are opaque, so consumers cannot infer element kinds from ID text.

This keeps SRJ small: routing behavior depends only on normal SRJ connectivity and geometry. `circuitJsonMetadata` is optional, carries producer provenance through the pipeline, and is explicitly forbidden as an input to routing decisions. Non-routing adapters may use it when reconstructing Circuit JSON entities.

Related autorouter reproduction/fix: https://github.com/tscircuit/tscircuit-autorouter/pull/2025

## Impact

Existing `connectedTo` data remains unchanged. Preserved traces no longer leak Circuit JSON route-point fields into SRJ, and obstacle provenance is additive under `circuitJsonMetadata`.

## Tests

- `bunx tsc --noEmit`
- `bun run build`
- `bun test tests/utils/autorouting` (31 pass)
