### PR TITLE
Avoid Sharp libvips downloads during CI install

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
   "overrides": {
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/props": "^0.0.620",
-    "circuit-json": "^0.0.466"
+    "circuit-json": "^0.0.466",
+    "looks-same": "^10.0.1"
   }
 }


### PR DESCRIPTION
Overrides the transitive `looks-same` dependency to v10. `bun-match-svg` currently requests `looks-same@9`, which installs `sharp@0.32.6`; Sharp downloads libvips from GitHub during `bun install` and falls back to a native build when that download fails.

That made every test shard in #3180 fail before tests ran:

```text
sharp: Downloading ...libvips-8.14.5-linux-x64.tar.br
sharp: Installation error: socket hang up
error: install script from "sharp" exited with 1
```

`looks-same@10` replaced Sharp with the portable PNG implementation. A clean install on this branch resolves `looks-same@10.0.1` and contains no Sharp package.

Validation:

- clean install without Sharp
- typecheck and focused snapshots pass
- exact Core PR gates pass: 7/7
- full suite: 1388 pass, 37 skip, 0 fail

This is intentionally separate from the enclosure stack. After it merges, #3180 can rebase onto it.