### PR TITLE
Update @tscircuit/capacity-autorouter to 0.0.785

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
-    "@tscircuit/capacity-autorouter": "^0.0.783",
+    "@tscircuit/capacity-autorouter": "^0.0.785",
     "@tscircuit/checks": "0.0.152",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

- Update `@tscircuit/capacity-autorouter` from `^0.0.783` to `^0.0.785`.
- No lockfile is tracked in `tscircuit/core`.

## Why

Use the current published capacity autorouter release while preserving the existing semver range style.

## Validation

- `TMPDIR=/private/tmp/codex-bun-tmp bun run build`
- `TMPDIR=/private/tmp/codex-bun-tmp bun test` — 1,379 passed, 37 skipped, 0 failed
- `TMPDIR=/private/tmp/codex-bun-tmp bunx tsc --noEmit`

The pre-existing untracked `tests/pin-attributes-probe.test.tsx` was left untouched and is not included in this PR.