### PR TITLE
Update capacity autorouter to 0.0.790

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
-    "@tscircuit/capacity-autorouter": "^0.0.786",
+    "@tscircuit/capacity-autorouter": "^0.0.790",
     "@tscircuit/checks": "0.0.153",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

- update `@tscircuit/capacity-autorouter` from `^0.0.786` to `^0.0.790`
- keep the existing semver range style

## Why

This brings `@tscircuit/core` onto the latest published capacity autorouter release so it can pick up the newest routing improvements and fixes.

## Impact

No core source code or peer dependency contract changes. Consumers continue to provide the autorouter through the existing peer dependency, while development and validation use the newer release.

## Validation

- confirmed `0.0.790` is the latest version published on npm
- parsed the updated `package.json` successfully
- verified the branch is one commit ahead of `main` and changes only `package.json` (1 addition, 1 deletion)
