### PR TITLE
fix: make autorouter progress and stop cooperative

### DIFF
--- a/lib/utils/autorouting/CapacityMeshAutorouter.ts
+++ b/lib/utils/autorouting/CapacityMeshAutorouter.ts
@@ -1,8 +1,8 @@
 import {
-  AutoroutingPipelineSolver,
   AssignableAutoroutingPipeline2,
   AssignableAutoroutingPipeline3,
   AutoroutingPipeline1_OriginalUnravel,
+  AutoroutingPipelineSolver,
   AutoroutingPipelineSolver3_HgPortPointPathing,
   AutoroutingPipelineSolver4,
   AutoroutingPipelineSolver5,
@@ -13,16 +13,16 @@ import {
 } from "@tscircuit/capacity-autorouter"
 import type { PlatformConfig } from "@tscircuit/props"
 import { AutorouterError } from "lib/errors/AutorouterError"
-import type { SimpleRouteJson, SimplifiedPcbTrace } from "./SimpleRouteJson"
+import { SOLVERS, type SolverName } from "lib/solvers"
 import type {
   AutorouterCompleteEvent,
   AutorouterErrorEvent,
-  AutorouterProgressEvent,
   AutorouterEvent,
+  AutorouterProgressEvent,
   GenericLocalAutorouter,
 } from "./GenericLocalAutorouter"
-import { SOLVERS, type SolverName } from "lib/solvers"
 import { getCacheProviderForLocalCacheEngine } from "./LocalCacheEngineCacheProvider"
+import type { SimpleRouteJson, SimplifiedPcbTrace } from "./SimpleRouteJson"
 import type { AutorouterVersion } from "./autorouter-version"
 
 export interface SolverStartedDetails {
@@ -210,12 +210,15 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
       const startTime = Date.now()
       const startIterations = this.solver.iterations
       while (
+        this.isRouting &&
         Date.now() - startTime < 250 &&
         !this.solver.failed &&
         !this.solver.solved
       ) {
         await this.stepSolver()
       }
+      if (!this.isRouting) return
+
       const iterationsPerSecond =
         ((this.solver.iterations - startIterations) /
           (Date.now() - startTime)) *
@@ -226,7 +229,12 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
       const debugGraphics = this.solver?.preview() || undefined
 
       // Report progress
-      const progress = this.solver.progress
+      const solverProgress = this.solver.progress
+      const progress = this.solver.solved
+        ? 1
+        : Number.isFinite(solverProgress) && solverProgress > 0
+          ? Math.min(1, solverProgress)
+          : undefined
 
       this.emitEvent({
         type: "progress",
@@ -251,6 +259,8 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
         ) as unknown as number
       }
     } catch (error) {
+      if (!this.isRouting) return
+
       // Handle any errors during the step
       this.emitEvent({
         type: "error",

--- a/lib/utils/autorouting/GenericLocalAutorouter.ts
+++ b/lib/utils/autorouting/GenericLocalAutorouter.ts
@@ -14,7 +14,8 @@ export type AutorouterErrorEvent = {
 export type AutorouterProgressEvent = {
   type: "progress"
   steps: number
-  progress: number
+  /** Omitted when the active solver cannot provide a meaningful estimate. */
+  progress?: number
   phase?: string
   iterationsPerSecond?: number
   debugGraphics?: GraphicsObject

--- a/tests/repros/__snapshots__/repro-autorouter-progress-cancellation.snap.svg
+++ b/tests/repros/__snapshots__/repro-autorouter-progress-cancellation.snap.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="260" viewBox="0 0 800 260">
     <rect width="800" height="260" fill="#111827" />
-    <text x="400" y="42" text-anchor="middle" fill="#f9fafb" font-family="Arial" font-size="24" font-weight="700">Autorouter status reproduction</text>
-    <rect x="40" y="75" width="720" height="64" rx="8" fill="#450a0a" stroke="#ef4444" stroke-width="2" />
-    <text x="65" y="103" fill="#fecaca" font-family="Arial" font-size="18">exact_geometry_improvement reported progress: 0%</text>
-    <text x="65" y="127" fill="#fecaca" font-family="Arial" font-size="18">No phase estimate exists, but the API reports a definite zero.</text>
-    <rect x="40" y="158" width="720" height="64" rx="8" fill="#450a0a" stroke="#ef4444" stroke-width="2" />
-    <text x="65" y="186" fill="#fecaca" font-family="Arial" font-size="18">Progress events emitted after stop(): 1</text>
-    <text x="65" y="210" fill="#fecaca" font-family="Arial" font-size="18">The in-flight cycle continues after cancellation.</text>
+    <text x="400" y="42" text-anchor="middle" fill="#f9fafb" font-family="Arial" font-size="24" font-weight="700">Autorouter status behavior</text>
+    <rect x="40" y="75" width="720" height="64" rx="8" fill="#052e16" stroke="#22c55e" stroke-width="2" />
+    <text x="65" y="103" fill="#bbf7d0" font-family="Arial" font-size="18">exact_geometry_improvement reported progress: indeterminate</text>
+    <text x="65" y="127" fill="#bbf7d0" font-family="Arial" font-size="18">Unknown estimates are explicit instead of a misleading hard zero.</text>
+    <rect x="40" y="158" width="720" height="64" rx="8" fill="#052e16" stroke="#22c55e" stroke-width="2" />
+    <text x="65" y="186" fill="#bbf7d0" font-family="Arial" font-size="18">Progress events emitted after stop(): 0</text>
+    <text x="65" y="210" fill="#bbf7d0" font-family="Arial" font-size="18">The in-flight async step exits at its cooperative boundary.</text>
   </svg>

--- a/tests/repros/repro-autorouter-progress-cancellation.test.ts
+++ b/tests/repros/repro-autorouter-progress-cancellation.test.ts
@@ -45,14 +45,14 @@ const createFakeSolver = ({
   },
 })
 
-test("repro: unknown progress is reported as 0% and stop leaks progress", async () => {
+test("unknown progress is indeterminate and stop prevents event leaks", async () => {
   const progressAutorouter = new TscircuitAutorouter(
     createTestSimpleRouteJson(),
   )
   const progressSolver = createFakeSolver({
     stepAsync: async () => {
       progressSolver.iterations++
-      progressSolver.solved = true
+      await new Promise((resolve) => setTimeout(resolve, 260))
     },
   })
   ;(progressAutorouter as any).solver = progressSolver
@@ -61,11 +61,11 @@ test("repro: unknown progress is reported as 0% and stop leaks progress", async 
   progressAutorouter.on("progress", (event) => {
     reportedProgressEvent = event
   })
-  await new Promise<void>((resolve, reject) => {
-    progressAutorouter.on("complete", () => resolve())
-    progressAutorouter.on("error", (event) => reject(event.error))
+  await new Promise<void>((resolve) => {
+    progressAutorouter.on("progress", () => resolve())
     progressAutorouter.start()
   })
+  progressAutorouter.stop()
 
   let releaseStep: (() => void) | undefined
   let markStepStarted: (() => void) | undefined
@@ -99,21 +99,22 @@ test("repro: unknown progress is reported as 0% and stop leaks progress", async 
   await new Promise((resolve) => setTimeout(resolve, 20))
 
   expect(reportedProgressEvent?.phase).toBe("exact_geometry_improvement")
-  expect(reportedProgressEvent?.progress).toBe(0)
-  expect(progressEventsAfterStop).toHaveLength(1)
+  expect(reportedProgressEvent?.progress).toBeUndefined()
+  expect(progressEventsAfterStop).toHaveLength(0)
 
-  const reportedProgress = `${Math.round(
-    (reportedProgressEvent?.progress ?? 0) * 100,
-  )}%`
+  const reportedProgress =
+    reportedProgressEvent?.progress === undefined
+      ? "indeterminate"
+      : `${Math.round(reportedProgressEvent.progress * 100)}%`
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="800" height="260" viewBox="0 0 800 260">
     <rect width="800" height="260" fill="#111827" />
-    <text x="400" y="42" text-anchor="middle" fill="#f9fafb" font-family="Arial" font-size="24" font-weight="700">Autorouter status reproduction</text>
-    <rect x="40" y="75" width="720" height="64" rx="8" fill="#450a0a" stroke="#ef4444" stroke-width="2" />
-    <text x="65" y="103" fill="#fecaca" font-family="Arial" font-size="18">exact_geometry_improvement reported progress: ${reportedProgress}</text>
-    <text x="65" y="127" fill="#fecaca" font-family="Arial" font-size="18">No phase estimate exists, but the API reports a definite zero.</text>
-    <rect x="40" y="158" width="720" height="64" rx="8" fill="#450a0a" stroke="#ef4444" stroke-width="2" />
-    <text x="65" y="186" fill="#fecaca" font-family="Arial" font-size="18">Progress events emitted after stop(): ${progressEventsAfterStop.length}</text>
-    <text x="65" y="210" fill="#fecaca" font-family="Arial" font-size="18">The in-flight cycle continues after cancellation.</text>
+    <text x="400" y="42" text-anchor="middle" fill="#f9fafb" font-family="Arial" font-size="24" font-weight="700">Autorouter status behavior</text>
+    <rect x="40" y="75" width="720" height="64" rx="8" fill="#052e16" stroke="#22c55e" stroke-width="2" />
+    <text x="65" y="103" fill="#bbf7d0" font-family="Arial" font-size="18">exact_geometry_improvement reported progress: ${reportedProgress}</text>
+    <text x="65" y="127" fill="#bbf7d0" font-family="Arial" font-size="18">Unknown estimates are explicit instead of a misleading hard zero.</text>
+    <rect x="40" y="158" width="720" height="64" rx="8" fill="#052e16" stroke="#22c55e" stroke-width="2" />
+    <text x="65" y="186" fill="#bbf7d0" font-family="Arial" font-size="18">Progress events emitted after stop(): ${progressEventsAfterStop.length}</text>
+    <text x="65" y="210" fill="#bbf7d0" font-family="Arial" font-size="18">The in-flight async step exits at its cooperative boundary.</text>
   </svg>`
   expect(svg).toMatchSvgSnapshot(import.meta.path)
 })


### PR DESCRIPTION
## Summary

Improves progress and cancellation behavior at the local autorouter wrapper boundary.

- `progress` is now optional in `AutorouterProgressEvent`
- unavailable/non-positive solver estimates are emitted as indeterminate instead of a misleading hard `0%`
- solved cycles report `1`
- an in-flight `stepAsync()` checks `isRouting` at its cooperative boundary
- stopped cycles do not emit progress, emit errors, or schedule another cycle

This does not claim to preempt a currently executing synchronous JavaScript instruction. It fixes the boundary core controls: async/cooperative solvers stop as soon as their current awaited step returns, and consumers receive truthful progress semantics.

## Visual change

The snapshot changes from two red failure panels (`0%`, one post-stop event) to green status panels (`indeterminate`, zero post-stop events).

## Validation

- 35 autorouting regression tests pass
- `bunx tsc --noEmit`
- `bun run build`
- Biome formatting passes on changed TypeScript files
- import ordering normalized in the touched legacy wrapper file
- `git diff --check`
- visually inspected updated SVG snapshot

Note: a full Biome `check` on `CapacityMeshAutorouter.ts` still reports the repository's pre-existing legacy filename rule; this PR does not rename that public module.

Stacked on #3233.