### PR TITLE
fix(connections): ignore empty target strings to prevent selector parser crash

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -1583,7 +1583,9 @@ export class NormalComponent<
       for (const [pinName, target] of Object.entries(props.connections)) {
         const targets = Array.isArray(target) ? target : [target]
         for (const targetPath of targets) {
-          propsWithConnections.push(String(targetPath))
+          const targetStr = String(targetPath ?? "").trim()
+          if (!targetStr) continue
+          propsWithConnections.push(targetStr)
         }
       }
     }
@@ -2179,10 +2181,12 @@ export class NormalComponent<
       for (const [pinName, target] of Object.entries(props.connections)) {
         const targets = Array.isArray(target) ? target : [target]
         for (const targetPath of targets) {
+          const targetStr = String(targetPath ?? "").trim()
+          if (!targetStr) continue
           this.add(
             new Trace({
               from: `.${this.name} > .${pinName}`,
-              to: String(targetPath),
+              to: targetStr,
             }),
           )
         }

--- a/tests/components/normal-components/connections-empty-string.test.tsx
+++ b/tests/components/normal-components/connections-empty-string.test.tsx
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("empty string in connections does not crash render (#2865)", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <capacitor
+        name="C1"
+        capacitance="1uF"
+        footprint="0402"
+        connections={{ pin1: "", pin2: ".R1 > .pin1" }}
+      />
+    </board>,
+  )
+
+  await expect(circuit.renderUntilSettled()).resolves.toBeUndefined()
+
+  const sourceTraces = circuit.db.source_trace.list()
+  expect(sourceTraces.length).toBe(1)
+})


### PR DESCRIPTION
## Summary

Fixes #2865.

Previously, providing an empty string in a component's \`connections\` object (e.g. \`connections={{ pin1: "", pin2: ".R1 > .pin1" }}\`) passed \`to: ""\` down into \`selectOne()\`, causing an unhandled \`css-what\` parser crash (\`Expected name, found .\`) that aborted the entire render pass.

### Changes
1. **Empty String Guard**: Filtered out empty or whitespace-only target values in \`NormalComponent._getNetsFromConnectionsProp()\` and \`NormalComponent._createTracesFromConnectionsProp()\`.
2. **Unit Tests**: Added \`tests/components/normal-components/connections-empty-string.test.tsx\` verifying that renders with empty connection targets complete cleanly without throwing and preserve valid sibling connections.

### Verification
- \`bun test tests/components/normal-components/connections-empty-string.test.tsx\` (1/1 passing).
