### PR TITLE
Expand phased autorouting bounds around connection points

### DIFF
--- a/lib/components/primitive-components/Group/Group_phasedAutoroutingUtils.ts
+++ b/lib/components/primitive-components/Group/Group_phasedAutoroutingUtils.ts
@@ -3,6 +3,7 @@ import type {
   SimpleRouteDifferentialPair,
   SimpleRouteJson,
 } from "lib/utils/autorouting/SimpleRouteJson"
+import { expandSrjBoundsToIncludeConnectionPoints } from "lib/utils/autorouting/expand-srj-bounds-to-include-connection-points"
 import type {
   RoutingPhaseDrcTolerances,
   RoutingPhasePlan,
@@ -85,9 +86,14 @@ export function Group_filterSimpleRouteJsonForPhase(
     }))
     .filter((bus) => bus.connectionNames.length > 0)
 
+  const bounds = expandSrjBoundsToIncludeConnectionPoints({
+    bounds: phasePlan.routingBounds ?? simpleRouteJson.bounds,
+    connections,
+  })
+
   return {
     ...simpleRouteJson,
-    bounds: phasePlan.routingBounds ?? simpleRouteJson.bounds,
+    bounds,
     connections,
     differentialPairs:
       differentialPairs.length > 0 ? differentialPairs : undefined,

--- a/tests/utils/autorouting/phased-autorouting-bounds.test.ts
+++ b/tests/utils/autorouting/phased-autorouting-bounds.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import { Group_filterSimpleRouteJsonForPhase } from "lib/components/primitive-components/Group/Group_phasedAutoroutingUtils"
+import type { RoutingPhasePlan } from "lib/components/primitive-components/Group/GroupRoutingPhasePlan"
+import { Trace } from "lib/components/primitive-components/Trace/Trace"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+
+test("phased autorouting expands substituted bounds around phase connection points", () => {
+  const phaseTrace = new Trace({
+    name: "DISPLAY_DATA",
+    from: ".U1 > .pin1",
+    to: ".J1 > .pin1",
+  })
+  phaseTrace.source_trace_id = "source_trace_display_data"
+
+  const unrelatedTrace = new Trace({
+    name: "UNRELATED",
+    from: ".U2 > .pin1",
+    to: ".J2 > .pin1",
+  })
+  unrelatedTrace.source_trace_id = "source_trace_unrelated"
+
+  const simpleRouteJson: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    obstacles: [],
+    connections: [
+      {
+        name: "source_trace_display_data",
+        source_trace_id: "source_trace_display_data",
+        pointsToConnect: [
+          { x: -2.25, y: 0, layer: "top" },
+          { x: 0, y: 1.5, layer: "top" },
+        ],
+      },
+      {
+        name: "source_trace_unrelated",
+        source_trace_id: "source_trace_unrelated",
+        pointsToConnect: [
+          { x: 50, y: 50, layer: "top" },
+          { x: 51, y: 50, layer: "top" },
+        ],
+      },
+    ],
+    bounds: { minX: -10, maxX: 10, minY: -10, maxY: 10 },
+  }
+
+  const phasePlan: RoutingPhasePlan = {
+    routingPhaseIndex: 0,
+    routingBounds: { minX: -1, maxX: 1, minY: -1, maxY: 1 },
+    traces: [phaseTrace],
+    nets: [],
+  }
+
+  const phaseInput = Group_filterSimpleRouteJsonForPhase(
+    simpleRouteJson,
+    phasePlan,
+  )
+
+  expect(phaseInput.bounds).toEqual({
+    minX: -2.25,
+    maxX: 1,
+    minY: -1,
+    maxY: 1.5,
+  })
+  expect(phaseInput.connections.map((connection) => connection.name)).toEqual([
+    "source_trace_display_data",
+  ])
+})


### PR DESCRIPTION
## Summary

- expand phased autorouting bounds around the phase's non-off-board connection points
- preserve explicit phase bounds when they already contain every routed point
- add a regression test covering a phase-specific bounds override and an unrelated out-of-phase connection

## Root cause

`getSimpleRouteJsonFromCircuitJson` expands the base SimpleRouteJson bounds around all non-off-board connection points. During phased autorouting, `Group_filterSimpleRouteJsonForPhase` can subsequently replace those expanded bounds with `phasePlan.routingBounds`. A point outside those phase-specific bounds then reaches the autorouter even though the base SRJ was corrected.

The phase filter now expands its final bounds after filtering connections and applying the optional phase-specific bounds override. Only connections routed in that phase influence the expansion.

## Impact

Custom and built-in autorouters receive bounds containing every non-off-board point routed in the current phase. This makes phased routing consistent with the base SRJ bounds behavior and avoids invalid autorouter problems that are difficult to diagnose.

## Validation

- `bun test tests/utils/autorouting`
- `bunx tsc --noEmit`
- `bun run build`
