### PR TITLE
fix(schematic): convert string pin labels to numeric pin numbers in port_arrangement

### DIFF
--- a/lib/soup/underscorifyPortArrangement.ts
+++ b/lib/soup/underscorifyPortArrangement.ts
@@ -5,6 +5,24 @@ export const underscorifyPortArrangement = (
   portArrangement?: PortArrangement | undefined,
 ): SchematicComponentInput["port_arrangement"] | undefined => {
   if (!portArrangement) return undefined
+
+  const convertSide = (side?: {
+    pins?: (number | string)[]
+    direction?: "top-to-bottom" | "bottom-to-top" | "left-to-right" | "right-to-left"
+  }) => {
+    if (!side) return undefined
+    return {
+      ...side,
+      pins: side.pins
+        ?.map((p) => {
+          if (typeof p === "number") return p
+          const match = String(p).match(/^(?:pin)?(\d+)$/i)
+          return match ? parseInt(match[1]!, 10) : Number(p)
+        })
+        .filter((n) => Number.isFinite(n)),
+    }
+  }
+
   if (
     "leftSide" in portArrangement ||
     "rightSide" in portArrangement ||
@@ -12,11 +30,11 @@ export const underscorifyPortArrangement = (
     "bottomSide" in portArrangement
   ) {
     return {
-      left_side: portArrangement.leftSide,
-      right_side: portArrangement.rightSide,
-      top_side: portArrangement.topSide,
-      bottom_side: portArrangement.bottomSide,
-    }
+      left_side: convertSide(portArrangement.leftSide as any),
+      right_side: convertSide(portArrangement.rightSide as any),
+      top_side: convertSide(portArrangement.topSide as any),
+      bottom_side: convertSide(portArrangement.bottomSide as any),
+    } as any
   }
 
   if (

--- a/tests/components/normal-components/pinheader-port-arrangement-circuit-json.test.tsx
+++ b/tests/components/normal-components/pinheader-port-arrangement-circuit-json.test.tsx
@@ -1,0 +1,25 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { schematic_component } from "circuit-json"
+
+test("pinheader schematic port_arrangement contains numeric pins and passes circuit-json schema (#3075)", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <pinheader name="J1" pinCount={2} footprint="pinrow2" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const sc = circuit
+    .getCircuitJson()
+    .find((e) => e.type === "schematic_component")
+
+  expect(sc).toBeDefined()
+  expect((sc as any).port_arrangement?.right_side?.pins).toEqual([1, 2])
+
+  const parseResult = schematic_component.safeParse(sc)
+  expect(parseResult.success).toBe(true)
+})


### PR DESCRIPTION
## Summary

Fixes #3075.

Previously, components like \`<pinheader />\` that emitted string pin names (e.g. \`["pin1", "pin2"]\`) in \`schematic_component.port_arrangement.<side>.pins\` produced Circuit JSON that failed \`schematic_component.safeParse()\` and \`any_circuit_element.safeParse()\` because the schema strictly expects \`pins: number[]\`.

### Changes
1. **Port Arrangement Conversion**: In \`underscorifyPortArrangement()\`, mapped string pin names to integer numbers (e.g. \`"pin1"\` -> \`1\`) and filtered non-finite values, ensuring emitted \`schematic_component.port_arrangement\` complies with \`SchematicPortArrangementBySides\`.
2. **Unit Tests**: Added \`tests/components/normal-components/pinheader-port-arrangement-circuit-json.test.tsx\` verifying that \`<pinheader name="J1" pinCount={2} footprint="pinrow2" />\` emits numeric pins (\`[1, 2]\`) and passes \`schematic_component.safeParse()\`.

### Verification
- \`bun test tests/components/normal-components/pinheader-port-arrangement-circuit-json.test.tsx\` (1/1 passing).
