### PR TITLE
fix(subcircuit): caching no longer drops standalone holes, plated holes and cutouts

### DIFF
--- a/lib/components/primitive-components/Group/Subcircuit/inflators/inflateStandalonePcbPrimitives.ts
+++ b/lib/components/primitive-components/Group/Subcircuit/inflators/inflateStandalonePcbPrimitives.ts
@@ -25,6 +25,9 @@ export function inflateStandalonePcbPrimitives(
     "pcb_note_path",
     "pcb_note_line",
     "pcb_via",
+    "pcb_hole",
+    "pcb_plated_hole",
+    "pcb_cutout",
   ]
 
   const standalonePrimitives = injectionDb.toArray().filter((elm) => {
@@ -45,6 +48,12 @@ export function inflateStandalonePcbPrimitives(
         )
 
       return !isHandledByInflatedTrace
+    }
+    if (elm.type === "pcb_cutout") {
+      // A cutout is a hole in the board itself: `pcb_cutout` has no
+      // `pcb_component_id` field at all, so it is always standalone. The check
+      // below requires the key to be present and would drop every cutout.
+      return true
     }
     // Check for null or undefined pcb_component_id
     return (

--- a/tests/subcircuits/subcircuit-caching-preserves-standalone-pcb-primitives.test.tsx
+++ b/tests/subcircuits/subcircuit-caching-preserves-standalone-pcb-primitives.test.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/**
+ * A cached subcircuit is rendered in isolation and then inflated back into
+ * components, so any primitive the inflator does not rebuild disappears from the
+ * board. Holes, plated holes and cutouts were absent from the standalone
+ * primitive list, which meant enabling subcircuit caching silently removed the
+ * board's mounting holes rather than failing.
+ */
+test("subcircuit caching preserves standalone holes, plated holes and cutouts", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <subcircuit name="S1" _subcircuitCachingEnabled>
+        <hole name="H1" pcbX={-4} pcbY={0} diameter="3mm" />
+        <platedhole
+          name="PH1"
+          pcbX={0}
+          pcbY={0}
+          shape="circle"
+          holeDiameter="1mm"
+          outerDiameter="2mm"
+        />
+        <cutout shape="rect" pcbX={4} pcbY={0} width="2mm" height="2mm" />
+      </subcircuit>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.pcb_hole.list()).toHaveLength(1)
+  expect(circuit.db.pcb_plated_hole.list()).toHaveLength(1)
+  expect(circuit.db.pcb_cutout.list()).toHaveLength(1)
+})


### PR DESCRIPTION
A cached subcircuit renders in isolation and is then inflated back into
components, so any primitive inflateStandalonePcbPrimitives does not rebuild
disappears. Its allowlist covered silkscreen, notes and vias but not
pcb_hole, pcb_plated_hole or pcb_cutout, so enabling _subcircuitCachingEnabled
silently removed a board's mounting holes instead of failing.

createComponentsFromCircuitJson already builds Hole, PlatedHole and Cutout, so
this is an allowlist addition plus one special case: pcb_cutout has no
pcb_component_id field at all, and the standalone check requires that key to be
present.
