### PR TITLE
Orient enclosure apertures from the component frame

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,81 @@ circuit.selectOne("resistor") // Find first resistor
   at an untrusted boundary; redundant internal guards add noise and hide broken
   type contracts.
 
+## Coordinate frames, side names, and transforms
+
+### Declare the frame at every boundary
+
+Any function or record carrying geometry states explicitly, in its docstring:
+**which frame** (footprint-local, board/circuit world, renderer scene), **what
+the axes mean**, **units** (mm throughout tscircuit), **handedness and which way
+is up**, and **whether the value is a point or a direction** — a point picks up
+translation, a direction must not. Most of the transform defects here were two
+functions silently disagreeing about which frame they were handed.
+
+### Validate a convention before copying it
+
+Matching surrounding code is the default *only* once you have confirmed the
+surrounding code is intentional. Prevailing patterns in this area have
+repeatedly turned out to be bugs, or compensations for bugs elsewhere. Before
+adopting one, find its origin commit, the test that pins it, or a measurement
+that confirms it — and prefer removing a compensation at its source over adding
+a matching one.
+
+### Canonical direction names
+
+Directions name **where something is**, in board space: +X `right`, −X `left`,
++Y `top`, −Y `bottom`, +Z `above`, −Z `below`. Published in `circuit-json` as
+`InsertionDirection` (`from_right`, `from_left`, `from_top`, …).
+
+`front` and `back` are retired and `@deprecated`: they named opposite axes in
+different packages (`3d-viewer`'s `Front` preset is −Y; `core`, `checks` and
+`circuit-json-to-gltf` treated front as +Y). They are accepted as input and
+normalized on parse, but never emitted — so never key a lookup on them.
+
+Beware that `top`/`bottom` mean **±Y** as a direction but **±Z** as a PCB
+**layer** (`layer`, `originalLayer`). A component carries `layer`; a
+`<footprint>` carries `originalLayer`; the part is mirrored when they differ.
+Enclosure and board faces avoid the ambiguity entirely by naming the axis:
+`BoardWall` and `EnclosureFace` are both
+`x_pos | x_neg | y_pos | y_neg | z_pos | z_neg`.
+
+### Transforms
+
+- **Compose; never hand-roll a rotation matrix.** Use `transformation-matrix`
+  with `compose()`/`applyToPoint()`.
+- **Orient from a paired reference transform.** When two places orient the same
+  physical thing, build both from the same expression rather than restating it.
+  `transformFootprintInsertionDirection` re-derived a footprint's placement by
+  hand, disagreed with the matrix `PrimitiveComponent` applies to the pads, and
+  reported the wrong side for every bottom-layer part. Cite the source
+  (file, symbol, expression) in a comment next to the copy.
+- **Order is load-bearing.** `compose(a, b)` applies **b** first, and rotations
+  and reflections do not commute (`F·R(θ) = R(−θ)·F`), so a re-statement that
+  differs only in order is wrong at *some* angles only — which is what lets it
+  survive review.
+- **A layer flip is a rotation, not an inversion.** Core flips with `flipY()`
+  (mirror on the y-axis, so it negates X), a 180° rotation about Y:
+  `(x, y, z) → (−x, y, −z)`. Exactly two components invert; negating all three
+  would be improper and would mirror the part.
+- **Never add a renderer compensation.** Fix the frame at its source. Core
+  previously swapped the +Y and −Y enclosure walls to offset a renderer bug;
+  such a flip is invisible once the bug it offsets is fixed, and then it *is*
+  the bug.
+- **State the frame** at every boundary carrying geometry: which frame, axis
+  meanings, units, handedness, and whether the value is a point (picks up
+  translation) or a direction (must not).
+
+### Testing geometry
+
+- Assert against **emitted geometry**, not a restatement of the transform — see
+  `tests/components/normal-components/footprint-insertion-direction-matches-pads.test.tsx`,
+  which derives every expectation from where pin1 actually lands.
+- Cover 0°/180° **and** 90°/270°, on both layers: each pair alone cannot
+  distinguish a wrong mirror axis, because there right and wrong agree exactly.
+- Make sure the test **can** fail. Where two inputs normally agree, place the
+  fixture where they disagree; otherwise the assertion holds no matter which one
+  the code used.
+
 ## Build Configuration
 
 - ESM output with TypeScript declarations

