### PR TITLE
Fix inductor max current rating

### DIFF
--- a/lib/components/normal-components/Inductor.ts
+++ b/lib/components/normal-components/Inductor.ts
@@ -6,7 +6,7 @@ import {
 } from "lib/utils/constants"
 import { NormalComponent } from "../base-components/NormalComponent/NormalComponent"
 import { Port } from "../primitive-components/Port"
-import { formatSiUnit } from "format-si-unit"
+import { formatSiUnit, parseAndConvertSiUnit } from "format-si-unit"
 import type { SourceSimpleInductor } from "circuit-json"
 
 export class Inductor extends NormalComponent<
@@ -45,6 +45,10 @@ export class Inductor extends NormalComponent<
       name: this.name,
       ftype: FTYPE.simple_inductor,
       inductance: this.props.inductance,
+      max_current_rating:
+        props.maxCurrentRating === undefined
+          ? undefined
+          : parseAndConvertSiUnit(props.maxCurrentRating, "A").value,
       display_inductance: this._getSchematicSymbolDisplayValue(),
       supplier_part_numbers: props.supplierPartNumbers,
       manufacturer_part_number: props.manufacturerPartNumber ?? props.mfn,

--- a/tests/components/normal-components/inductor.test.tsx
+++ b/tests/components/normal-components/inductor.test.tsx
@@ -9,6 +9,7 @@ test("<inductor /> component", async () => {
       <inductor
         name="U1"
         inductance="10"
+        maxCurrentRating="2A"
         footprint="axial_p0.3in"
         pcbX={0}
         pcbY={0}
@@ -17,6 +18,12 @@ test("<inductor /> component", async () => {
   )
 
   circuit.render()
+
+  expect(circuit.db.source_component.getWhere({ name: "U1" })).toMatchObject({
+    ftype: "simple_inductor",
+    inductance: "10",
+    max_current_rating: 2,
+  })
 
   expect(circuit).toMatchPcbSnapshot(import.meta.path)
   expect(circuit).toMatchSchematicSnapshot(import.meta.path)


### PR DESCRIPTION
## Summary

- Preserve `maxCurrentRating` when rendering an inductor source component.
- Convert values such as `"2A"` to the numeric Circuit JSON value `2`.
- Add regression coverage for the generated source component.

## Root cause

The inductor prop was accepted but omitted from the source component insert payload.

## Validation

- `bun test tests/components/normal-components/inductor.test.tsx` passes.
- `bunx tsc --noEmit` remains blocked by existing unrelated type errors in other files.