### PR TITLE
fix resistor tolerance serialization

### DIFF
--- a/lib/components/normal-components/Resistor.ts
+++ b/lib/components/normal-components/Resistor.ts
@@ -6,6 +6,13 @@ import { Port } from "../primitive-components/Port"
 import { Trace } from "../primitive-components/Trace/Trace"
 import { formatSiUnit } from "format-si-unit"
 
+// `circuit-json` versions that predate resistor tolerance do not expose this
+// optional field in `SourceSimpleResistorInput` yet. Keep the boundary type
+// local until the dependency publishes the field.
+type SourceSimpleResistorWithTolerance = SourceSimpleResistorInput & {
+  tolerance?: number
+}
+
 export class Resistor extends NormalComponent<
   typeof resistorProps,
   PassivePorts
@@ -86,10 +93,11 @@ export class Resistor extends NormalComponent<
       supplier_part_numbers: props.supplierPartNumbers,
 
       resistance: props.resistance,
+      tolerance: props.tolerance,
       display_resistance: this._getSchematicSymbolDisplayValue(),
       are_pins_interchangeable: true,
       display_name: props.displayName,
-    } as SourceSimpleResistorInput)
+    } as SourceSimpleResistorWithTolerance)
     this.source_component_id = source_component.source_component_id
   }
 }

--- a/tests/components/normal-components/resistor-tolerance.test.tsx
+++ b/tests/components/normal-components/resistor-tolerance.test.tsx
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("resistor tolerance is included in Circuit JSON", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board>
+      <resistor name="R1" resistance="10k" tolerance="5%" />
+    </board>,
+  )
+  circuit.render()
+
+  expect(circuit.db.source_component.getWhere({ name: "R1" })).toMatchObject({
+    resistance: 10_000,
+    tolerance: 0.05,
+  })
+})


### PR DESCRIPTION
## What changed

Resistor tolerance is now preserved in generated Circuit JSON.

## Why

The resistor props schema already accepts `tolerance`, but `Resistor.doInitialSourceRender()` omitted it from the source component record. Values such as `"5%"` are serialized as `0.05`.

## Validation

- `bun test tests/components/normal-components/resistor-tolerance.test.tsx`
- `bunx tsc --noEmit`

The fix is submitted from `rushabhcodes/core` branch `fix-resistor-tolerance`.