### PR TITLE
fix(board): respect anchorAlignment prop for board centering

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -445,7 +445,9 @@ export class Board
       y: globalPos.y + (props.outlineOffsetY ?? 0),
     }
 
-    const { boardAnchorPosition, boardAnchorAlignment } = props
+    const boardAnchorPosition = props.boardAnchorPosition
+    const boardAnchorAlignment =
+      props.anchorAlignment ?? props.boardAnchorAlignment
 
     if (boardAnchorPosition) {
       center = getBoardCenterFromAnchor({

--- a/tests/components/normal-components/board-anchor-alignment.test.tsx
+++ b/tests/components/normal-components/board-anchor-alignment.test.tsx
@@ -1,0 +1,22 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("board anchorAlignment aligns board center relative to boardAnchorPosition (#3100)", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board
+      width="20mm"
+      height="10mm"
+      boardAnchorPosition={{ x: 0, y: 0 }}
+      anchorAlignment="top_left"
+    />,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const pcbBoard = circuit.db.pcb_board.list()[0]
+  expect(pcbBoard).toBeDefined()
+  expect(pcbBoard?.center.x).toBe(10)
+  expect(pcbBoard?.center.y).toBe(-5)
+})


### PR DESCRIPTION
## Summary

Fixes #3100.

Previously, \`<board />\` only read the deprecated \`boardAnchorAlignment\` prop in \`Board._getPcbCenterBeforeLayout()\`, ignoring the preferred \`anchorAlignment\` prop from \`@tscircuit/props\`.

### Changes
1. **Board Anchor Alignment**: Checked \`props.anchorAlignment ?? props.boardAnchorAlignment\` in \`Board._getPcbCenterBeforeLayout()\`.
2. **Unit Tests**: Added \`tests/components/normal-components/board-anchor-alignment.test.tsx\` asserting that \`anchorAlignment="top_left"\` correctly offsets the center of a 20x10mm board at \`(0, 0)\` to \`{ x: 10, y: -5 }\`.

### Verification
- \`bun test tests/components/normal-components/board-anchor-alignment.test.tsx\` (1/1 passing).
