### PR TITLE
update autorouter dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
-    "@tscircuit/capacity-autorouter": "^0.0.802",
+    "@tscircuit/capacity-autorouter": "^0.0.803",
     "@tscircuit/checks": "^0.0.160",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

- update `@tscircuit/capacity-autorouter` from `^0.0.802` to `^0.0.803`
- verify `@tscircuit/fanout-solver` is already on the latest published release (`0.0.23`)

## Impact

Core now resolves the latest published capacity autorouter while retaining the current latest fanout solver release.

## Validation

- `bunx tsc --noEmit`
- `bun run build`
- `bun test` (1,405 passed, 37 skipped, 0 failed)