### PR TITLE
fix(trace): emit error when trace connects a port to itself

### DIFF
--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -286,6 +286,19 @@ export class Trace
 
     if (!allPortsFound) return
 
+    const uniquePortIds = new Set(
+      ports.map((p) => p.port.source_port_id).filter(Boolean),
+    )
+    if (ports.length >= 2 && uniquePortIds.size === 1) {
+      db.source_trace_not_connected_error.insert({
+        message: `${this.getString()} connects a port to itself; both ends resolve to the same port.`,
+        subcircuit_id: this.getSubcircuit()?.subcircuit_id ?? undefined,
+        error_type: "source_trace_not_connected_error",
+      })
+      this._couldNotFindPort = true
+      return
+    }
+
     this._traceConnectionHash = this._computeTraceConnectionHash()
 
     const existingTraces = db.source_trace.list()

--- a/tests/components/primitive-components/trace-self-connection.test.tsx
+++ b/tests/components/primitive-components/trace-self-connection.test.tsx
@@ -1,0 +1,22 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("trace connecting a port to itself emits source_trace_not_connected_error (#2859)", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <trace from=".R1 > .pin1" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_trace_not_connected_error.list()
+  expect(errors.length).toBe(1)
+  expect(errors[0]?.message).toContain("connects a port to itself")
+
+  const traces = circuit.db.source_trace.list()
+  expect(traces.length).toBe(0)
+})


### PR DESCRIPTION
## Summary

Fixes #2859.

Previously, a trace whose endpoints resolve to the same port (e.g. \`<trace from=".R1 > .pin1" to=".R1 > .pin1" />\`) was accepted silently and emitted a duplicate-port \`source_trace\` element with \`connected_source_port_ids: ["source_port_0", "source_port_0"]\`.

### Changes
1. **Self-Connection Detection**: In \`Trace.doInitialSourceTraceRender()\`, checked if all resolved endpoints point to a single unique port, inserting a clear \`source_trace_not_connected_error\` and skipping invalid trace emission.
2. **Unit Tests**: Added \`tests/components/primitive-components/trace-self-connection.test.tsx\` verifying that self-connected traces produce a \`source_trace_not_connected_error\` and do not emit a \`source_trace\`.

### Verification
- \`bun test tests/components/primitive-components/trace-self-connection.test.tsx\` (1/1 passing).
