### PR TITLE
fix(schematic): support PinCount field names in schPinArrangement

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -348,7 +348,9 @@ export class NormalComponent<
       const sides = ["left", "right", "top", "bottom"]
       let pinNum = 1
       for (const side of sides) {
-        const size = (schPortArrangement as any)[`${side}Size`]
+        const size =
+          (schPortArrangement as any)[`${side}PinCount`] ??
+          (schPortArrangement as any)[`${side}Size`]
         for (let i = 0; i < size; i++) {
           const nextPinNumber = pinNum++
           if (hasExistingOrQueuedPortWithPinNumber(nextPinNumber)) continue

--- a/lib/utils/schematic/getSizeOfSidesFromPortArrangement.ts
+++ b/lib/utils/schematic/getSizeOfSidesFromPortArrangement.ts
@@ -56,6 +56,9 @@ export const getSizeOfSidesFromPortArrangement = (
       bottomSize: getPinsFromSideDefinition(pa.bottomSide).length,
     }
   }
-  const { leftSize = 0, rightSize = 0, topSize = 0, bottomSize = 0 } = pa as any
+  const leftSize = (pa as any).leftPinCount ?? (pa as any).leftSize ?? 0
+  const rightSize = (pa as any).rightPinCount ?? (pa as any).rightSize ?? 0
+  const topSize = (pa as any).topPinCount ?? (pa as any).topSize ?? 0
+  const bottomSize = (pa as any).bottomPinCount ?? (pa as any).bottomSize ?? 0
   return { leftSize, rightSize, topSize, bottomSize }
 }

--- a/tests/components/normal-components/sch-pin-arrangement-pin-count.test.tsx
+++ b/tests/components/normal-components/sch-pin-arrangement-pin-count.test.tsx
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("schPinArrangement with leftPinCount/rightPinCount creates schematic ports (#2871)", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        schPinArrangement={{ leftPinCount: 4, rightPinCount: 4 }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const sourcePorts = circuit.db.source_port.list()
+  expect(sourcePorts.length).toBe(8)
+
+  const schematicPorts = circuit.db.schematic_port.list()
+  expect(schematicPorts.length).toBe(8)
+})


### PR DESCRIPTION
## Summary

Fixes #2871.

Previously, specifying \`schPinArrangement\` using the documented \`...PinCount\` properties (e.g. \`{ leftPinCount: 4, rightPinCount: 4 }\`) resulted in 0 schematic ports being created because port creation in \`NormalComponent\` and box sizing in \`getSizeOfSidesFromPortArrangement\` only checked the deprecated \`...Size\` property names.

### Changes
1. **Port Creation**: Supported \`...PinCount\` alongside \`...Size\` in \`NormalComponent._addChildrenFromStringOrProps()\`.
2. **Box Layout Sizing**: Added \`...PinCount\` resolution fallback in \`getSizeOfSidesFromPortArrangement()\`.
3. **Unit Tests**: Added \`tests/components/normal-components/sch-pin-arrangement-pin-count.test.tsx\` asserting that \`schPinArrangement={{ leftPinCount: 4, rightPinCount: 4 }}\` creates 8 source and schematic ports.

### Verification
- \`bun test tests/components/normal-components/sch-pin-arrangement-pin-count.test.tsx\` (1/1 passing).
