### PR TITLE
Avoid reading React reserved key in component schemas

### DIFF
--- a/lib/fiber/create-instance-from-react-element.ts
+++ b/lib/fiber/create-instance-from-react-element.ts
@@ -73,7 +73,11 @@ const hostConfig: HostConfig<
     }
 
     try {
-      const instance = prepare(new target(props) as any, {})
+      // React reserves `key` for reconciliation and installs a warning getter
+      // on the host props object. Component schemas must receive ordinary
+      // enumerable props rather than probing React's reserved metadata.
+      const intrinsicProps = { ...props }
+      const instance = prepare(new target(intrinsicProps) as any, {})
       return instance
     } catch (error: any) {
       return createErrorPlaceholderComponent(

--- a/tests/repros/__snapshots__/repro-react-key-schema-mismatch.snap.svg
+++ b/tests/repros/__snapshots__/repro-react-key-schema-mismatch.snap.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="230" viewBox="0 0 820 230">
     <rect width="820" height="230" fill="#111827" />
     <text x="410" y="42" text-anchor="middle" fill="#f9fafb" font-family="Arial" font-size="24" font-weight="700">React key/schema reproduction</text>
-    <rect x="40" y="72" width="740" height="116" rx="10" fill="#450a0a" stroke="#ef4444" stroke-width="2" />
-    <text x="68" y="108" fill="#fecaca" font-family="Arial" font-size="18">Reserved key warnings: 1</text>
-    <text x="68" y="139" fill="#fecaca" font-family="Arial" font-size="18">Zod asks React props for key even though React never exposes it.</text>
-    <text x="68" y="168" fill="#fecaca" font-family="Arial" font-size="18">Mapped autoroutingphase elements therefore emit a runtime warning.</text>
+    <rect x="40" y="72" width="740" height="116" rx="10" fill="#052e16" stroke="#22c55e" stroke-width="2" />
+    <text x="68" y="108" fill="#bbf7d0" font-family="Arial" font-size="18">Reserved key warnings: 0</text>
+    <text x="68" y="139" fill="#bbf7d0" font-family="Arial" font-size="18">Schemas receive a plain enumerable-props copy.</text>
+    <text x="68" y="168" fill="#bbf7d0" font-family="Arial" font-size="18">Both keyed autoroutingphase elements remain reconciled.</text>
   </svg>

--- a/tests/repros/repro-react-key-schema-mismatch.test.tsx
+++ b/tests/repros/repro-react-key-schema-mismatch.test.tsx
@@ -36,15 +36,16 @@ test("repro: parsing keyed intrinsic elements reads React's reserved key prop", 
         argument.includes("`key` is not a prop"),
     ),
   )
-  expect(keyWarnings.length).toBeGreaterThan(0)
+  expect(keyWarnings).toHaveLength(0)
+  expect(circuit.selectAll("autoroutingphase")).toHaveLength(2)
 
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="820" height="230" viewBox="0 0 820 230">
     <rect width="820" height="230" fill="#111827" />
     <text x="410" y="42" text-anchor="middle" fill="#f9fafb" font-family="Arial" font-size="24" font-weight="700">React key/schema reproduction</text>
-    <rect x="40" y="72" width="740" height="116" rx="10" fill="#450a0a" stroke="#ef4444" stroke-width="2" />
-    <text x="68" y="108" fill="#fecaca" font-family="Arial" font-size="18">Reserved key warnings: ${keyWarnings.length}</text>
-    <text x="68" y="139" fill="#fecaca" font-family="Arial" font-size="18">Zod asks React props for key even though React never exposes it.</text>
-    <text x="68" y="168" fill="#fecaca" font-family="Arial" font-size="18">Mapped autoroutingphase elements therefore emit a runtime warning.</text>
+    <rect x="40" y="72" width="740" height="116" rx="10" fill="#052e16" stroke="#22c55e" stroke-width="2" />
+    <text x="68" y="108" fill="#bbf7d0" font-family="Arial" font-size="18">Reserved key warnings: ${keyWarnings.length}</text>
+    <text x="68" y="139" fill="#bbf7d0" font-family="Arial" font-size="18">Schemas receive a plain enumerable-props copy.</text>
+    <text x="68" y="168" fill="#bbf7d0" font-family="Arial" font-size="18">Both keyed autoroutingphase elements remain reconciled.</text>
   </svg>`
   expect(svg).toMatchSvgSnapshot(import.meta.path)
 })


### PR DESCRIPTION
## Summary

- copy enumerable intrinsic props at the React host boundary before component construction
- prevent Zod schemas from probing React's reserved `key` warning getter
- retain normal reconciliation behavior; both keyed phases are still constructed
- update the visual status snapshot from one warning to zero

## Why the fix is in core

React owns `key`; it is not an application prop. Removing `key` from one component schema would leave the same runtime warning in every other schema that mentions it. Normalizing host props once in the reconciler fixes the ownership boundary without changing public component props or reconciliation keys.

## Validation

- reproduction and fiber tests passed
- `bunx tsc --noEmit`
- `bun run build`
- fixed SVG snapshot rendered and inspected

## Stack

- Base/repro: #3236
- This PR: fix
