### PR TITLE
fix(schematic): preserve fillColor prop in schematic_rect circuit-json

### DIFF
--- a/lib/components/primitive-components/SchematicRect.ts
+++ b/lib/components/primitive-components/SchematicRect.ts
@@ -45,6 +45,7 @@ export class SchematicRect extends PrimitiveComponent<
         props.strokeWidth ?? SCHEMATIC_COMPONENT_OUTLINE_STROKE_WIDTH,
       color: props.color ?? SCHEMATIC_COMPONENT_OUTLINE_COLOR,
       is_filled: props.isFilled,
+      fill_color: props.fillColor,
       schematic_component_id,
       is_dashed: props.isDashed,
       rotation: props.rotation ?? 0,

--- a/tests/components/primitive-components/schematic-rect-fill-color.test.tsx
+++ b/tests/components/primitive-components/schematic-rect-fill-color.test.tsx
@@ -1,0 +1,51 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("SchematicRect preserves fillColor in circuit json (#3068)", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="12mm" height="8mm" routingDisabled>
+      <chip
+        name="U1"
+        manufacturerPartNumber="SCHEMATIC_FILL_REPRO"
+        pinLabels={{ pin1: ["A"], pin2: ["B"] }}
+        footprint="dip2"
+        symbol={
+          <symbol>
+            <schematicrect
+              schX={0}
+              schY={1.5}
+              width={4}
+              height={2}
+              color="#880000"
+              isFilled
+              fillColor="#FFFFFF"
+            />
+            <port
+              name="pin1"
+              pinNumber={1}
+              direction="left"
+              schX={-3}
+              schY={0}
+            />
+            <port
+              name="pin2"
+              pinNumber={2}
+              direction="right"
+              schX={3}
+              schY={0}
+            />
+          </symbol>
+        }
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const schematicRects = circuit.db.schematic_rect.list()
+  expect(schematicRects.length).toBe(1)
+  expect(schematicRects[0]?.is_filled).toBe(true)
+  expect(schematicRects[0]?.fill_color).toBe("#FFFFFF")
+})


### PR DESCRIPTION
## Summary

Fixes #3068.

Previously, \`<schematicrect isFilled fillColor="..." />\` accepted \`fillColor\` in \`@tscircuit/props\`, but \`SchematicRect.doInitialSchematicPrimitiveRender()\` omitted \`fill_color\` when inserting into \`db.schematic_rect\`. Renderers fell back to the stroke color, converting desired white/custom fills into dark blocks.

### Changes
1. **SchematicRect Fill Color**: Passed \`fill_color: props.fillColor\` to \`db.schematic_rect.insert()\` in \`lib/components/primitive-components/SchematicRect.ts\`, matching \`SchematicCircle\` and \`SchematicPath\`.
2. **Unit Tests**: Added \`tests/components/primitive-components/schematic-rect-fill-color.test.tsx\` asserting that \`fill_color: "#FFFFFF"\` is preserved on the emitted \`schematic_rect\` in Circuit JSON.

### Verification
- \`bun test tests/components/primitive-components/schematic-rect-fill-color.test.tsx\` (1/1 passing).
