### PR TITLE
fix(schematic): validate positive dimensions on schematic elements

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -2196,6 +2196,23 @@ export class NormalComponent<
 
   doInitialSourceComponentPropertyValidation(): void {
     this._insertInvalidFootprintPropErrors()
+    const props = this._parsedProps
+    if (typeof props.schWidth === "number" && props.schWidth <= 0) {
+      this.root!.db.source_invalid_component_property_error.insert({
+        source_component_id: this.source_component_id || "",
+        property_name: "schWidth",
+        message: `Invalid schWidth for ${this.componentName} "${this.name}": ${props.schWidth}, which must be greater than zero.`,
+        error_type: "source_invalid_component_property_error",
+      })
+    }
+    if (typeof props.schHeight === "number" && props.schHeight <= 0) {
+      this.root!.db.source_invalid_component_property_error.insert({
+        source_component_id: this.source_component_id || "",
+        property_name: "schHeight",
+        message: `Invalid schHeight for ${this.componentName} "${this.name}": ${props.schHeight}, which must be greater than zero.`,
+        error_type: "source_invalid_component_property_error",
+      })
+    }
   }
 
   doInitialValidatePcbCoordinates(): void {

--- a/lib/components/primitive-components/SchematicCircle.ts
+++ b/lib/components/primitive-components/SchematicCircle.ts
@@ -33,6 +33,15 @@ export class SchematicCircle extends PrimitiveComponent<
 
     const schematic_symbol_id = this._getSymbolAncestor()?.schematic_symbol_id
 
+    if (typeof props.radius === "number" && props.radius <= 0) {
+      db.source_invalid_component_property_error.insert({
+        source_component_id: schematic_component_id || "",
+        property_name: "radius",
+        message: `Invalid radius for SchematicCircle: ${props.radius}, which must be greater than zero.`,
+        error_type: "source_invalid_component_property_error",
+      })
+    }
+
     const schematic_circle = db.schematic_circle.insert({
       schematic_component_id,
       schematic_symbol_id,

--- a/lib/components/primitive-components/SchematicRect.ts
+++ b/lib/components/primitive-components/SchematicRect.ts
@@ -33,6 +33,23 @@ export class SchematicRect extends PrimitiveComponent<
 
     const schematic_symbol_id = this._getSymbolAncestor()?.schematic_symbol_id
 
+    if (typeof props.width === "number" && props.width <= 0) {
+      db.source_invalid_component_property_error.insert({
+        source_component_id: schematic_component_id || "",
+        property_name: "width",
+        message: `Invalid width for SchematicRect: ${props.width}, which must be greater than zero.`,
+        error_type: "source_invalid_component_property_error",
+      })
+    }
+    if (typeof props.height === "number" && props.height <= 0) {
+      db.source_invalid_component_property_error.insert({
+        source_component_id: schematic_component_id || "",
+        property_name: "height",
+        message: `Invalid height for SchematicRect: ${props.height}, which must be greater than zero.`,
+        error_type: "source_invalid_component_property_error",
+      })
+    }
+
     const schematic_rect = db.schematic_rect.insert({
       schematic_symbol_id,
       center: {

--- a/tests/components/primitive-components/negative-schematic-dimensions.test.tsx
+++ b/tests/components/primitive-components/negative-schematic-dimensions.test.tsx
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("negative schematic dimensions emit source_invalid_component_property_error (#2861)", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        schWidth={-4}
+        schHeight={3}
+        symbol={
+          <symbol>
+            <schematicrect width={-3} height={1} schX={0} schY={0} />
+            <schematiccircle center={{ x: 0, y: 0 }} radius={-1} />
+          </symbol>
+        }
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_invalid_component_property_error.list()
+  expect(errors.length).toBeGreaterThanOrEqual(3)
+
+  const propertyNames = errors.map((e) => e.property_name)
+  expect(propertyNames).toContain("schWidth")
+  expect(propertyNames).toContain("width")
+  expect(propertyNames).toContain("radius")
+})


### PR DESCRIPTION
## Summary

Fixes #2861.

Previously, negative schematic dimensions (\`schWidth={-4}\`, \`schematicrect width={-3}\`, \`schematiccircle radius={-1}\`) were accepted silently with 0 errors, causing symbols to vanish or render inside-out with no actionable diagnostic feedback.

### Changes
1. **Property Validation**: Added non-positive dimension checks inserting \`source_invalid_component_property_error\` in:
   - \`NormalComponent.doInitialSourceComponentPropertyValidation()\` for \`schWidth\` and \`schHeight\`
   - \`SchematicRect.doInitialSchematicPrimitiveRender()\` for \`width\` and \`height\`
   - \`SchematicCircle.doInitialSchematicPrimitiveRender()\` for \`radius\`
2. **Unit Tests**: Added \`tests/components/primitive-components/negative-schematic-dimensions.test.tsx\` verifying that negative schematic dimensions emit \`source_invalid_component_property_error\` entries naming the invalid properties.

### Verification
- \`bun test tests/components/primitive-components/negative-schematic-dimensions.test.tsx\` (1/1 passing).
