### PR TITLE
fix: preserve top-level static route state

### DIFF
--- a/lib/utils/autorouting/getPreservedRoutedSubcircuitTraces.ts
+++ b/lib/utils/autorouting/getPreservedRoutedSubcircuitTraces.ts
@@ -70,8 +70,8 @@ const getSimpleRouteForPreservedTrace = (
 
 /**
  * Converts PCB traces that already exist when autorouting starts into SRJ
- * `traces`. This includes manual copper rendered in an earlier render phase
- * and routed child-subcircuit copper.
+ * `traces`. This includes prebuilt root-level routes, manual copper rendered
+ * in an earlier render phase, and routed child-subcircuit copper.
  *
  * `connectsTo` is physical routing state, not electrical-net metadata. It must
  * contain only the PCB points joined by this exact copper trace so the parent
@@ -81,14 +81,20 @@ const getSimpleRouteForPreservedTrace = (
 export const getPreservedRoutedSubcircuitTraces = ({
   scopedDb,
   relevantSubcircuitIds,
+  ignoreExistingTopLevelPcbRouteState,
 }: {
   scopedDb: CircuitJsonUtilObjects
   relevantSubcircuitIds: Set<string> | null
+  ignoreExistingTopLevelPcbRouteState: boolean
 }): SimplifiedPcbTrace[] =>
   scopedDb.pcb_trace
     .list()
     .filter((trace) => {
-      if (!trace.subcircuit_id) return false
+      if (!trace.subcircuit_id) {
+        return (
+          relevantSubcircuitIds === null && !ignoreExistingTopLevelPcbRouteState
+        )
+      }
       return (
         relevantSubcircuitIds === null ||
         relevantSubcircuitIds.has(trace.subcircuit_id)

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -206,9 +206,10 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   //
   // Keep connectivity metadata on preserved traces so parent routes can
   // legally touch child fanout copper that belongs to the same connected net.
-  const preservedRoutedSubcircuitTraces = getPreservedRoutedSubcircuitTraces({
+  const preservedRoutedTraces = getPreservedRoutedSubcircuitTraces({
     scopedDb: db,
     relevantSubcircuitIds,
+    ignoreExistingTopLevelPcbRouteState,
   })
 
   // Add every equivalent ID from the shared connectivity map to each obstacle.
@@ -335,26 +336,14 @@ export const getSimpleRouteJsonFromCircuitJson = ({
       maxY: Math.max(bounds.maxY, groupBounds.maxY),
     }
   }
+  const preservedPcbTraceIds = new Set(
+    preservedRoutedTraces.map((trace) => trace.pcb_trace_id),
+  )
   const sourceTraceIdsAlreadyPreservedAsSrjTraces = new Set(
     db.pcb_trace
       .list()
-      .filter((t) => {
-        if (!t.source_trace_id) return false
-
-        // While routing one subcircuit, skip source_traces already routed in
-        // that same subcircuit. Descendant routed traces are still preserved as
-        // fixed SRJ traces above.
-        if (subcircuit_id) return t.subcircuit_id === subcircuit_id
-
-        // While routing the board, only skip a source_trace when the existing
-        // pcb_trace is the child subcircuit's own routed copy. Cross-boundary
-        // or board-owned source_traces must remain routable board connections.
-        if (!t.subcircuit_id) return false
-
-        const sourceTrace = db.source_trace.get(t.source_trace_id)
-        return sourceTrace?.subcircuit_id === t.subcircuit_id
-      })
-      .map((t) => t.source_trace_id)
+      .filter((trace) => preservedPcbTraceIds.has(trace.pcb_trace_id))
+      .map((trace) => trace.source_trace_id)
       .filter((id): id is string => Boolean(id)),
   )
   // Build a map of source_port_id → breakout point for adding breakout
@@ -403,7 +392,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   }
 
   // Create connections from source traces in this routing scope. Any
-  // source_trace represented by `preservedRoutedSubcircuitTraces` is excluded
+  // source_trace represented by `preservedRoutedTraces` is excluded
   // here so it is preserved as fixed copper instead of re-routed.
   // For cross-boundary traces, add breakout points as additional
   // waypoints so the autorouter routes through the boundary.
@@ -822,9 +811,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
       differentialPairs: srjDifferentialPairs,
       ...(srjBuses ? { buses: srjBuses } : {}),
       traces:
-        preservedRoutedSubcircuitTraces.length > 0
-          ? preservedRoutedSubcircuitTraces
-          : undefined,
+        preservedRoutedTraces.length > 0 ? preservedRoutedTraces : undefined,
       layerCount: board?.num_layers ?? 2,
       minTraceWidth: Math.min(
         defaultTraceWidth,

--- a/tests/repros/__snapshots__/repro-top-level-static-trace-not-preserved.snap.svg
+++ b/tests/repros/__snapshots__/repro-top-level-static-trace-not-preserved.snap.svg
@@ -1,12 +1,8 @@
-<svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#fff"/><g><circle data-type="point" data-label="source_trace_fixed
-source_trace_fixed
-top" data-x="-4" data-y="0" cx="140" cy="300" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_fixed
-source_trace_fixed
-top" data-x="4" data-y="0" cx="660" cy="300" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_to_route
+<svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#fff"/><g><polyline data-points="-4,0 4,0" data-type="line" data-label="" points="140,300 660,300" fill="none" stroke="red" stroke-width="19.5"/></g><g><circle data-type="point" data-label="source_trace_to_route
 source_trace_to_route
-top" data-x="0" data-y="-4" cx="400" cy="560" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_to_route
+top" data-x="0" data-y="-4" cx="400" cy="560" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_to_route
 source_trace_to_route
-top" data-x="0" data-y="4" cx="400" cy="40" r="3" fill="hsl(170, 100%, 50%)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+top" data-x="0" data-y="4" cx="400" cy="40" r="3" fill="hsl(0, 100%, 50%)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
               document.currentScript.parentElement.addEventListener('mousemove', (e) => {
                 const svg = e.currentTarget;
                 const rect = svg.getBoundingClientRect();

--- a/tests/repros/repro-top-level-static-trace-not-preserved.test.ts
+++ b/tests/repros/repro-top-level-static-trace-not-preserved.test.ts
@@ -5,7 +5,7 @@ import { getSvgFromGraphicsObject } from "graphics-debug"
 import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
 import "tests/fixtures/get-test-fixture"
 
-test("repro: top-level static PCB traces are missing from autorouter input", () => {
+test("top-level static PCB traces are preserved in autorouter input", () => {
   const circuitJson: AnyCircuitElement[] = [
     {
       type: "pcb_board",
@@ -112,8 +112,16 @@ test("repro: top-level static PCB traces are missing from autorouter input", () 
 
   const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({ circuitJson })
 
-  expect(simpleRouteJson.connections).toHaveLength(2)
-  expect(simpleRouteJson.traces).toBeUndefined()
+  expect(simpleRouteJson.connections).toHaveLength(1)
+  expect(simpleRouteJson.traces).toHaveLength(1)
+
+  const { simpleRouteJson: freshRoutingInput } =
+    getSimpleRouteJsonFromCircuitJson({
+      circuitJson,
+      ignoreExistingTopLevelPcbRouteState: true,
+    })
+  expect(freshRoutingInput.connections).toHaveLength(2)
+  expect(freshRoutingInput.traces).toBeUndefined()
 
   const svg = getSvgFromGraphicsObject(
     convertSrjToGraphicsObject(simpleRouteJson as any),

--- a/tests/utils/autorouting/simple-route-json-ignores-existing-top-level-pcb-traces.test.ts
+++ b/tests/utils/autorouting/simple-route-json-ignores-existing-top-level-pcb-traces.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import type { AnyCircuitElement } from "circuit-json"
 import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
 
-test("simple route json ignores existing top-level pcb traces as routing state", () => {
+test("simple route json preserves existing top-level pcb traces as routing state", () => {
   const circuitJson: AnyCircuitElement[] = [
     {
       type: "pcb_board",
@@ -103,12 +103,15 @@ test("simple route json ignores existing top-level pcb traces as routing state",
 
   expect(netConnection).toBeDefined()
   expect(netConnection!.pointsToConnect.map((p) => p.pointId)).toEqual([
-    "pcb_port_a",
     "pcb_port_b",
     "pcb_port_c",
   ])
   expect(netConnection!.externallyConnectedPointIds).toBeUndefined()
-  expect(simpleRouteJson.traces).toBeUndefined()
+  expect(simpleRouteJson.traces).toHaveLength(1)
+  expect(simpleRouteJson.traces?.[0].connectsTo).toEqual([
+    "pcb_port_a",
+    "pcb_port_b",
+  ])
 })
 
 test("simple route json keeps existing pcb traces as routing state inside subcircuits", () => {


### PR DESCRIPTION
## Summary

Preserves existing root-level `pcb_trace` elements as Simple Route JSON `traces` when converting prebuilt/imported Circuit JSON. The already-routed source trace is removed from pending `connections`, so subsequent routing receives the static copper as preloaded geometry and routes around it.

The existing `ignoreExistingTopLevelPcbRouteState` option remains the explicit fresh-reroute escape hatch: when enabled, top-level traces are omitted and their connections remain routable. Scoped board/subcircuit behavior is unchanged.

Current `main` already handles board-owned `pcbPath`/`pcbStraightLine` copper through #3146; this PR closes the remaining root/prebuilt route-state gap demonstrated by the base PR.

## Visual change

The reproduction snapshot changes from four disconnected endpoints with no copper to one horizontal preloaded trace plus the two endpoints of the remaining vertical connection.

## Validation

- 37 autorouting and focused regression tests pass
- native `pcbStraightLine` preservation regression passes
- phased autorouting regression passes
- `bunx tsc --noEmit`
- `bun run build`
- Biome check on all changed TypeScript files
- `git diff --check`
- visually inspected updated SVG snapshot

Stacked on #3229.