--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -45,6 +45,7 @@ import {
 import {
   isFootprintFlipped,
   transformFootprintInsertionDirection,
+  transformFootprintInsertionDirectionVector,
 } from "lib/utils/pcb/transform-footprint-insertion-direction"
 import {
   type PortArrangement,
@@ -1170,6 +1171,7 @@ export class NormalComponent<
   private _getFootprintMetadataForPcbComponent():
     | {
         insertionDirection?: FootprintInsertionDirection
+        cutoutApertureDirection?: FootprintInsertionDirection
         originalLayer?: LayerRef
       }
     | undefined {
@@ -1180,6 +1182,8 @@ export class NormalComponent<
     if (footprintChild) {
       return {
         insertionDirection: footprintChild._parsedProps.insertionDirection,
+        cutoutApertureDirection:
+          footprintChild._parsedProps.cutoutApertureDirection,
         originalLayer: footprintChild._parsedProps.originalLayer,
       }
     }
@@ -1189,10 +1193,12 @@ export class NormalComponent<
     if (isValidElement(footprint)) {
       const footprintProps = footprint.props as {
         insertionDirection?: FootprintInsertionDirection
+        cutoutApertureDirection?: FootprintInsertionDirection
         originalLayer?: LayerRef
       }
       return {
         insertionDirection: footprintProps.insertionDirection,
+        cutoutApertureDirection: footprintProps.cutoutApertureDirection,
         originalLayer: footprintProps.originalLayer,
       }
     }
@@ -1202,6 +1208,9 @@ export class NormalComponent<
         insertionDirection:
           footprint._parsedProps?.insertionDirection ??
           footprint.props?.insertionDirection,
+        cutoutApertureDirection:
+          footprint._parsedProps?.cutoutApertureDirection ??
+          footprint.props?.cutoutApertureDirection,
         originalLayer:
           footprint._parsedProps?.originalLayer ??
           footprint.props?.originalLayer,
@@ -1235,6 +1244,37 @@ export class NormalComponent<
       isFlipped: isFootprintFlipped({
         componentLayer,
         originalLayer: footprintMetadata.originalLayer,
+      }),
+    })
+  }
+
+  /**
+   * The enclosure aperture's outward axis as a continuous unit direction in
+   * board XYZ (+Z above the board). It is a direction, not a point, and receives
+   * the same rotation and layer transform as the footprint's pads.
+   *
+   * The emitted named direction is deliberately quantized because it chooses a
+   * Cartesian wall. A cutting tool must use this unquantized companion instead:
+   * at +45 degrees the chosen wall can still be x_neg while the physical axis
+   * is exactly halfway toward y_neg, and reconstructing that angle from the
+   * component rotation loses which side of the tie core selected.
+   */
+  _getEnclosureApertureAxisDirection(
+    componentLayer: LayerRef,
+    rotationDegrees: number = this.getGlobalTransformRotation(),
+  ): { x: number; y: number; z: number } | undefined {
+    const footprintMetadata = this._getFootprintMetadataForPcbComponent()
+    const apertureDirection =
+      footprintMetadata?.cutoutApertureDirection ??
+      footprintMetadata?.insertionDirection
+    if (!apertureDirection) return undefined
+
+    return transformFootprintInsertionDirectionVector({
+      insertionDirection: apertureDirection,
+      rotationDegrees,
+      isFlipped: isFootprintFlipped({
+        componentLayer,
+        originalLayer: footprintMetadata?.originalLayer,
       }),
     })
   }
@@ -1936,6 +1976,10 @@ export class NormalComponent<
       model_origin_alignment: "center_of_component_on_board_surface",
       anchor_alignment: "center_of_component_on_board_surface",
       model_origin_position: cadModel?.modelOriginPosition,
+      // The authored extent, carried on the record so consumers can read the
+      // part's mechanical facts from one place instead of reaching back into
+      // props -- which only works for the object form of `cadModel`.
+      ...(cadModel?.size ? { size: cadModel.size as never } : {}),
       footprinter_string: footprinterStringForCadComponent,
       show_as_translucent_model: this._parsedProps.showAsTranslucentModel,
     } as any)

--- a/lib/components/primitive-components/EnclosureCutoutAperture/get-fdm-enclosure-solver-input.ts
+++ b/lib/components/primitive-components/EnclosureCutoutAperture/get-fdm-enclosure-solver-input.ts
@@ -3,40 +3,42 @@ import type {
   EnclosureFace,
 } from "@tscircuit/create-fdm-enclosure"
 import type { ParsedEnclosureCutoutApertureProps } from "@tscircuit/props"
