### PR TITLE
Emit maximum via count for traces

### DIFF
--- a/lib/components/normal-components/Crystal.ts
+++ b/lib/components/normal-components/Crystal.ts
@@ -15,6 +15,7 @@ type SubcircuitConnectivityMapKey = NonNullable<
 >
 
 const DEFAULT_CRYSTAL_MAX_TRACE_LENGTH_MM = 10
+const DEFAULT_CRYSTAL_MAX_VIA_COUNT = 0
 
 export class Crystal extends NormalComponent<
   typeof crystalProps,
@@ -118,15 +119,20 @@ export class Crystal extends NormalComponent<
         )
 
       if (!isDirectlyConnectedToCrystal && !isOnCrystalNet) continue
-      if (
-        typeof sourceTrace.max_length === "number" &&
-        sourceTrace.max_length <= maximumTraceLength
-      ) {
-        continue
-      }
+
+      const needsMaximumTraceLength =
+        typeof sourceTrace.max_length !== "number" ||
+        sourceTrace.max_length > maximumTraceLength
+      const needsMaximumViaCount =
+        sourceTrace.max_via_count !== DEFAULT_CRYSTAL_MAX_VIA_COUNT
+
+      if (!needsMaximumTraceLength && !needsMaximumViaCount) continue
 
       db.source_trace.update(sourceTrace.source_trace_id, {
-        max_length: maximumTraceLength,
+        ...(needsMaximumTraceLength ? { max_length: maximumTraceLength } : {}),
+        ...(needsMaximumViaCount
+          ? { max_via_count: DEFAULT_CRYSTAL_MAX_VIA_COUNT }
+          : {}),
       })
     }
   }

--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -317,6 +317,7 @@ export class Trace
           ports.map((p) => p.port),
           { db },
         ),
+      max_via_count: props.maxViaCount,
       display_name: props.displayName ?? displayName,
       min_trace_thickness: this._getExplicitTraceThickness(),
     })

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "bun-match-svg": "0.0.12",
     "calculate-elbow": "^0.0.12",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.468",
+    "circuit-json": "^0.0.469",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-gltf": "^0.0.118",
     "circuit-json-to-connectivity-map": "^0.0.27",
@@ -131,6 +131,6 @@
   "overrides": {
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/props": "^0.0.621",
-    "circuit-json": "^0.0.468"
+    "circuit-json": "^0.0.469"
   }
 }

--- a/tests/components/normal-components/crystal-four-pin-trace-length.test.tsx
+++ b/tests/components/normal-components/crystal-four-pin-trace-length.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test("four-pin crystal maximum trace length only applies to signal pins", async () => {
+test("four-pin crystal routing constraints only apply to signal pins", async () => {
   const { circuit } = getTestFixture()
 
   circuit.add(
@@ -56,6 +56,20 @@ test("four-pin crystal maximum trace length only applies to signal pins", async 
   ).toEqual({
     ".Y1 > .X1 to .C_XIN > .pin1": 10,
     ".Y1 > .X2 to .C_XOUT > .pin1": 10,
+    ".Y1 > .pin2 to net.GND": undefined,
+    ".Y1 > .pin4 to net.GND": undefined,
+    ".R_GND > .pin1 to net.GND": undefined,
+  })
+
+  expect(
+    Object.fromEntries(
+      circuit.db.source_trace
+        .list()
+        .map((trace) => [trace.display_name, trace.max_via_count]),
+    ),
+  ).toEqual({
+    ".Y1 > .X1 to .C_XIN > .pin1": 0,
+    ".Y1 > .X2 to .C_XOUT > .pin1": 0,
     ".Y1 > .pin2 to net.GND": undefined,
     ".Y1 > .pin4 to net.GND": undefined,
     ".R_GND > .pin1 to net.GND": undefined,

--- a/tests/components/primitive-components/trace-max-via-count.test.tsx
+++ b/tests/components/primitive-components/trace-max-via-count.test.tsx
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("trace maxViaCount is emitted on the source trace", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board routingDisabled>
+      <resistor name="R1" resistance="1k" />
+      <resistor name="R2" resistance="1k" />
+      <trace from=".R1 > .pin1" to=".R2 > .pin1" maxViaCount={2} />
+    </board>,
+  )
+
+  circuit.render()
+
+  expect(circuit.db.source_trace.list()).toHaveLength(1)
+  expect(circuit.db.source_trace.list()[0].max_via_count).toBe(2)
+})


### PR DESCRIPTION
## What changed

- update `circuit-json` to 0.0.469
- serialize the existing trace `maxViaCount` prop as `source_trace.max_via_count`
- apply a default maximum of zero vias to every trace on a crystal's X1/X2 signal nets
- leave four-pin crystal ground connections unconstrained
- add focused coverage for generic trace serialization and crystal-net propagation

## Why

The trace prop schema already accepted `maxViaCount`, but core discarded it while constructing `source_trace`. That made the prop ineffective and left downstream checks without the constraint. Crystal traces also need a zero-via default across the complete signal net, including load-capacitor branches.

This builds on the merged `tscircuit/circuit-json#704` schema addition.

## Validation

- focused trace/crystal tests: 2 passed
- `bunx tsc --noEmit`
- `bun run build`
- full suite: 1,405 passed, 37 skipped; 4 unrelated existing 3D snapshot comparisons failed (`enclosure-fdm-box-usb-cutout`, `repro-imported-rotated-pill-pads-missing-3d`, `example38-cad-model-placement`, and `pcb-pack-cad-component-rotation`)
- `git diff --check`
