### PR TITLE
fix(inductor): parse unit strings to numeric henries in source_component

### DIFF
--- a/lib/components/normal-components/Inductor.ts
+++ b/lib/components/normal-components/Inductor.ts
@@ -44,7 +44,7 @@ export class Inductor extends NormalComponent<
     const source_component = db.source_component.insert({
       name: this.name,
       ftype: FTYPE.simple_inductor,
-      inductance: this.props.inductance,
+      inductance: props.inductance,
       max_current_rating:
         props.maxCurrentRating === undefined
           ? undefined

--- a/tests/components/normal-components/inductor.test.tsx
+++ b/tests/components/normal-components/inductor.test.tsx
@@ -1,30 +1,63 @@
 import { test, expect } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test("<inductor /> component", async () => {
-  const { circuit } = getTestFixture()
+test(
+  "<inductor /> component",
+  async () => {
+    const { circuit } = getTestFixture()
 
-  circuit.add(
-    <board width="12mm" height="10mm">
-      <inductor
-        name="U1"
-        inductance="10"
-        maxCurrentRating="2A"
-        footprint="axial_p0.3in"
-        pcbX={0}
-        pcbY={0}
-      />
-    </board>,
-  )
+    circuit.add(
+      <board width="12mm" height="10mm">
+        <inductor
+          name="U1"
+          inductance="10"
+          maxCurrentRating="2A"
+          footprint="axial_p0.3in"
+          pcbX={0}
+          pcbY={0}
+        />
+      </board>,
+    )
 
-  circuit.render()
+    circuit.render()
 
-  expect(circuit.db.source_component.getWhere({ name: "U1" })).toMatchObject({
-    ftype: "simple_inductor",
-    inductance: "10",
-    max_current_rating: 2,
-  })
+    expect(
+      circuit.db.source_component.getWhere({ name: "U1" }),
+    ).toMatchObject({
+      ftype: "simple_inductor",
+      inductance: 10,
+      max_current_rating: 2,
+    })
 
-  expect(circuit).toMatchPcbSnapshot(import.meta.path)
-  expect(circuit).toMatchSchematicSnapshot(import.meta.path)
-})
+    expect(circuit).toMatchPcbSnapshot(import.meta.path)
+    expect(circuit).toMatchSchematicSnapshot(import.meta.path)
+  },
+  { timeout: 30000 },
+)
+
+test(
+  "<inductor /> with unit string parses inductance to numeric henries (#3111)",
+  async () => {
+    const { circuit } = getTestFixture()
+
+    circuit.add(
+      <board width="12mm" height="10mm">
+        <inductor
+          name="L1"
+          inductance="10uH"
+          footprint="axial_p0.3in"
+          pcbX={0}
+          pcbY={0}
+        />
+      </board>,
+    )
+
+    circuit.render()
+
+    const sourceComp = circuit.db.source_component.getWhere({ name: "L1" })!
+    expect(sourceComp.ftype).toBe("simple_inductor")
+    expect(sourceComp.inductance).toBeCloseTo(10e-6, 8)
+    expect(sourceComp.display_inductance).toBe("10µH")
+  },
+  { timeout: 30000 },
+)

--- a/tests/components/normal-components/inductor.test.tsx
+++ b/tests/components/normal-components/inductor.test.tsx
@@ -56,8 +56,10 @@ test(
 
     const sourceComp = circuit.db.source_component.getWhere({ name: "L1" })!
     expect(sourceComp.ftype).toBe("simple_inductor")
-    expect(sourceComp.inductance).toBeCloseTo(10e-6, 8)
-    expect(sourceComp.display_inductance).toBe("10µH")
+    if (sourceComp.ftype === "simple_inductor") {
+      expect(sourceComp.inductance).toBeCloseTo(10e-6, 8)
+      expect(sourceComp.display_inductance).toBe("10µH")
+    }
   },
   { timeout: 30000 },
 )


### PR DESCRIPTION
## Summary

Fixes #3111.

Previously, \`Inductor.doInitialSourceRender\` directly passed \`this.props.inductance\` (the raw string or numeric prop) into \`db.source_component.insert\`. When a string with units was passed (such as \`inductance="10uH"\`), the raw string leaked into Circuit JSON rather than numeric henries (\`SourceSimpleInductor.inductance: number\`).

### Changes
1. **Numeric Inductance**: Updated \`Inductor.doInitialSourceRender\` to pass \`props.inductance\` (from \`this._parsedProps\`), guaranteeing numeric Henries are emitted in the source component.
2. **Unit Tests**: Added test case in \`tests/components/normal-components/inductor.test.tsx\` verifying that string unit inputs (e.g. \`"10uH"\`) correctly emit numeric henries (\`0.00001\`) and display string (\`"10µH"\`).

### Verification
- \`bun test tests/components/normal-components/inductor.test.tsx\` (2/2 passing).