-import type { CadComponent, PcbBoard } from "circuit-json"
+import type { CadComponent, PcbBoard, PcbComponent } from "circuit-json"
 import type { Board } from "../../normal-components/Board"
 import type { EnclosureCutoutAperture } from "./EnclosureCutoutAperture"
 import { getComponentBody } from "./get-component-body"
 import { getNearestBoardWall } from "./get-nearest-board-wall"
 import type { BoardWall } from "./get-nearest-board-wall"
-import { getSolverWall } from "./get-solver-wall"
 
+/**
+ * `insertion_direction` names the board edge a part is reached from, and board
+ * walls are named for the same axes, so this is a straight correspondence.
+ *
+ * Keyed on the canonical Circuit JSON names only. The deprecated `from_front`
+ * and `from_back` are normalized away on parse and are never present on an
+ * emitted `pcb_component`.
+ */
 const INSERTION_DIRECTION_TO_BOARD_WALL: Record<string, BoardWall> = {
   from_top: "y_pos",
   from_bottom: "y_neg",
   from_left: "x_neg",
   from_right: "x_pos",
 }
+import { getSolverWall } from "./get-solver-wall"
 
 export interface GetFdmEnclosureSolverInputParams {
   board: Board
   pcbBoard: PcbBoard
 }
 
