### PR TITLE
Report enclosure component bodies and aperture depth

### DIFF
--- a/lib/components/primitive-components/EnclosureCutoutAperture/get-component-body.ts
+++ b/lib/components/primitive-components/EnclosureCutoutAperture/get-component-body.ts
@@ -1,0 +1,125 @@
+import type { EnclosureComponentBody } from "@tscircuit/create-fdm-enclosure"
+import type { CadComponent, PcbComponent } from "circuit-json"
+import type { PrimitiveComponent } from "../../base-components/PrimitiveComponent"
+
+type Point3Like = { x?: number; y?: number; z?: number }
+
+/**
+ * How far the model reaches beyond the point that sits on the board surface.
+ *
+ * `model_origin_position` is that point, and `model_bounds` is the model's
+ * extent in the same frame, so the difference along the board normal is the
+ * reach. `size` cannot answer this: it carries the extent but not where the box
+ * sits relative to the origin, and the box is generally not centered on it.
+ *
+ * Everything that merely *translates* the model -- `zOffsetFromSurface`,
+ * `positionOffset.z`, the mounting layer -- is already composed into
+ * `cad_component.position.z`, so the caller adds that rather than re-deriving
+ * it here.
+ */
+const getModelReachAboveOrigin = ({
+  cad,
+  authoredModel,
+}: {
+  cad: CadComponent
+  authoredModel?: Record<string, any>
+}): number | undefined => {
+  // `modelBounds` is staged in Props before it becomes durable Circuit JSON.
+  // Prefer the eventual record field when present, but read the parsed prop in
+  // this migration PR so Core can consume it without a schema fork.
+  const bounds =
+    ((cad as CadComponent & { model_bounds?: unknown }).model_bounds as
+      | { min?: Point3Like; max?: Point3Like }
+      | undefined) ?? authoredModel?.modelBounds
+  const origin =
+    (cad.model_origin_position as Point3Like | undefined) ??
+    authoredModel?.modelOriginPosition
+  if (!bounds?.min || !bounds?.max || !origin) return undefined
+
+  // The model axis that leaves the board. Defaults to z+, matching the
+  // renderer's own default in `getOrientationRotationForBoardNormal`.
+  const normal =
+    cad.model_board_normal_direction ??
+    authoredModel?.modelBoardNormalDirection ??
+    "z+"
+  const axis = normal[0] as "x" | "y" | "z"
+  if (axis !== "x" && axis !== "y" && axis !== "z") return undefined
+
+  const min = bounds.min[axis]
+  const max = bounds.max[axis]
+  const at = origin[axis]
+  if (min === undefined || max === undefined || at === undefined)
+    return undefined
+
+  // For a negative normal the model points the other way, so the reach runs
+  // from the origin down to the minimum instead of up to the maximum.
+  const reach = normal.endsWith("-") ? at - min : max - at
+  return Number.isFinite(reach) && reach >= 0 ? reach : undefined
+}
+
+/**
+ * Project the part's physical facts into the enclosure package's normalized
+ * body envelope.
+ *
+ * Size, placement and rotation come from the emitted `cad_component`, the
+ * normalized form every authoring path converges on. During this staged
+ * migration only, measured `modelBounds` may still live solely in the parsed
+ * object prop because Circuit JSON has not gained the durable field yet; that
+ * one fact falls back to the owner prop and moves to the record in the later
+ * schema PR.
+ *
+ * It also means the rotation and the Z datum are the ones the model is actually
+ * rendered at: `rotation.z` already composes the footprint rotation with the
+ * model's own `pcbRotationOffset`, and `position.z` already composes
+ * `zOffsetFromSurface`, `positionOffset.z` and the mounting layer. Re-deriving
+ * either here is how the two drift apart.
+ *
+ * Core reports what it canonically knows and does not decide what any of it
+ * means for a cut: face selection and depth projection are enclosure policy,
+ * which is why no face is taken here.
+ */
+export const getComponentBody = ({
+  owner,
+  pcbComponent,
+  cadComponent,
+  boardSurfaceZ,
+}: {
+  owner?: PrimitiveComponent | null
+  pcbComponent: PcbComponent
+  cadComponent: CadComponent | null | undefined
+  /**
+   * World Z of the surface the part is mounted on, so the model's reach is
+   * measured from the board rather than from wherever its origin landed.
+   */
+  boardSurfaceZ: number
+}): EnclosureComponentBody => {
+  const cadModelProp = owner?._parsedProps?.cadModel
+  const authoredModel =
+    cadModelProp && typeof cadModelProp === "object"
+      ? (cadModelProp as Record<string, any>)
+      : undefined
+  const size = (cadComponent?.size ?? authoredModel?.size) as
+    | Point3Like
+    | undefined
+  const x = size?.x
+  const y = size?.y
+  const z = size?.z
+  const reach = cadComponent
+    ? getModelReachAboveOrigin({ cad: cadComponent, authoredModel })
+    : undefined
+  const originZ = cadComponent?.position?.z
+  const aboveBoardHeight =
+    reach !== undefined && originZ !== undefined
+      ? reach + Math.abs(originZ - boardSurfaceZ)
+      : undefined
+
+  return {
+    size: x !== undefined && y !== undefined ? { x, y, z } : undefined,
+    aboveBoardHeight,
+    rotation: cadComponent?.rotation?.z ?? pcbComponent.rotation ?? 0,
+    footprint: {
+      width: pcbComponent.width,
+      height: pcbComponent.height,
+    },
+  }
+}

