### PR TITLE
Update @tscircuit/capacity-autorouter to 0.0.786

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
-    "@tscircuit/capacity-autorouter": "^0.0.785",
+    "@tscircuit/capacity-autorouter": "^0.0.786",
     "@tscircuit/checks": "0.0.153",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

- update `@tscircuit/capacity-autorouter` from `^0.0.785` to `^0.0.786`
- pick up the Pipeline9 partial-ripping implementation from tscircuit/tscircuit-autorouter#2057

## Why

Pipeline9 now uses the partial-ripping tiny hypergraph for preloaded traces, reducing unnecessary changes to already-routed geometry while still allowing targeted trace adaptation.

## Verification

- `bun test` (1380 passed, 37 skipped, 0 failed)
- focused Pipeline9 and autorouter cache tests (5 passed)
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`
