### PR TITLE
fix(pcb): fallback match-adapt pcb layout to pack layout

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -2145,7 +2145,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
 
     if (pcbLayoutMode === "grid") {
       this._doInitialPcbLayoutGrid()
-    } else if (pcbLayoutMode === "pack") {
+    } else if (pcbLayoutMode === "pack" || pcbLayoutMode === "match-adapt") {
       this._doInitialPcbLayoutPack()
     } else if (pcbLayoutMode === "flex") {
       this._doInitialPcbLayoutFlex()

--- a/tests/components/primitive-components/pcb-match-adapt-layout.test.tsx
+++ b/tests/components/primitive-components/pcb-match-adapt-layout.test.tsx
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("pcbLayout.matchAdapt does not collapse PCB components onto origin (#3136)", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board
+      width="40mm"
+      height="40mm"
+      routingDisabled
+      pcbLayout={{ matchAdapt: true }}
+    >
+      <net name="V" />
+      <net name="GND" />
+      <resistor
+        name="R1"
+        resistance="1k"
+        footprint="0805"
+        connections={{ pin1: "net.V", pin2: "net.GND" }}
+      />
+      <resistor
+        name="R2"
+        resistance="1k"
+        footprint="0805"
+        connections={{ pin1: "net.V", pin2: "net.GND" }}
+      />
+      <capacitor
+        name="C1"
+        capacitance="100nF"
+        footprint="0805"
+        connections={{ pin1: "net.V", pin2: "net.GND" }}
+      />
+      <capacitor
+        name="C2"
+        capacitance="100nF"
+        footprint="0805"
+        connections={{ pin1: "net.V", pin2: "net.GND" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const pcbComponents = circuit.db.pcb_component.list()
+  expect(pcbComponents.length).toBe(4)
+
+  // Verify that components are not all at (0, 0)
+  const centers = pcbComponents.map((c) => `${c.center.x},${c.center.y}`)
+  const uniqueCenters = new Set(centers)
+  expect(uniqueCenters.size).toBe(4)
+
+  // Verify no courtyard overlap errors
+  const errors = circuit.db.pcb_error.list()
+  const overlapErrors = errors.filter(
+    (e) => (e as any).error_type === "pcb_courtyard_overlap_error",
+  )
+  expect(overlapErrors.length).toBe(0)
+})


### PR DESCRIPTION
## Summary

Fixes #3136.

Previously, specifying \`pcbLayout={{ matchAdapt: true }}\` or \`matchAdapt\` on a board or group caused \`Group._getPcbLayoutMode()\` to return \`"match-adapt"\`. Because \`doInitialPcbLayout()\` only dispatched \`grid\`, \`pack\`, and \`flex\`, no layout routine was executed, causing unpositioned PCB components to collapse onto the group origin \`(0, 0)\` and trigger \`pcb_courtyard_overlap_error\`s.

### Changes
1. **PCB Layout Dispatch**: Dispatched \`"match-adapt"\` to \`_doInitialPcbLayoutPack()\` in \`Group.doInitialPcbLayout()\` so PCB components are cleanly packed without overlap until a specialized PCB match-adapt solver is implemented.
2. **Unit Tests**: Added \`tests/components/primitive-components/pcb-match-adapt-layout.test.tsx\` asserting that unpositioned components on a board with \`pcbLayout={{ matchAdapt: true }}\` are positioned at 4 distinct coordinates without courtyard overlap errors.

### Verification
- \`bun test tests/components/primitive-components/pcb-match-adapt-layout.test.tsx\` (1/1 passing).
