### PR TITLE
fix(capacitor): validate capacitance strings and throw on invalid input

### DIFF
--- a/lib/components/normal-components/Capacitor.ts
+++ b/lib/components/normal-components/Capacitor.ts
@@ -55,19 +55,21 @@ export class Capacitor extends NormalComponent<
 
   _getSchematicSymbolDisplayValue(): string | undefined {
     const inputCapacitance = this.props.capacitance
-    let capacitanceDisplay: string | undefined
+    const capValue = this._parsedProps.capacitance
 
     if (
-      this._parsedProps.capacitance !== undefined &&
-      !isNaN(this._parsedProps.capacitance)
+      capValue === undefined ||
+      capValue === null ||
+      typeof capValue !== "number" ||
+      Number.isNaN(capValue)
     ) {
-      capacitanceDisplay =
-        typeof inputCapacitance === "string"
-          ? inputCapacitance
-          : `${formatSiUnit(this._parsedProps.capacitance)}F`
-    } else {
-      capacitanceDisplay = `${formatSiUnit(this._parsedProps.capacitance)}F`
+      return undefined
     }
+
+    let capacitanceDisplay: string =
+      typeof inputCapacitance === "string"
+        ? inputCapacitance
+        : `${formatSiUnit(capValue)}F`
 
     if (
       this._parsedProps.schShowRatings &&
@@ -115,6 +117,18 @@ export class Capacitor extends NormalComponent<
   doInitialSourceRender() {
     const { db } = this.root!
     const { _parsedProps: props } = this
+
+    if (
+      props.capacitance === undefined ||
+      props.capacitance === null ||
+      typeof props.capacitance !== "number" ||
+      Number.isNaN(props.capacitance)
+    ) {
+      throw new Error(
+        `Invalid capacitance for capacitor "${this.name}": "${this.props.capacitance}". Expected a valid numeric capacitance or SI unit string (e.g. "10uF", "100nF").`,
+      )
+    }
+
     const source_component = db.source_component.insert({
       ftype: "simple_capacitor",
       name: this.name,

--- a/tests/components/normal-components/capacitor-display-value.test.tsx
+++ b/tests/components/normal-components/capacitor-display-value.test.tsx
@@ -173,7 +173,7 @@ test("capacitor with numeric values handles display correctly", () => {
   )
 })
 
-test("capacitor with invalid capacitance string outputs NaNpF display_capacitance", () => {
+test("capacitor with invalid capacitance string throws validation error (#3110)", () => {
   const { project } = getTestFixture()
 
   project.add(
@@ -188,15 +188,7 @@ test("capacitor with invalid capacitance string outputs NaNpF display_capacitanc
     </board>,
   )
 
-  project.render()
-
-  const capacitors = project.db.source_component.list({
-    ftype: "simple_capacitor",
-  }) as Array<{
-    ftype: "simple_capacitor"
-    display_capacitance?: string
-  }>
-
-  expect(capacitors).toHaveLength(1)
-  expect(capacitors[0].display_capacitance).toBe("NaNpF")
+  expect(() => project.render()).toThrow(
+    /Invalid capacitance for capacitor "C1": "lijF"/,
+  )
 })

--- a/tests/components/normal-components/capacitor-invalid-capacitance.test.tsx
+++ b/tests/components/normal-components/capacitor-invalid-capacitance.test.tsx
@@ -1,0 +1,52 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test(
+  "capacitor throws validation error on invalid capacitance string (#3110)",
+  async () => {
+    const { circuit } = getTestFixture()
+
+    circuit.add(
+      <board width="10mm" height="10mm">
+        <capacitor
+          name="C1"
+          capacitance="invalid"
+          footprint="0402"
+          pcbX={0}
+          pcbY={0}
+        />
+      </board>,
+    )
+
+    expect(() => circuit.render()).toThrow(
+      /Invalid capacitance for capacitor "C1": "invalid"/,
+    )
+  },
+  { timeout: 30000 },
+)
+
+test(
+  "capacitor renders valid capacitance without error",
+  async () => {
+    const { circuit } = getTestFixture()
+
+    circuit.add(
+      <board width="10mm" height="10mm">
+        <capacitor
+          name="C1"
+          capacitance="10uF"
+          footprint="0402"
+          pcbX={0}
+          pcbY={0}
+        />
+      </board>,
+    )
+
+    circuit.render()
+
+    const sourceComp = circuit.db.source_component.getWhere({ name: "C1" })!
+    expect(sourceComp.ftype).toBe("simple_capacitor")
+    expect(sourceComp.capacitance).toBeCloseTo(10e-6, 8)
+  },
+  { timeout: 30000 },
+)


### PR DESCRIPTION
## Summary

Fixes #3110.

Previously, invalid capacitance strings (e.g. \`capacitance="invalid"\` or \`"lijF"\`) passed through unvalidated, causing builds to succeed while emitting \`capacitance: null\` and \`display_capacitance: "NaNpF"\` into Circuit JSON.

### Changes
1. **Validation on Source Render**: Added explicit validation in \`Capacitor.doInitialSourceRender\` to verify that \`props.capacitance\` is a valid finite number, throwing a descriptive \`Error\` on invalid inputs.
2. **Display Value Safeguard**: Returned \`undefined\` in \`_getSchematicSymbolDisplayValue\` when capacitance cannot be parsed, preventing \`NaN\`-prefixed display strings.
3. **Unit Tests**: Added \`tests/components/normal-components/capacitor-invalid-capacitance.test.tsx\` and updated \`tests/components/normal-components/capacitor-display-value.test.tsx\` to assert that invalid capacitance strings throw validation errors rather than producing invalid Circuit JSON.

### Verification
- \`bun test tests/components/normal-components/capacitor-invalid-capacitance.test.tsx\` (2/2 passing).
- \`bun test tests/components/normal-components/capacitor-display-value.test.tsx\` (6/6 passing).