--- a/lib/components/primitive-components/EnclosureCutoutAperture/get-fdm-enclosure-solver-input.ts
+++ b/lib/components/primitive-components/EnclosureCutoutAperture/get-fdm-enclosure-solver-input.ts
@@ -3,9 +3,10 @@ import type {
   EnclosureFace,
 } from "@tscircuit/create-fdm-enclosure"
 import type { ParsedEnclosureCutoutApertureProps } from "@tscircuit/props"
-import type { PcbBoard } from "circuit-json"
+import type { CadComponent, PcbBoard } from "circuit-json"
 import type { Board } from "../../normal-components/Board"
 import type { EnclosureCutoutAperture } from "./EnclosureCutoutAperture"
+import { getComponentBody } from "./get-component-body"
 import { getNearestBoardWall } from "./get-nearest-board-wall"
 import type { BoardWall } from "./get-nearest-board-wall"
 import { getSolverWall } from "./get-solver-wall"
@@ -26,8 +27,8 @@ export interface GetFdmEnclosureSolverInputParams {
  * Minimal adapter for the staged solver API.
  *
  * This layer preserves Core's existing insertion-direction/nearest-edge
- * placement. Component bodies, offsets, explicit depth and the continuous
- * cutout aperture axis are added by the next stacked layers.
+ * placement. This layer adds component bodies, offsets and explicit depth;
+ * the continuous cutout aperture axis is added by the next stacked layer.
  */
 export const getFdmEnclosureSolverInput = (
   apertureComponent: EnclosureCutoutAperture,
@@ -72,22 +73,49 @@ export const getFdmEnclosureSolverInput = (
         y: point.y - pcbBoard.center.y,
       }
 
+  const boardSide: "top" | "bottom" =
+    pcbComponent.layer === "bottom" ? "bottom" : "top"
+  const cadComponent = (apertureComponent.root?.db.cad_component.getWhere({
+    pcb_component_id: pcbComponent.pcb_component_id,
+  }) ?? null) as CadComponent | null
+  const boardSurfaceZ =
+    (boardSide === "bottom" ? -1 : 1) *
+    ((pcbBoard.thickness ?? board.boardThickness) / 2)
+  const componentBody = getComponentBody({
+    owner,
+    pcbComponent,
+    cadComponent,
+    boardSurfaceZ,
+  })
+
   const commonInput = {
     face,
     center,
-    boardSide:
-      pcbComponent.layer === "bottom" ? ("bottom" as const) : ("top" as const),
+    boardSide,
     rotation: pcbComponent.rotation ?? undefined,
+    depth: aperture.depth,
+    componentBody,
+    widthDimensionOffset: aperture.widthDimensionOffset,
+    heightDimensionOffset: aperture.heightDimensionOffset,
     margin: aperture.margin,
   }
 
-  if (aperture.shape === "circle") {
-    return { ...commonInput, shape: "circle", radius: aperture.radius }
-  }
-  return {
-    ...commonInput,
-    shape: aperture.shape,
-    width: aperture.width,
-    height: aperture.height,
+  switch (aperture.shape) {
+    case "circle":
+      return { ...commonInput, shape: "circle", radius: aperture.radius }
+    case "pill":
+      return {
+        ...commonInput,
+        shape: "pill",
+        width: aperture.width,
+        height: aperture.height,
+      }
+    case "rect":
+      return {
+        ...commonInput,
+        shape: "rect",
+        width: aperture.width,
+        height: aperture.height,
+      }
   }
 }

--- a/tests/enclosure/enclosure-cutout-aperture-depth.test.tsx
+++ b/tests/enclosure/enclosure-cutout-aperture-depth.test.tsx
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test"
+import { enclosure } from "lib"
+import type { SolverStartedEvent } from "lib/events"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/**
+ * Core reports the part's physical facts as a normalized body envelope; the FDM
+ * solver owns what they mean for a cut. An authored `depth` stays
+ * explicit and suppresses the envelope entirely.
+ */
+const footprint = (
+  <footprint insertionDirection="from_bottom">
+    <smtpad portHints={["pin1"]} width="2mm" height="2mm" shape="rect" />
+  </footprint>
+)
+
+const renderWith = (
+  apertureProps: Record<string, unknown>,
+  cadSize?: unknown,
+) => {
+  const { circuit } = getTestFixture()
+  let event: SolverStartedEvent | undefined
+  circuit.on("solver:started", (e) => {
+    if (e.solverName === "CreateFdmEnclosureSolver") event = e
+  })
+  circuit.add(
+    <group>
+      <board name="B1" width="30mm" height="20mm" routingDisabled>
+        <connector
+          name="J1"
+          pcbX="0mm"
+          pcbY="9mm"
+          footprint={footprint}
+          cadModel={
+            cadSize
+              ? ({ objUrl: "https://example.com/x.obj", size: cadSize } as any)
+              : undefined
+          }
+        >
+          <enclosure.cutoutaperture
+            shape="rect"
+            width="6mm"
+            height="4mm"
+            {...apertureProps}
+          />
+        </connector>
+      </board>
+      <enclosure.fdm.box boardRef=".B1" />
+    </group>,
+  )
+  circuit.render()
+  return event!.solverParams.apertures[0]
+}
+
+test("the CAD body is reported in the part's own frame", () => {
+  // Footprint is a single 2mm pad; the declared body is 15mm deep.
+  const aperture = renderWith({}, { x: 6, y: 15, z: 8 })
+  expect(aperture.componentBody.size).toMatchObject({ x: 6, y: 15, z: 8 })
+  expect(aperture.depth).toBeUndefined()
+})
+
+test("the footprint is reported when a part declares no body size", () => {
+  const aperture = renderWith({})
+  expect(aperture.componentBody.size).toBeUndefined()
+  // The pcb_component extents still describe how far the part reaches.
+  expect(aperture.componentBody.footprint.width).toBeGreaterThan(0)
+  expect(aperture.componentBody.footprint.height).toBeGreaterThan(0)
+  expect(aperture.depth).toBeUndefined()
+})
+
+test("board rotation is reported so the solver can project the body", () => {
+  const aperture = renderWith({}, { x: 6, y: 15, z: 8 })
+  expect(aperture.componentBody.rotation).toBe(0)
+})
+
+test("an authored depth wins, but the body is still reported", () => {
+  const aperture = renderWith({ depth: "22mm" }, { x: 6, y: 15, z: 8 })
+  expect(aperture.depth).toBeCloseTo(22)
+
+  // The body used to be withheld here, on the grounds that an authored depth
+  // made it redundant. It is not: placement needs it too, because a side-face
+  // opening is centred on the part's reach above the board. The solver already
+  // prefers the authored depth, so reporting the body cannot override it.
+  expect(aperture.componentBody).toBeDefined()
+  expect(aperture.componentBody.size).toMatchObject({ x: 6, y: 15, z: 8 })
+})

--- a/tests/enclosure/enclosure-cutout-dimension-offsets.test.tsx
+++ b/tests/enclosure/enclosure-cutout-dimension-offsets.test.tsx
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test"
+import { enclosure } from "lib"
+import type { SolverStartedEvent } from "lib/events"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const apertureWith = async (props: Record<string, unknown>) => {
+  const { circuit } = getTestFixture()
+  let event: SolverStartedEvent | undefined
+  circuit.on("solver:started", (e) => {
+    if (e.solverName === "CreateFdmEnclosureSolver") event = e
+  })
+
+  circuit.add(
+    <group>
+      <board name="B1" width="40mm" height="24mm" routingDisabled>
+        <chip
+          name="J1"
+          pcbX={0}
+          pcbY={11}
+          footprint={
+            <footprint insertionDirection={"from_top" as any}>
+              <smtpad
+                shape="rect"
+                portHints={["pin1"]}
+                pcbX={0}
+                pcbY={0}
+                width={2}
+                height={2}
+              />
+            </footprint>
+          }
+          cadModel={{
+            objUrl: "https://example.com/x.obj",
+            size: { x: 8, y: 4, z: 6 },
+            modelOriginPosition: { x: 0, y: 0, z: -3 },
+            modelBounds: {
+              min: { x: -4, y: -2, z: -3 },
+              max: { x: 4, y: 2, z: 3 },
+            },
+          }}
+        >
+          <enclosure.cutoutaperture
+            shape="rect"
+            width="6mm"
+            height="3mm"
+            {...props}
+          />
+        </chip>
+      </board>
+      <enclosure.fdm.box boardRef=".B1" />
+    </group>,
+  )
+  await circuit.renderUntilSettled()
+  return (event as any)?.solverParams.apertures[0]
+}
+
+// The model sits entirely above the board: bounds z span -3..3 with the origin
+// at -3, so it reaches 6mm up. A side-face opening therefore centres 3mm above
+// the mounting surface without anyone authoring a height.
+test("a side opening centres on the part's measured body", async () => {
+  const aperture = await apertureWith({})
+  expect(aperture.face).toBe("y_pos")
+  expect(aperture.componentBody.aboveBoardHeight).toBeCloseTo(6, 6)
+  expect(aperture.heightDimensionOffset).toBeUndefined()
+})
+
+test("the offsets are passed through, signed", async () => {
+  const up = await apertureWith({ heightDimensionOffset: "1.5mm" })
+  expect(up.heightDimensionOffset).toBeCloseTo(1.5, 6)
+
+  const down = await apertureWith({ heightDimensionOffset: "-1.5mm" })
+  expect(down.heightDimensionOffset).toBeCloseTo(-1.5, 6)
+
+  const across = await apertureWith({ widthDimensionOffset: "-2mm" })
+  expect(across.widthDimensionOffset).toBeCloseTo(-2, 6)
+})
+
+// Both are Distances, so unit suffixes are parsed before the solver sees them.
+test("offsets accept units", async () => {
+  const aperture = await apertureWith({ heightDimensionOffset: "0.25in" })
+  expect(aperture.heightDimensionOffset).toBeCloseTo(6.35, 3)
+})


### PR DESCRIPTION
## Summary

- report each cutout component's normalized CAD-model bounds to the staged enclosure solver
- fall back to the component footprint when no explicit CAD body dimensions are available
- pass signed aperture offsets and an explicitly authored aperture depth through unchanged
- preserve the current quantized wall selection; continuous component-relative aperture axes remain the final follow-up layer

## Layering

This follows the merged two-part CAD output in #3180. It is the component-body/offset/depth layer required before #3152 is reduced to its final component-relative aperture-axis diff.

## Testing

- `bun run format`
- `bunx tsc --noEmit`
- focused enclosure tests: 7 passed
- full Core PR check: 1,395 passed, 37 skipped; the only failure was the existing BQ25895 routing repro taking 5.60s against Bun's 5s default timeout
- focused rerun of that routing repro: passed in 4.87s
