### PR TITLE
fix(schematic): support schSize scaling for components and symbols

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -796,9 +796,13 @@ export class NormalComponent<
     const center = this._getGlobalSchematicPositionBeforeLayout()
 
     if (symbol) {
+      const s = this._getSchematicSymbolScale()
       const schematic_component = db.schematic_component.insert({
         center,
-        size: { ...symbol.size },
+        size: {
+          width: symbol.size.width * s,
+          height: symbol.size.height * s,
+        },
         source_component_id: this.source_component_id!,
         is_box_with_pins: true,
         symbol_name,

--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -32,6 +32,7 @@ import {
   flipY,
   identity,
   rotate,
+  scale,
   translate,
 } from "transformation-matrix"
 import type { Primitive, ZodType } from "zod"
@@ -727,8 +728,35 @@ export abstract class PrimitiveComponent<
    * Computes a transformation matrix from the props of this component for
    * schematic components
    */
+  _getSchematicSymbolScale(): number {
+    const parsedSchSize = (this._parsedProps as any)?.schSize
+    const rawSchSize = (this.props as any)?.schSize
+    const schSize =
+      typeof parsedSchSize === "number" && !Number.isNaN(parsedSchSize)
+        ? parsedSchSize
+        : rawSchSize
+
+    if (!schSize) return 1
+    if (schSize === "xs") return 0.5
+    if (schSize === "sm" || schSize === "small") return 0.75
+    if (schSize === "default") return 1
+    if (schSize === "md") return 1.25
+    if (typeof schSize === "number" && !Number.isNaN(schSize)) {
+      const symbol = this.getSchematicSymbol()
+      if (symbol && symbol.size.width > 0) {
+        return schSize / symbol.size.width
+      }
+      return schSize
+    }
+    return 1
+  }
+
   computeSchematicPropsTransform(): Matrix {
     const { _parsedProps: props } = this
+    const s = this._getSchematicSymbolScale()
+    if (s !== 1) {
+      return compose(translate(props.schX ?? 0, props.schY ?? 0), scale(s, s))
+    }
     return compose(translate(props.schX ?? 0, props.schY ?? 0))
   }
 

--- a/tests/components/normal-components/sch-size-scaling.test.tsx
+++ b/tests/components/normal-components/sch-size-scaling.test.tsx
@@ -1,0 +1,74 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test(
+  "resistor schSize scales schematic component dimensions and port positions (#3106)",
+  async () => {
+    const { circuit } = getTestFixture()
+
+    circuit.add(
+      <board width="30mm" height="30mm">
+        <resistor name="R_XS" resistance="10k" schSize="xs" schX={0} schY={0} />
+        <resistor name="R_MD" resistance="10k" schSize="md" schX={10} schY={0} />
+      </board>,
+    )
+
+    circuit.render()
+
+    const rXs = circuit.db.source_component.getWhere({ name: "R_XS" })!
+    const rMd = circuit.db.source_component.getWhere({ name: "R_MD" })!
+
+    const rXsSch = circuit.db.schematic_component.getWhere({
+      source_component_id: rXs.source_component_id,
+    })!
+    const rMdSch = circuit.db.schematic_component.getWhere({
+      source_component_id: rMd.source_component_id,
+    })!
+
+    expect(rXsSch.size.width).toBeLessThan(rMdSch.size.width)
+    expect(rXsSch.size.height).toBeLessThan(rMdSch.size.height)
+  },
+  { timeout: 30000 },
+)
+
+test(
+  "capacitor schSize scales schematic component dimensions (#3108)",
+  async () => {
+    const { circuit } = getTestFixture()
+
+    circuit.add(
+      <board width="30mm" height="30mm">
+        <capacitor
+          name="C_SM"
+          capacitance="100nF"
+          schSize="small"
+          schX={0}
+          schY={0}
+        />
+        <capacitor
+          name="C_MD"
+          capacitance="100nF"
+          schSize="md"
+          schX={10}
+          schY={0}
+        />
+      </board>,
+    )
+
+    circuit.render()
+
+    const cSm = circuit.db.source_component.getWhere({ name: "C_SM" })!
+    const cMd = circuit.db.source_component.getWhere({ name: "C_MD" })!
+
+    const cSmSch = circuit.db.schematic_component.getWhere({
+      source_component_id: cSm.source_component_id,
+    })!
+    const cMdSch = circuit.db.schematic_component.getWhere({
+      source_component_id: cMd.source_component_id,
+    })!
+
+    expect(cSmSch.size.width).toBeLessThan(cMdSch.size.width)
+    expect(cSmSch.size.height).toBeLessThan(cMdSch.size.height)
+  },
+  { timeout: 30000 },
+)


### PR DESCRIPTION
## Summary

Fixes #3106.
Fixes #3108.

Previously, documented and accepted \`schSize\` properties (such as \`"xs"\`, \`"sm"\`, \`"small"\`, \`"md"\`, or numeric distances) on components like \`<resistor />\` and \`<capacitor />\` had no effect on schematic rendering, emitting identical component sizes and port coordinates.

### Changes
1. **Schematic Symbol Scaling**: Added \`_getSchematicSymbolScale()\` in \`PrimitiveComponent\` to resolve size scale factors for standard named sizes (\`"xs"\` -> 0.5, \`"sm"\` / \`"small"\` -> 0.75, \`"default"\` -> 1.0, \`"md"\` -> 1.25, or proportional to symbol width for numeric inputs).
2. **Transform & Dimensions**: Applied the scale factor to \`computeSchematicPropsTransform\` so ports and internal primitives are proportionally positioned, and scaled \`schematic_component.size\` in \`NormalComponent._doInitialSchematicComponentRenderWithSymbol\`.
3. **Unit Tests**: Added \`tests/components/normal-components/sch-size-scaling.test.tsx\` asserting that \`schSize\` variations dynamically alter the resulting \`schematic_component\` dimensions.

### Verification
- \`bun test tests/components/normal-components/sch-size-scaling.test.tsx\` (2/2 passing).
- \`bun test tests/components/normal-components/capacitor-display-value.test.tsx\` (6/6 passing).
