### PR TITLE
fix(pushbutton): resolve side1/side2 port aliases and provide default internal connections

### DIFF
--- a/lib/components/normal-components/PushButton.ts
+++ b/lib/components/normal-components/PushButton.ts
@@ -24,6 +24,13 @@ export class PushButton extends NormalComponent<
   }
 
   get defaultInternallyConnectedPinNames(): string[][] {
+    const ports = this.selectAll("port")
+    if (ports.length >= 4) {
+      return [
+        ["pin1", "pin2"],
+        ["pin3", "pin4"],
+      ]
+    }
     return []
   }
 
@@ -31,6 +38,10 @@ export class PushButton extends NormalComponent<
     super.initPorts({
       pinCount: 2,
       ignoreSymbolPorts: true,
+      additionalAliases: {
+        pin1: ["side1", "left", "anode", "pos", "1"],
+        pin2: ["side2", "right", "cathode", "neg", "2"],
+      },
     })
 
     const symbol = symbols[this._getSchematicSymbolNameOrThrow()]!

--- a/tests/components/normal-components/pushbutton-side-aliases.test.tsx
+++ b/tests/components/normal-components/pushbutton-side-aliases.test.tsx
@@ -1,0 +1,67 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test(
+  "pushbutton side1 and side2 aliases resolve in trace selectors (#3116)",
+  async () => {
+    const { circuit } = getTestFixture()
+
+    circuit.add(
+      <board width="20mm" height="20mm">
+        <pushbutton name="SW1" pcbX={0} pcbY={0} />
+        <resistor name="R1" resistance="10k" pcbX={5} pcbY={0} />
+        <trace from=".SW1 > .side1" to="net.VCC" />
+        <trace from=".SW1 > .side2" to=".R1 > .pin1" />
+      </board>,
+    )
+
+    circuit.render()
+
+    const traces = circuit.db.source_trace.list()
+    expect(traces.length).toBe(2)
+
+    const sw1 = circuit.db.source_component.getWhere({ name: "SW1" })!
+    const sw1Port1 = circuit.db.source_port.getWhere({
+      source_component_id: sw1.source_component_id,
+      pin_number: 1,
+    })!
+    const sw1Port2 = circuit.db.source_port.getWhere({
+      source_component_id: sw1.source_component_id,
+      pin_number: 2,
+    })!
+
+    const connectedPortIds = traces.flatMap(
+      (t) => t.connected_source_port_ids ?? [],
+    )
+    expect(connectedPortIds).toContain(sw1Port1.source_port_id)
+    expect(connectedPortIds).toContain(sw1Port2.source_port_id)
+  },
+  { timeout: 30000 },
+)
+
+test(
+  "pushbutton with 4 pins has default internally connected pins (#3115)",
+  async () => {
+    const { circuit } = getTestFixture()
+
+    circuit.add(
+      <board width="20mm" height="20mm">
+        <pushbutton
+          name="SW1"
+          footprint="pushbutton_id1.3mm_od2mm"
+          pcbX={0}
+          pcbY={0}
+        />
+      </board>,
+    )
+
+    circuit.render()
+
+    const sw1Component = circuit.selectAll("pushbutton")[0] as any
+    expect(sw1Component.internallyConnectedPinNames).toEqual([
+      ["pin1", "pin2"],
+      ["pin3", "pin4"],
+    ])
+  },
+  { timeout: 30000 },
+)


### PR DESCRIPTION
## Summary

Fixes #3116.
Fixes #3115.

Previously, documented \`side1\` and \`side2\` port aliases failed to resolve on pushbutton components, and 4-pin pushbuttons did not emit the standard default internal pin connections (\`[["pin1", "pin2"], ["pin3", "pin4"]]\`).

### Changes
1. **Port Aliases**: Added \`additionalAliases\` mapping \`pin1\` to \`side1\` / \`left\` and \`pin2\` to \`side2\` / \`right\` in \`PushButton.initPorts()\`.
2. **Default Internal Connections**: Defined \`defaultInternallyConnectedPinNames\` on \`PushButton\` to return \`[["pin1", "pin2"], ["pin3", "pin4"]]\` when 4 ports are present on the component.
3. **Unit Tests**: Added \`tests/components/normal-components/pushbutton-side-aliases.test.tsx\` verifying that \`.side1\` and \`.side2\` resolve in trace selectors and that 4-pin pushbuttons have default internal pin connections.

### Verification
- \`bun test tests/components/normal-components/pushbutton-side-aliases.test.tsx\` (2/2 passing).
- All 6 existing pushbutton test suites pass.
