### PR TITLE
Update capacity autorouter to 0.0.783

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
-    "@tscircuit/capacity-autorouter": "^0.0.782",
+    "@tscircuit/capacity-autorouter": "^0.0.783",
     "@tscircuit/checks": "0.0.152",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

- update `@tscircuit/capacity-autorouter` from `^0.0.782` to `^0.0.783`
- bring the Pipeline9 preloaded-hypergraph materialization fix from tscircuit/tscircuit-autorouter#2049 into Core

## Impact

When `beta_pipeline9` accepts movement of a preloaded trace section, the autorouter now carries that section through high-density routing and splices the routed replacement back into the original trace before DRC cleanup.

## Validation

- `bunx tsc --noEmit`
- `bun run build`
- focused Pipeline9 and preloaded-trace adaptation tests: 4 passed, 0 failed
- full `bun test --timeout 30000`: 1,379 passed, 37 skipped, 0 failed; all 58 snapshots matched
- GitHub CI: format, type-check, smoke-test, previews, and all 10 test shards pass
