### PR TITLE
fix(capacitor): connect nets and traces when bypassFor and bypassTo are provided

### DIFF
--- a/lib/components/normal-components/Capacitor.ts
+++ b/lib/components/normal-components/Capacitor.ts
@@ -90,22 +90,27 @@ export class Capacitor extends NormalComponent<
     this._createNetsFromProps([
       this.props.decouplingFor,
       this.props.decouplingTo,
+      this.props.bypassFor,
+      this.props.bypassTo,
       ...this._getNetsFromConnectionsProp(),
     ])
   }
 
   doInitialCreateTracesFromProps() {
-    if (this.props.decouplingFor && this.props.decouplingTo) {
+    const pin1Target = this.props.decouplingFor ?? this.props.bypassFor
+    const pin2Target = this.props.decouplingTo ?? this.props.bypassTo
+
+    if (pin1Target && pin2Target) {
       this.add(
         new Trace({
           from: `${this.getSubcircuitSelector()} > port.1`,
-          to: this.props.decouplingFor,
+          to: pin1Target,
         }),
       )
       this.add(
         new Trace({
           from: `${this.getSubcircuitSelector()} > port.2`,
-          to: this.props.decouplingTo,
+          to: pin2Target,
         }),
       )
     }

--- a/tests/components/normal-components/capacitor-bypass-props.test.tsx
+++ b/tests/components/normal-components/capacitor-bypass-props.test.tsx
@@ -1,0 +1,54 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test(
+  "capacitor creates nets and traces when bypassFor and bypassTo are used (#3107)",
+  async () => {
+    const { circuit } = getTestFixture()
+
+    circuit.add(
+      <board width="20mm" height="20mm">
+        <capacitor
+          name="C1"
+          capacitance="100nF"
+          footprint="0402"
+          bypassFor="net.VCC"
+          bypassTo="net.GND"
+          pcbX={0}
+          pcbY={0}
+        />
+      </board>,
+    )
+
+    circuit.render()
+
+    const sourceTraces = circuit.db.source_trace.list()
+    expect(sourceTraces.length).toBeGreaterThanOrEqual(2)
+
+    const connectedPortIds = sourceTraces.flatMap(
+      (t) => t.connected_source_port_ids ?? [],
+    )
+    const connectedNetIds = sourceTraces.flatMap(
+      (t) => t.connected_source_net_ids ?? [],
+    )
+
+    const c1Ports = circuit.db.source_port.list({
+      source_component_id: circuit.db.source_component.getWhere({
+        name: "C1",
+      })!.source_component_id,
+    })
+
+    expect(c1Ports.length).toBeGreaterThanOrEqual(2)
+    for (const port of c1Ports) {
+      expect(connectedPortIds).toContain(port.source_port_id)
+    }
+
+    const vccNet = circuit.db.source_net.getWhere({ name: "VCC" })
+    const gndNet = circuit.db.source_net.getWhere({ name: "GND" })
+    expect(vccNet).toBeDefined()
+    expect(gndNet).toBeDefined()
+    expect(connectedNetIds).toContain(vccNet!.source_net_id)
+    expect(connectedNetIds).toContain(gndNet!.source_net_id)
+  },
+  { timeout: 30000 },
+)


### PR DESCRIPTION
## Summary

Fixes #3107.

Previously, documented and accepted capacitor properties \`bypassFor\` and \`bypassTo\` were ignored during component lifecycle, resulting in zero source nets and traces being created.

### Changes
1. **Nets Registration**: Included \`this.props.bypassFor\` and \`this.props.bypassTo\` in \`doInitialCreateNetsFromProps\`.
2. **Traces Generation**: Created source traces connecting port 1 to \`pin1Target\` (\`decouplingFor ?? bypassFor\`) and port 2 to \`pin2Target\` (\`decouplingTo ?? bypassTo\`) in \`doInitialCreateTracesFromProps\`.
3. **Unit Tests**: Added \`tests/components/normal-components/capacitor-bypass-props.test.tsx\` verifying that using \`bypassFor\` and \`bypassTo\` generates connected source nets and traces.

### Verification
- \`bun test tests/components/normal-components/capacitor-bypass-props.test.tsx\` (1/1 passing).
