### PR TITLE
fix(port): emit error when pinLabels names pin not in footprint

### DIFF
--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -494,7 +494,24 @@ export class Port extends PrimitiveComponent<typeof portProps> {
 
     const pcbMatches = matchedComponents.filter((c) => c.isPcbPrimitive)
 
-    if (pcbMatches.length === 0) return
+    if (pcbMatches.length === 0) {
+      const parentHasPcbPrimitives =
+        (parentWithPcbComponentId?.children ?? []).some(
+          (c) => c.isPcbPrimitive,
+        ) ||
+        (parentNormalComponent?.children ?? []).some((c) => c.isPcbPrimitive)
+
+      if (parentHasPcbPrimitives) {
+        const portName = this.props.name ?? "unknown"
+        db.source_invalid_component_property_error.insert({
+          source_component_id: parentNormalComponent?.source_component_id || "",
+          property_name: "pinLabels",
+          message: `Port "${portName}" on ${parentNormalComponent?.getDisplayName() ?? "component"} does not match any PCB primitive in footprint.`,
+          error_type: "source_invalid_component_property_error",
+        })
+      }
+      return
+    }
 
     let matchCenter: { x: number; y: number } | null = null
 

--- a/tests/components/primitive-components/unroutable-pin-label.test.tsx
+++ b/tests/components/primitive-components/unroutable-pin-label.test.tsx
@@ -1,0 +1,38 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("pinLabels naming a pin the footprint lacks emits source_invalid_component_property_error (#2863)", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: ["A"], pin99: ["Z"] }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_invalid_component_property_error.list()
+  expect(errors.length).toBe(1)
+  expect(errors[0]?.property_name).toBe("pinLabels")
+  expect(errors[0]?.message).toContain("Z")
+})
+
+test("component with no footprint does not emit error for unmapped ports (#2863)", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <solderjumper name="SJ1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_invalid_component_property_error.list()
+  expect(errors.length).toBe(0)
+})


### PR DESCRIPTION
## Summary

Fixes #2863.

Previously, specifying a \`pinLabels\` entry for a pin that the footprint does not possess (e.g. \`<chip name="U1" footprint="soic8" pinLabels={{ pin1: ["A"], pin99: ["Z"] }} />\`) was silently ignored during \`Port.doInitialPcbPortRender()\`, creating an unroutable phantom source port with 0 diagnostic errors.

### Changes
1. **Unroutable Port Detection**: In \`Port.doInitialPcbPortRender()\`, checked if the port has 0 matching PCB primitives while its parent component has other PCB primitives (footprint pads), inserting a \`source_invalid_component_property_error\` pointing directly at the misconfigured \`pinLabels\`.
2. **Unit Tests**: Added \`tests/components/primitive-components/unroutable-pin-label.test.tsx\` verifying that:
   - Extra/unmatched pin labels on footprinted components emit \`source_invalid_component_property_error\`.
   - Bare footprintless components (e.g. \`<solderjumper />\`) do not emit false-positive errors.

### Verification
- \`bun test tests/components/primitive-components/unroutable-pin-label.test.tsx\` (2/2 passing).
