### PR TITLE
Update circuit-json-util for plated pill-hole bounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
     "@tscircuit/capacity-autorouter": "^0.0.772",
     "@tscircuit/checks": "0.0.152",
-    "@tscircuit/circuit-json-util": "^0.0.104",
+    "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "0.0.42",
     "@tscircuit/create-fdm-enclosure": "0.0.3",
@@ -129,7 +129,7 @@
     "zod": "^3.25.67"
   },
   "overrides": {
-    "@tscircuit/circuit-json-util": "^0.0.104",
+    "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/props": "^0.0.618",
     "circuit-json": "^0.0.465"
   }


### PR DESCRIPTION
## Summary

- update `@tscircuit/circuit-json-util` from `^0.0.104` to `^0.0.106`
- update the circuit-json-util override so nested DRC dependencies resolve the fixed geometry implementation

`@tscircuit/checks@0.0.152` was already added automatically by #3126.

## Why

The previous utility version could collapse pill/oval plated-hole bounds to a point during DRC spatial indexing. As a result, a foreign-net trace crossing a rotated USB shell tab could be missed.

The updated utility supplies tight bounds based on `outer_width`, `outer_height`, and `ccw_rotation`. The installed checks package includes a regression test for the reproduced CC2-to-GND overlap.

## Impact

Core's board DRC pipeline now detects traces overlapping rotated pill-shaped plated holes. Merging this package update will publish a new core version and trigger the configured upstream update workflow.

## Validation

- reproduced the USB pill-pad collision through installed `@tscircuit/checks@0.0.152` and `@tscircuit/circuit-json-util@0.0.106`
- `bun test tests/features/drc-error-detection.test.tsx tests/repros/repro6-USB-C-route.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`