-/**
- * Minimal adapter for the staged solver API.
- *
- * This layer preserves Core's existing insertion-direction/nearest-edge
- * placement. This layer adds component bodies, offsets and explicit depth;
- * the continuous cutout aperture axis is added by the next stacked layer.
- */
 export const getFdmEnclosureSolverInput = (
   apertureComponent: EnclosureCutoutAperture,
   { board, pcbBoard }: GetFdmEnclosureSolverInputParams,
 ): EnclosureApertureInput => {
   let owner = apertureComponent.parent
-  while (owner && owner !== board && !owner.pcb_component_id)
+  while (owner && owner !== board && !owner.pcb_component_id) {
     owner = owner.parent
+  }
 
   const pcbComponent = owner?.pcb_component_id
     ? apertureComponent.root?.db.pcb_component.get(owner.pcb_component_id)
@@ -49,38 +51,131 @@ export const getFdmEnclosureSolverInput = (
 
   const aperture =
     apertureComponent._parsedProps as ParsedEnclosureCutoutApertureProps
-  const direction = pcbComponent.insertion_direction
+
+  const apertureDirectionOwner = owner as typeof owner & {
+    _getEnclosureApertureAxisDirection?: (
+      componentLayer: PcbComponent["layer"],
+      rotationDegrees: number,
+    ) => { x: number; y: number; z: number } | undefined
+  }
+  // Props are staged before the durable Circuit JSON direction field. Read the
+  // transformed component-owned axis directly for now; once the schema lands,
+  // Core will additionally emit its quantized name on pcb_component.
+  const apertureAxisDirection =
+    apertureDirectionOwner?._getEnclosureApertureAxisDirection?.(
+      pcbComponent.layer,
+      pcbComponent.rotation ?? 0,
+    )
+  const apertureDirection = apertureAxisDirection
+    ? apertureAxisDirection.z !== 0
+      ? apertureAxisDirection.z > 0
+        ? "from_above"
+        : "from_below"
+      : Math.abs(apertureAxisDirection.x) >= Math.abs(apertureAxisDirection.y)
+        ? apertureAxisDirection.x >= 0
+          ? "from_right"
+          : "from_left"
+        : apertureAxisDirection.y >= 0
+          ? "from_top"
+          : "from_bottom"
+    : pcbComponent.insertion_direction
+
+  // A part that mates along Z exits through a horizontal face. Which one is
+  // carried by the direction itself: `transformFootprintInsertionDirection`
+  // inverts Z on a layer flip, because moving to the other layer is a 180
+  // degree rotation about the board's Y axis. So a footprint authored
+  // `from_above` reports `from_below` when mounted on the bottom layer, and its
+  // aperture pierces the floor rather than the lid.
+  //
+  // Reading the face off the direction rather than off the mounting layer also
+  // honours a part that explicitly declares the opposite side.
   const verticalFace: EnclosureFace | undefined =
-    direction === "from_above"
+    apertureDirection === "from_above"
       ? "z_pos"
-      : direction === "from_below"
+      : apertureDirection === "from_below"
         ? "z_neg"
         : undefined
-  const point = pcbComponent.cable_insertion_center ?? pcbComponent.center
-  const face =
-    verticalFace ??
-    getSolverWall(
-      INSERTION_DIRECTION_TO_BOARD_WALL[direction ?? ""] ??
-        getNearestBoardWall({ point, board: pcbBoard }),
-    )
-  const center = verticalFace
-    ? {
-        x: pcbComponent.center.x - pcbBoard.center.x,
-        y: pcbComponent.center.y - pcbBoard.center.y,
-      }
-    : {
-        x: point.x - pcbBoard.center.x,
-        y: point.y - pcbBoard.center.y,
-      }
-
+  // Sets the datum for heightDimensionOffset. This one stays `top`/`bottom` because
+  // it names a PCB layer, which is a Z-side concept, not a face.
   const boardSide: "top" | "bottom" =
     pcbComponent.layer === "bottom" ? "bottom" : "top"
+
+  let face: EnclosureFace
+  let center: { x: number; y: number }
+
+  if (verticalFace) {
+    face = verticalFace
+    // Vertical apertures are centered on the component itself. No inference is
+    // involved: `cable_insertion_center` is connector-specific, and a button or
+    // LED sits exactly at its own placement.
+    center = {
+      x: pcbComponent.center.x - pcbBoard.center.x,
+      y: pcbComponent.center.y - pcbBoard.center.y,
+    }
+  } else {
+    const point = pcbComponent.cable_insertion_center ?? pcbComponent.center
+    // The named direction is the nearest Cartesian wall to the physical axis,
+    // already rotated out of the footprint frame and mirrored for the layer. It
+    // is an initial face choice; with a continuous axis the enclosure resolves
+    // the first wall that ray actually intersects, which can differ near a
+    // corner. Nearest-edge is only consulted when the footprint declares no
+    // direction, where a guess beats no aperture at all.
+    const boardWall =
+      INSERTION_DIRECTION_TO_BOARD_WALL[
+        apertureDirection as keyof typeof INSERTION_DIRECTION_TO_BOARD_WALL
+      ] ?? getNearestBoardWall({ point, board: pcbBoard })
+    const cableDelta = pcbComponent.cable_insertion_center
+      ? {
+          x: pcbComponent.cable_insertion_center.x - pcbComponent.center.x,
+          y: pcbComponent.cable_insertion_center.y - pcbComponent.center.y,
+        }
+      : null
+    const cableProjectionMatchesWall =
+      cableDelta != null &&
+      (boardWall === "x_neg" || boardWall === "x_pos"
+        ? Math.abs(cableDelta.x) >= Math.abs(cableDelta.y)
+        : Math.abs(cableDelta.y) >= Math.abs(cableDelta.x))
+    // A declared direction gives the enclosure a physical axis. Its stable datum
+    // is the same component centre the body rotates around. The inferred
+    // `cable_insertion_center` is chosen from one side of the component's
+    // axis-aligned bounds; when direction quantization switches sides near a
+    // corner, that point jumps discontinuously and is not on the rotated body
+    // axis. It remains useful only for the no-direction nearest-edge fallback.
+    const tangentPoint = apertureAxisDirection
+      ? pcbComponent.center
+      : cableProjectionMatchesWall
+        ? point
+        : pcbComponent.center
+    face = getSolverWall(boardWall)
+    center = {
+      x: tangentPoint.x - pcbBoard.center.x,
+      y: tangentPoint.y - pcbBoard.center.y,
+    }
+  }
+
+  // The physical envelope of the part. Core reports the facts; the enclosure
+  // package projects them onto the face normal to decide how far inboard the cut
+  // must reach. An authored `depth` still wins outright, so the
+  // envelope is only supplied when there is nothing authored to respect.
+  // Read off the emitted record rather than the owner's props: that is the
+  // normalized form every authoring path converges on, and it already carries
+  // the composed rotation and Z datum. `EnclosureRender` runs after
+  // `CadModelRender` precisely so this exists by now, whichever order the board
+  // and the enclosure were declared in.
+  // Looked up by `pcb_component_id` rather than the owner's `cad_component_id`,
+  // because a `<cadmodel>` child owns the record itself -- the component only
+  // holds an id when it emitted one from its own props.
   const cadComponent = (apertureComponent.root?.db.cad_component.getWhere({
     pcb_component_id: pcbComponent.pcb_component_id,
   }) ?? null) as CadComponent | null
   const boardSurfaceZ =
     (boardSide === "bottom" ? -1 : 1) *
     ((pcbBoard.thickness ?? board.boardThickness) / 2)
+  // Always supplied. It used to be withheld when a depth was authored, but the
+  // solver already prefers an authored depth over the envelope, and placement
+  // now needs the body too: a side-face opening is centred on the part's reach
+  // above the board. Withholding it would silently fall back to centring on the
+  // opening's own height.
   const componentBody = getComponentBody({
     owner,
     pcbComponent,
@@ -92,30 +187,46 @@ export const getFdmEnclosureSolverInput = (
     face,
     center,
     boardSide,
+    /**
+     * Unit direction in board XYZ (+Z above the board), not a translated point.
+     * `create-fdm-enclosure` measures it against the selected face normal to get
+     * the exact signed incidence angle.
+     */
+    apertureAxisDirection,
+    // A lid/floor aperture is authored in the footprint frame, so its in-plane
+    // roll follows the PCB component -- the same transform as pads and
+    // silkscreen. Never use `cadComponent.rotation.z` here: it also contains the
+    // model asset's `pcbRotationOffset`, and on the bottom layer its Z scalar is
+    // negated as one part of a full 3D Y-flip. Applying that scalar alone to a
+    // 2D aperture made a 45-degree floor slot rotate to -45 degrees. CAD
+    // rotation remains correct for `componentBody`, whose bounds are model-local.
+    // Side faces use `apertureAxisDirection` instead; there the board-Z rotation
+    // is an approach angle rather than roll within the wall.
     rotation: pcbComponent.rotation ?? undefined,
     depth: aperture.depth,
     componentBody,
+    // Left undefined when unauthored: `create-fdm-enclosure` owns where an
+    // opening sits by default -- centred on the part's body -- so the placement
+    // arithmetic lives with the aperture geometry, not in core.
     widthDimensionOffset: aperture.widthDimensionOffset,
     heightDimensionOffset: aperture.heightDimensionOffset,
     margin: aperture.margin,
   }
 
   switch (aperture.shape) {
-    case "circle":
-      return { ...commonInput, shape: "circle", radius: aperture.radius }
     case "pill":
-      return {
-        ...commonInput,
-        shape: "pill",
-        width: aperture.width,
-        height: aperture.height,
-      }
     case "rect":
       return {
         ...commonInput,
-        shape: "rect",
+        shape: aperture.shape,
         width: aperture.width,
         height: aperture.height,
+      }
+    case "circle":
+      return {
+        ...commonInput,
+        shape: "circle",
+        radius: aperture.radius,
       }
   }
 }

--- a/lib/utils/pcb/transform-footprint-insertion-direction.ts
+++ b/lib/utils/pcb/transform-footprint-insertion-direction.ts
@@ -18,14 +18,22 @@ import {
  * directions are handled separately because rotating a footprint within the
  * board plane cannot change them.
  */
-const inPlaneDirectionToVector: Record<
-  Exclude<InsertionDirection, "from_above" | "from_below">,
-  { x: number; y: number }
+const insertionDirectionToVector: Record<
+  InsertionDirection,
+  { x: number; y: number; z: number }
 > = {
-  from_left: { x: -1, y: 0 },
-  from_right: { x: 1, y: 0 },
-  from_top: { x: 0, y: 1 },
-  from_bottom: { x: 0, y: -1 },
+  from_left: { x: -1, y: 0, z: 0 },
+  from_right: { x: 1, y: 0, z: 0 },
+  from_top: { x: 0, y: 1, z: 0 },
+  from_bottom: { x: 0, y: -1, z: 0 },
+  from_above: { x: 0, y: 0, z: 1 },
+  from_below: { x: 0, y: 0, z: -1 },
+}
+
+export interface BoardDirectionVector {
+  x: number
+  y: number
+  z: number
 }
 
 export const isFootprintFlipped = (params: {
@@ -37,31 +45,28 @@ export const isFootprintFlipped = (params: {
 }
 
 /**
- * Converts a footprint-frame insertion direction into board coordinates by
- * applying the component's rotation and layer.
+ * Converts a footprint-local direction into a unit direction vector in the
+ * board's right-handed XYZ frame (+Z above the board), applying the exact same
+ * rotation and layer transform as the footprint's pads. This is a direction,
+ * not a point: it receives no translation. Millimetres therefore do not apply.
  *
- * Accepts either spelling the props enum allows and always returns one of the
- * six canonical named directions.
+ * Unlike `transformFootprintInsertionDirection`, this retains the continuous
+ * in-plane angle. Consumers that orient physical geometry must use this vector;
+ * the named direction is intentionally quantized and is only suitable for
+ * choosing the nearest Cartesian side.
  */
-export const transformFootprintInsertionDirection = (params: {
+export const transformFootprintInsertionDirectionVector = (params: {
   insertionDirection?: FootprintInsertionDirection
   rotationDegrees?: number
   isFlipped?: boolean
-}): InsertionDirection | undefined => {
+}): BoardDirectionVector | undefined => {
   const { insertionDirection, rotationDegrees = 0, isFlipped = false } = params
-
   if (!insertionDirection) return undefined
 
   // Circuit JSON accepts deprecated and Cartesian direction names at input,
-  // but pcb_component.insertion_direction is written with the canonical names.
+  // but internal geometry uses the six canonical axes.
   const direction = insertionDirectionToCanonical[insertionDirection]
-
-  // A footprint moved to the other layer is rotated 180 degrees about the
-  // board's Y axis, so an insertion along Z now points the opposite way.
-  if (direction === "from_above" || direction === "from_below") {
-    if (!isFlipped) return direction
-    return direction === "from_above" ? "from_below" : "from_above"
-  }
+  const localVector = insertionDirectionToVector[direction]
 
   // Reuse the transform PrimitiveComponent applies to the footprint's own
   // geometry, so this direction cannot drift from where the pads land. From
@@ -75,16 +80,38 @@ export const transformFootprintInsertionDirection = (params: {
   //   )
   //
   // compose() applies right to left, so the footprint is flipped in its own
-  // frame and the component's rotation is applied after. flipY() mirrors on
-  // the y-axis, which negates X and leaves Y alone.
+  // frame and the component's rotation is applied after. In board 3D, flipY()
+  // is the XY projection of the layer's 180-degree turn about Y: it negates X,
+  // leaves Y alone, and the corresponding Z component is negated explicitly.
   const transform = compose(
     rotate((normalizeDegrees(rotationDegrees) * Math.PI) / 180),
     isFlipped ? flipY() : identity(),
   )
-  const finalVector = applyToPoint(
-    transform,
-    inPlaneDirectionToVector[direction],
-  )
+  const transformedXy = applyToPoint(transform, localVector)
+
+  return {
+    x: transformedXy.x,
+    y: transformedXy.y,
+    z: isFlipped ? -localVector.z : localVector.z,
+  }
+}
+
+/**
+ * Converts a footprint-frame insertion direction into the nearest canonical
+ * board axis. This quantized result chooses a wall; use the paired vector
+ * transform above to orient geometry within that choice.
+ */
+export const transformFootprintInsertionDirection = (params: {
+  insertionDirection?: FootprintInsertionDirection
+  rotationDegrees?: number
+  isFlipped?: boolean
+}): InsertionDirection | undefined => {
+  const finalVector = transformFootprintInsertionDirectionVector(params)
+  if (!finalVector) return undefined
+
+  if (finalVector.z !== 0) {
+    return finalVector.z > 0 ? "from_above" : "from_below"
+  }
 
   if (Math.abs(finalVector.x) >= Math.abs(finalVector.y)) {
     return finalVector.x >= 0 ? "from_right" : "from_left"

--- a/tests/enclosure/enclosure-cutout-direction-beats-insertion.test.tsx
+++ b/tests/enclosure/enclosure-cutout-direction-beats-insertion.test.tsx
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { enclosure } from "lib"
+import type { SolverStartedEvent } from "lib/events"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/** Installation and interaction are independent part-local facts. */
+test("cutoutApertureDirection places the opening instead of insertionDirection", () => {
+  const { circuit } = getTestFixture()
+  let event: SolverStartedEvent | undefined
+  circuit.on("solver:started", (nextEvent) => {
+    if (nextEvent.solverName === "CreateFdmEnclosureSolver") event = nextEvent
+  })
+
+  circuit.add(
+    <group>
+      <board name="B1" width="40mm" height="24mm" routingDisabled>
+        <pushbutton
+          name="SW1"
+          pcbX="14mm"
+          footprint={
+            <footprint
+              insertionDirection="from_above"
+              cutoutApertureDirection="from_right"
+            >
+              <smtpad
+                portHints={["pin1"]}
+                width="2mm"
+                height="2mm"
+                shape="rect"
+              />
+            </footprint>
+          }
+        >
+          <enclosure.cutoutaperture shape="circle" radius="1.6mm" />
+        </pushbutton>
+      </board>
+      <enclosure.fdm.box boardRef=".B1" />
+    </group>,
+  )
+  circuit.render()
+
+  expect(circuit.db.pcb_component.list()[0]?.insertion_direction).toBe(
+    "from_above",
+  )
+  expect(event?.solverParams.apertures[0]).toMatchObject({
+    face: "x_pos",
+    apertureAxisDirection: { x: 1, y: 0, z: 0 },
+  })
+})

--- a/tests/enclosure/enclosure-cutout-direction-rotates-with-part.test.tsx
+++ b/tests/enclosure/enclosure-cutout-direction-rotates-with-part.test.tsx
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { enclosure } from "lib"
+import type { SolverStartedEvent } from "lib/events"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/** The aperture axis uses the same component transform as footprint geometry. */
+test("cutoutApertureDirection rotates with the part", () => {
+  const { circuit } = getTestFixture()
+  let event: SolverStartedEvent | undefined
+  circuit.on("solver:started", (nextEvent) => {
+    if (nextEvent.solverName === "CreateFdmEnclosureSolver") event = nextEvent
+  })
+
+  circuit.add(
+    <group>
+      <board name="B1" width="40mm" height="24mm" routingDisabled>
+        <pushbutton
+          name="SW1"
+          pcbY="9mm"
+          pcbRotation="90deg"
+          footprint={
+            <footprint
+              insertionDirection="from_above"
+              cutoutApertureDirection="from_right"
+            >
+              <smtpad
+                portHints={["pin1"]}
+                width="2mm"
+                height="2mm"
+                shape="rect"
+              />
+            </footprint>
+          }
+        >
+          <enclosure.cutoutaperture shape="circle" radius="1.6mm" />
+        </pushbutton>
+      </board>
+      <enclosure.fdm.box boardRef=".B1" />
+    </group>,
+  )
+  circuit.render()
+
+  expect(event?.solverParams.apertures[0]?.face).toBe("y_pos")
+  expect(event?.solverParams.apertures[0]?.apertureAxisDirection.x).toBeCloseTo(
+    0,
+  )
+  expect(event?.solverParams.apertures[0]?.apertureAxisDirection.y).toBeCloseTo(
+    1,
+  )
+})

--- a/tests/enclosure/enclosure-cutout-horizontal-bottom-layer-rotation.test.tsx
+++ b/tests/enclosure/enclosure-cutout-horizontal-bottom-layer-rotation.test.tsx
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { enclosure } from "lib"
+import type { SolverStartedEvent } from "lib/events"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/**
+ * A bottom-layer placement is a full 180-degree rotation about board Y. Core
+ * represents that on a CAD model as Y=180 plus a negated Z scalar, but the
+ * footprint itself -- pads, silkscreen, and aperture profile -- still has the
+ * authored board-Z roll. Taking CAD Z alone made +45 become -45 and turned a
+ * rectangular floor opening perpendicular to the switch it served.
+ */
+test("a bottom-layer floor aperture rolls with its footprint, not CAD Z", async () => {
+  const { circuit } = getTestFixture()
+  let event: SolverStartedEvent | undefined
+  circuit.on("solver:started", (solverEvent) => {
+    if (solverEvent.solverName === "CreateFdmEnclosureSolver") {
+      event = solverEvent
+    }
+  })
+
+  circuit.add(
+    <group>
+      <board name="B1" width="30mm" height="24mm" routingDisabled>
+        <pushbutton
+          name="SW1"
+          layer="bottom"
+          pcbX={0}
+          pcbY={0}
+          pcbRotation={45}
+          footprint={
+            <footprint insertionDirection="from_above">
+              <smtpad
+                portHints={["pin1"]}
+                pcbX={-3}
+                width={2}
+                height={1}
+                shape="rect"
+              />
+              <smtpad
+                portHints={["pin2"]}
+                pcbX={3}
+                width={2}
+                height={1}
+                shape="rect"
+              />
+            </footprint>
+          }
+          cadModel={{
+            objUrl: "https://example.com/switch.obj",
+            pcbRotationOffset: 0,
+            size: { x: 8, y: 5, z: 4 },
+          }}
+        >
+          <enclosure.cutoutaperture shape="rect" width="8mm" height="3mm" />
+        </pushbutton>
+      </board>
+      <enclosure.fdm.box boardRef=".B1" />
+    </group>,
+  )
+  await circuit.renderUntilSettled()
+
+  const aperture = event?.solverParams.apertures[0]
+  const cadComponent = circuit.db.cad_component.list()[0]!
+
+  expect(aperture.face).toBe("z_neg")
+  expect(aperture.rotation).toBeCloseTo(45)
+  // This is a valid component of the CAD model's full Y=180 transform, but it
+  // is not the standalone 2D roll of the footprint-owned aperture.
+  expect(cadComponent.rotation?.z).toBeCloseTo(315)
+})

--- a/tests/enclosure/enclosure-cutout-horizontal-ignores-cad-rotation-offset.test.tsx
+++ b/tests/enclosure/enclosure-cutout-horizontal-ignores-cad-rotation-offset.test.tsx
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test"
+import { enclosure } from "lib"
+import type { SolverStartedEvent } from "lib/events"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/**
+ * `pcbRotationOffset` aligns a raw CAD asset's native axes to its footprint. It
+ * must rotate only model-local geometry; inheriting it into a footprint-owned
+ * aperture turns a correct slot merely because a downloaded OBJ needed repair.
+ */
+test("a lid aperture ignores the CAD asset rotation offset", async () => {
+  const { circuit } = getTestFixture()
+  let event: SolverStartedEvent | undefined
+  circuit.on("solver:started", (solverEvent) => {
+    if (solverEvent.solverName === "CreateFdmEnclosureSolver") {
+      event = solverEvent
+    }
+  })
+
+  circuit.add(
+    <group>
+      <board name="B1" width="30mm" height="24mm" routingDisabled>
+        <pushbutton
+          name="SW1"
+          pcbX={0}
+          pcbY={0}
+          pcbRotation={20}
+          footprint={
+            <footprint insertionDirection="from_above">
+              <smtpad
+                portHints={["pin1"]}
+                pcbX={-3}
+                width={2}
+                height={1}
+                shape="rect"
+              />
+              <smtpad
+                portHints={["pin2"]}
+                pcbX={3}
+                width={2}
+                height={1}
+                shape="rect"
+              />
+            </footprint>
+          }
+          cadModel={{
+            objUrl: "https://example.com/switch-native-y.obj",
+            pcbRotationOffset: 90,
+            size: { x: 8, y: 5, z: 4 },
+          }}
+        >
+          <enclosure.cutoutaperture shape="rect" width="8mm" height="3mm" />
+        </pushbutton>
+      </board>
+      <enclosure.fdm.box boardRef=".B1" />
+    </group>,
+  )
+  await circuit.renderUntilSettled()
+
+  const aperture = event?.solverParams.apertures[0]
+  const cadComponent = circuit.db.cad_component.list()[0]!
+
+  expect(aperture.face).toBe("z_pos")
+  expect(aperture.rotation).toBeCloseTo(20)
+  expect(cadComponent.rotation?.z).toBeCloseTo(110)
+})


### PR DESCRIPTION
## Summary

- prefer footprint-local `cutoutApertureDirection` over `insertionDirection`, with nearest-edge detection remaining the fallback when neither is authored
- preserve the continuous aperture axis through component rotation and bottom-layer transforms instead of quantizing it to a wall direction
- anchor the transformed axis at the component datum so the enclosure solver can choose the first wall it intersects
- derive horizontal aperture profile roll from the PCB component frame rather than CAD asset alignment offsets

## Layering

All prerequisites for this final layer are merged:

- #3166 — `assembly.device` compatibility container
- #3174 — staged two-part solver integration
- #3180 — separate base and lid CAD components
- #3196 — component body, aperture offsets and explicit depth
- tscircuit/3d-viewer#974 — compatibility appearance controls for the assembled enclosure

This PR is now rebased onto Core `v0.0.1670` and contains only the component-relative aperture-axis layer.

## Circuit JSON compatibility

This deliberately preserves the existing synthetic enclosure representation. It does not emit unreleased typed enclosure records or persist viewer appearance state in Circuit JSON.

## Engineering guidance

This PR also adds the repository-local geometry rules learned while implementing the axis transform: explicit frame declarations, canonical direction names, composed transforms, proper bottom-layer rotations, and discriminating geometry tests. Keeping the guidance with the implementation prevents the same frame defects from returning.

## Testing

- `bun run format`
- `bunx tsc --noEmit`
- dependency check
- build and `smoke-test:dist`
- duplicate-helper check
- focused enclosure tests: 4 passed
- full Core suite: 1,400 passed, 37 skipped, 0 failed; 58 snapshots and 7,961 assertions

