### PR TITLE
test: reproduce missing top-level static route state

### DIFF
--- a/tests/repros/__snapshots__/repro-top-level-static-trace-not-preserved.snap.svg
+++ b/tests/repros/__snapshots__/repro-top-level-static-trace-not-preserved.snap.svg
@@ -1,0 +1,52 @@
+<svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#fff"/><g><circle data-type="point" data-label="source_trace_fixed
+source_trace_fixed
+top" data-x="-4" data-y="0" cx="140" cy="300" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_fixed
+source_trace_fixed
+top" data-x="4" data-y="0" cx="660" cy="300" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_to_route
+source_trace_to_route
+top" data-x="0" data-y="-4" cx="400" cy="560" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_to_route
+source_trace_to_route
+top" data-x="0" data-y="4" cx="400" cy="40" r="3" fill="hsl(170, 100%, 50%)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '800');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '600');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":65,"c":0,"e":400,"b":0,"d":-65,"f":300};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repros/repro-top-level-static-trace-not-preserved.test.ts
+++ b/tests/repros/repro-top-level-static-trace-not-preserved.test.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "bun:test"
+import { convertSrjToGraphicsObject } from "@tscircuit/capacity-autorouter"
+import type { AnyCircuitElement } from "circuit-json"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+import "tests/fixtures/get-test-fixture"
+
+test("repro: top-level static PCB traces are missing from autorouter input", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      center: { x: 0, y: 0 },
+      width: 12,
+      height: 12,
+      num_layers: 2,
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "source_port_fixed_left",
+      name: "FIXED_LEFT",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "source_port_fixed_right",
+      name: "FIXED_RIGHT",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "source_port_route_bottom",
+      name: "ROUTE_BOTTOM",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "source_port_route_top",
+      name: "ROUTE_TOP",
+    } as any,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_fixed_left",
+      source_port_id: "source_port_fixed_left",
+      x: -4,
+      y: 0,
+      layers: ["top"],
+    } as any,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_fixed_right",
+      source_port_id: "source_port_fixed_right",
+      x: 4,
+      y: 0,
+      layers: ["top"],
+    } as any,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_route_bottom",
+      source_port_id: "source_port_route_bottom",
+      x: 0,
+      y: -4,
+      layers: ["top"],
+    } as any,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_route_top",
+      source_port_id: "source_port_route_top",
+      x: 0,
+      y: 4,
+      layers: ["top"],
+    } as any,
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_fixed",
+      connected_source_port_ids: [
+        "source_port_fixed_left",
+        "source_port_fixed_right",
+      ],
+      connected_source_net_ids: [],
+    } as any,
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_to_route",
+      connected_source_port_ids: [
+        "source_port_route_bottom",
+        "source_port_route_top",
+      ],
+      connected_source_net_ids: [],
+    } as any,
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "pcb_trace_fixed",
+      source_trace_id: "source_trace_fixed",
+      route: [
+        {
+          route_type: "wire",
+          x: -4,
+          y: 0,
+          width: 0.3,
+          layer: "top",
+          start_pcb_port_id: "pcb_port_fixed_left",
+        },
+        {
+          route_type: "wire",
+          x: 4,
+          y: 0,
+          width: 0.3,
+          layer: "top",
+          end_pcb_port_id: "pcb_port_fixed_right",
+        },
+      ],
+    } as any,
+  ]
+
+  const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({ circuitJson })
+
+  expect(simpleRouteJson.connections).toHaveLength(2)
+  expect(simpleRouteJson.traces).toBeUndefined()
+
+  const svg = getSvgFromGraphicsObject(
+    convertSrjToGraphicsObject(simpleRouteJson as any),
+    {
+      backgroundColor: "#fff",
+      hideInlineLabels: false,
+      svgHeight: 600,
+      svgWidth: 800,
+    },
+  )
+  expect(svg).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary

Adds a passing visual reproduction for a remaining static-route omission in `getSimpleRouteJsonFromCircuitJson`.

Current `main` already preserves board-owned manual copper (including `pcbPath`/`pcbStraightLine`) through #3146. However, valid prebuilt/root-level Circuit JSON can contain an existing `pcb_trace` without a `subcircuit_id`. That copper is currently omitted from SRJ `traces`, while its already-routed `source_trace` remains in SRJ `connections`. The autorouter therefore cannot treat it as preserved routing geometry.

The snapshot intentionally captures the broken state: four endpoints are visible, but the existing horizontal copper is absent.

## Reproduction

- one top-level source trace already has a horizontal PCB route
- one vertical source trace remains to be routed
- expected broken state on current `main`: 2 connections, 0 preserved traces

## Validation

- `bun test tests/repros/repro-top-level-static-trace-not-preserved.test.ts --update-snapshots`
- `bunx biome check tests/repros/repro-top-level-static-trace-not-preserved.test.ts`
- `bunx tsc --noEmit`
- `git diff --check`
- visually inspected generated SVG snapshot