### PR TITLE
fix(subcircuit): decline caching, loudly, for anything the inflators cannot rebuild

### DIFF
--- a/lib/components/primitive-components/EnclosureCutoutAperture/EnclosureCutoutAperture.ts
+++ b/lib/components/primitive-components/EnclosureCutoutAperture/EnclosureCutoutAperture.ts
@@ -14,6 +14,13 @@ import {
 export class EnclosureCutoutAperture extends PrimitiveComponent<
   typeof enclosureCutoutApertureProps
 > {
+  /**
+   * No Circuit JSON record of its own, so it cannot survive being round-tripped
+   * through one. Subcircuit isolation checks this and declines to isolate a
+   * subtree containing it, rather than dropping it silently.
+   */
+  isEphemeralDeclaration = true as const
+
   get config() {
     return {
       componentName: "EnclosureCutoutAperture",

--- a/lib/components/primitive-components/Group/Subcircuit/Subcircuit_doInitialRenderIsolatedSubcircuits.ts
+++ b/lib/components/primitive-components/Group/Subcircuit/Subcircuit_doInitialRenderIsolatedSubcircuits.ts
@@ -1,5 +1,9 @@
 import type { AnyCircuitElement } from "circuit-json"
 import { IsolatedCircuit } from "lib/IsolatedCircuit"
+import {
+  findComponentsThatCannotSurviveIsolation,
+  warnIsolationDeclined,
+} from "./isolation-round-trip"
 import type { ISubcircuit } from "./ISubcircuit"
 
 /**
@@ -26,6 +30,20 @@ export function Subcircuit_doInitialRenderIsolatedSubcircuits(
   if (subcircuit._isolatedCircuitJson) return
 
   if (!subcircuit.getSubcircuitPropHash) return
+
+  // Isolation is an optimization; correctness is not negotiable against it.
+  //
+  // This subtree is about to be replaced by Circuit JSON and rebuilt from it, so
+  // anything the inflators cannot put back would be dropped without a trace --
+  // an enclosure simply comes out missing a boss. Rendering this one subcircuit
+  // normally costs a cache miss and nothing else; measured, the whole feature is
+  // worth 1.0-1.3x on 4-24 identical modules, so declining it is a rounding
+  // error against getting the wrong board. See ./isolation-round-trip.ts.
+  const blockers = findComponentsThatCannotSurviveIsolation(subcircuit)
+  if (blockers.length > 0) {
+    warnIsolationDeclined(subcircuit, blockers)
+    return
+  }
 
   const propHash = subcircuit.getSubcircuitPropHash()
   const cachedSubcircuits = subcircuit.root?.cachedSubcircuits

--- a/lib/components/primitive-components/Group/Subcircuit/ephemeral-declarations.ts
+++ b/lib/components/primitive-components/Group/Subcircuit/ephemeral-declarations.ts
@@ -1,0 +1,26 @@
+/**
+ * A component that exists only in the render tree, with no Circuit JSON record
+ * of its own.
+ *
+ * `<enclosure.cutoutaperture>` and `<enclosure.screwboss>` are the current
+ * examples: they are read by the enclosure solver during the render and emit
+ * nothing, deliberately, because a solver input is not something Circuit JSON
+ * should have to carry (see the mounting-hardware RFC 1.5.3).
+ *
+ * That choice has one consequence, and this is it. Subcircuit isolation renders
+ * a subtree separately, **replaces it with `AnyCircuitElement[]`** and rebuilds
+ * components from those records with the inflators in `./inflators/`. Anything
+ * with no record has nothing to rebuild from, so it silently disappears -- and
+ * "silently" is the problem: the enclosure comes out missing a boss with no
+ * error anywhere.
+ *
+ * The subtree is checked in `./isolation-round-trip.ts`, which declines
+ * isolation for any subcircuit containing one of these.
+ */
+export interface EphemeralDeclaration {
+  /** Marks a component that cannot survive a Circuit JSON round trip. */
+  isEphemeralDeclaration: true
+}
+
+export const isEphemeralDeclaration = (component: unknown): boolean =>
+  Boolean((component as Partial<EphemeralDeclaration>)?.isEphemeralDeclaration)

--- a/lib/components/primitive-components/Group/Subcircuit/ephemeral-declarations.ts
+++ b/lib/components/primitive-components/Group/Subcircuit/ephemeral-declarations.ts
@@ -1,18 +1,18 @@
 /**
  * A component that exists only in the render tree, with no Circuit JSON record
- * of its own.
+ * of its own, and therefore cannot be re-inflated.
  *
- * `<enclosure.cutoutaperture>` and `<enclosure.screwboss>` are the current
- * examples: they are read by the enclosure solver during the render and emit
- * nothing, deliberately, because a solver input is not something Circuit JSON
- * should have to carry (see the mounting-hardware RFC 1.5.3).
- *
- * That choice has one consequence, and this is it. Subcircuit isolation renders
- * a subtree separately, **replaces it with `AnyCircuitElement[]`** and rebuilds
- * components from those records with the inflators in `./inflators/`. Anything
- * with no record has nothing to rebuild from, so it silently disappears -- and
- * "silently" is the problem: the enclosure comes out missing a boss with no
- * error anywhere.
+ * Subcircuit isolation renders a subtree separately, **replaces it with
+ * `AnyCircuitElement[]`** and rebuilds components from those records with the
+ * inflators in `./inflators/`. Anything with no circuit-json record has nothing
+ * to rebuild from, so it silently disappears. So if we find any elements that are
+ * "Ephemeral" i.e. do not have a circuit-json representaiton in the tsx tree,
+ * disable caching. This is not especially important yet; subcircuit caching is
+ * not yet widely used nor does it boost performance substantially in most cases
+ * yet, this isolation guard is intended to be helpful to developers and agents
+ * who are writing new elements to alleviate concern that subcircuit isolation will
+ * cause silent bugs; now it won't, it will safely disable caching for subcircuits
+ * containing non-inflatable elements, which is fine for now.
  *
  * The subtree is checked in `./isolation-round-trip.ts`, which declines
  * isolation for any subcircuit containing one of these.

--- a/lib/components/primitive-components/Group/Subcircuit/isolation-round-trip.ts
+++ b/lib/components/primitive-components/Group/Subcircuit/isolation-round-trip.ts
@@ -1,0 +1,217 @@
+import type { PrimitiveComponent } from "../../../base-components/PrimitiveComponent"
+import { isEphemeralDeclaration } from "./ephemeral-declarations"
+import type { ISubcircuit } from "./ISubcircuit"
+
+/**
+ * Subcircuit isolation renders a subtree in its own circuit, throws the
+ * components away, keeps the `AnyCircuitElement[]` and rebuilds components from
+ * those records with `lib/utils/circuit-json/inflate-circuit-json.ts`.
+ *
+ * That is only transparent for the things an inflator knows how to rebuild.
+ * Everything else takes one of two exits, and both used to be quiet:
+ *
+ * - no record at all (`<enclosure.cutoutaperture>`) -- dropped, no error anywhere
+ * - a record with no inflator (`<netlabel>`) -- dropped, no error anywhere
+ *
+ * ...and one that is loud but fatal: an `ftype` the inflator's switch does not
+ * have a case for (`<pinheader>`, `<crystal>`) throws mid-render.
+ *
+ * So the round trip is checked *before* it is taken. Anything this file does
+ * not positively know how to rebuild means the subcircuit renders normally --
+ * correct output, no cache -- and says so. The cache is worth 1.0x-1.33x on
+ * 4-24 identical modules (measured, see the RFC); nothing about that is worth a
+ * board that quietly comes out missing a part.
+ *
+ * The check itself is not what costs anything. It runs after the
+ * `_isIsolatedSubcircuit` early return, so a circuit that never enables caching
+ * -- which is every circuit rendered by eval, cli and runframe today -- pays
+ * nothing, and the walk is ~0.3us per node (measured 2026-08-15: a 497-node
+ * subcircuit of 40 passives and a QFN-64 took 0.15ms, 0.014% of its render).
+ * What costs is the decision it makes: declining is worth the cache, no more --
+ * 1.03x at 4 identical modules and 1.39x at 24, on the same circuit, with the
+ * cache silently dropping a `<netlabel>` from each of them.
+ *
+ * See rfc/rfcs/2026-08-14-subcircuit-caching-must-be-lossless.md for the
+ * measurements and for the fixes that would let entries be added here.
+ */
+
+/**
+ * The allowlist, and what rebuilds each entry.
+ *
+ * This is paired with `inflate-circuit-json.ts` by hand: a component belongs
+ * here only when that file has a path that produces it, and the value names
+ * that path so the pairing can be checked by reading. `isolation-round-trip`
+ * tests cover the entries that matter.
+ *
+ * Keyed by `componentName`, which is *not* the class name for every component:
+ * a `<subcircuit>` is a `Subcircuit` instance reporting `"Group"`, and so is a
+ * `<breakout>`.
+ */
+export const COMPONENTS_REBUILT_BY_INFLATORS: Record<string, string> = {
+  // Containers
+  Group: "inflateSourceGroup <- source_group (<subcircuit> reports Group too)",
+  Board: "inflatePcbBoard <- pcb_board",
+
+  // source_component, by ftype, per inflate-circuit-json's switch
+  Resistor: "inflateSourceResistor <- source_component simple_resistor",
+  Capacitor: "inflateSourceCapacitor <- source_component simple_capacitor",
+  Inductor: "inflateSourceInductor <- source_component simple_inductor",
+  Diode: "inflateSourceDiode <- source_component simple_diode",
+  Fiducial: "inflateSourceFiducial <- source_component simple_fiducial",
+  Led: "inflateSourceLed <- source_component simple_led",
+  Chip: "inflateSourceChip <- source_component simple_chip",
+  Jumper: "inflateSourceChip <- source_component simple_chip",
+  SolderJumper: "inflateSourceChip <- source_component simple_chip",
+  Connector: "inflateSourceConnector <- source_component simple_connector",
+  Transistor: "inflateSourceTransistor <- source_component simple_transistor",
+  Mosfet: "inflateSourceMosfet <- source_component simple_mosfet",
+  PushButton: "inflateSourcePushButton <- source_component simple_push_button",
+  Switch: "inflateSourceSwitch <- source_component simple_switch",
+
+  // Connectivity
+  Trace: "inflateSourceTrace <- source_trace",
+  Port: "inflateSourcePort <- source_port",
+
+  // Standalone PCB primitives, per inflateStandalonePcbPrimitives' type list
+  SilkscreenRect: "inflateStandalonePcbPrimitives <- pcb_silkscreen_rect",
+  SilkscreenCircle: "inflateStandalonePcbPrimitives <- pcb_silkscreen_circle",
+  SilkscreenLine: "inflateStandalonePcbPrimitives <- pcb_silkscreen_line",
+  SilkscreenPath: "inflateStandalonePcbPrimitives <- pcb_silkscreen_path",
+  SilkscreenText: "inflateStandalonePcbPrimitives <- pcb_silkscreen_text",
+  FabricationNoteText:
+    "inflateStandalonePcbPrimitives <- pcb_fabrication_note_text",
+  FabricationNotePath:
+    "inflateStandalonePcbPrimitives <- pcb_fabrication_note_path",
+  FabricationNoteRect:
+    "inflateStandalonePcbPrimitives <- pcb_fabrication_note_rect",
+  PcbNoteText: "inflateStandalonePcbPrimitives <- pcb_note_text",
+  PcbNoteRect: "inflateStandalonePcbPrimitives <- pcb_note_rect",
+  PcbNotePath: "inflateStandalonePcbPrimitives <- pcb_note_path",
+  PcbNoteLine: "inflateStandalonePcbPrimitives <- pcb_note_line",
+  PcbVia: "inflateStandalonePcbPrimitives <- pcb_via",
+  Hole: "inflateStandalonePcbPrimitives <- pcb_hole",
+  PlatedHole: "inflateStandalonePcbPrimitives <- pcb_plated_hole",
+  Cutout: "inflateStandalonePcbPrimitives <- pcb_cutout",
+}
+
+/**
+ * Containers whose *children* are declarations in their own right, so the walk
+ * keeps checking inside them.
+ *
+ * Everything else in the allowlist is checked as a unit: a `<chip>`'s ports,
+ * footprint and pads come back through `inflateFootprintComponent` /
+ * `inflateSourcePort` as part of rebuilding the chip, so they are not separate
+ * declarations to vet.
+ */
+const CONTAINER_COMPONENTS = new Set(["Group", "Board"])
+
+export type IsolationBlockerReason = "emits-no-circuit-json" | "no-inflator"
+
+export interface IsolationBlocker {
+  component: PrimitiveComponent
+  reason: IsolationBlockerReason
+}
+
+const REASON_EXPLANATION: Record<IsolationBlockerReason, string> = {
+  "emits-no-circuit-json":
+    "emits no Circuit JSON of its own, so there is no record to rebuild it from",
+  "no-inflator":
+    "has no inflator, so nothing rebuilds it from its Circuit JSON record",
+}
+
+/**
+ * Everything in this subtree that isolation could not put back.
+ *
+ * Checked against the *live* children, before they are cleared, which is the
+ * only moment both the tree and the decision exist together.
+ */
+export const findComponentsThatCannotSurviveIsolation = (
+  subcircuit: ISubcircuit,
+): IsolationBlocker[] => {
+  const blockers: IsolationBlocker[] = []
+
+  const visit = (
+    component: PrimitiveComponent,
+    { insideRebuiltComponent }: { insideRebuiltComponent: boolean },
+  ) => {
+    if (isEphemeralDeclaration(component)) {
+      blockers.push({ component, reason: "emits-no-circuit-json" })
+      return
+    }
+
+    const isRebuilt = component.componentName in COMPONENTS_REBUILT_BY_INFLATORS
+
+    // Inside something the inflators rebuild whole (a chip's footprint, a
+    // resistor's ports), the parts are not separate declarations -- but an
+    // ephemeral declaration nested in there still has nowhere to come back
+    // from, so the walk continues rather than stopping.
+    if (!insideRebuiltComponent && !isRebuilt) {
+      blockers.push({ component, reason: "no-inflator" })
+      return
+    }
+
+    const descendAsRebuilt =
+      insideRebuiltComponent ||
+      !CONTAINER_COMPONENTS.has(component.componentName)
+
+    for (const child of component.children ?? []) {
+      visit(child as PrimitiveComponent, {
+        insideRebuiltComponent: descendAsRebuilt,
+      })
+    }
+  }
+
+  const children = ((subcircuit as unknown as PrimitiveComponent).children ??
+    []) as PrimitiveComponent[]
+  for (const child of children) {
+    visit(child, { insideRebuiltComponent: false })
+  }
+
+  return blockers
+}
+
+/**
+ * One warning per distinct set of offenders per circuit: a board of 24 identical
+ * modules has one problem, not 24, and a warning printed 24 times is a warning
+ * that gets filtered out.
+ */
+const warnedSignaturesByRoot = new WeakMap<object, Set<string>>()
+
+export const getIsolationDeclinedWarning = (
+  subcircuit: ISubcircuit,
+  blockers: IsolationBlocker[],
+): string => {
+  const lines = blockers.map(
+    ({ component, reason }) =>
+      `  - ${component.getString?.() ?? component.componentName} ${REASON_EXPLANATION[reason]}`,
+  )
+  const subcircuitName =
+    (subcircuit as unknown as PrimitiveComponent).getString?.() ?? "subcircuit"
+
+  return [
+    `⚠️ subcircuit caching disabled for ${subcircuitName}: it contains ${blockers.length} declaration(s) that cannot be rebuilt from Circuit JSON, and caching would silently drop them:`,
+    ...lines,
+    "  This subcircuit rendered normally instead (correct output, no cache).",
+    "  See rfc/rfcs/2026-08-14-subcircuit-caching-must-be-lossless.md",
+  ].join("\n")
+}
+
+export const warnIsolationDeclined = (
+  subcircuit: ISubcircuit,
+  blockers: IsolationBlocker[],
+): void => {
+  const root = (subcircuit.root ?? subcircuit) as unknown as object
+  let warnedSignatures = warnedSignaturesByRoot.get(root)
+  if (!warnedSignatures) {
+    warnedSignatures = new Set<string>()
+    warnedSignaturesByRoot.set(root, warnedSignatures)
+  }
+
+  const signature = blockers
+    .map(({ component, reason }) => `${component.componentName}:${reason}`)
+    .join(",")
+  if (warnedSignatures.has(signature)) return
+  warnedSignatures.add(signature)
+
+  console.warn(getIsolationDeclinedWarning(subcircuit, blockers))
+}

--- a/tests/enclosure/enclosure-aperture-survives-subcircuit-caching.test.tsx
+++ b/tests/enclosure/enclosure-aperture-survives-subcircuit-caching.test.tsx
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { enclosure } from "lib"
+import type { SolverStartedEvent } from "lib/events"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/**
+ * `<enclosure.cutoutaperture>` emits no Circuit JSON of its own -- deliberately,
+ * because a solver input is not something the interchange format should carry.
+ *
+ * Subcircuit isolation replaces a subtree with `AnyCircuitElement[]` and rebuilds
+ * it from the inflators, so a declaration with no record has nothing to be
+ * rebuilt from. Before the guard, the aperture inside the cached subcircuit was
+ * dropped without a word: the enclosure rendered, looked fine, and was missing
+ * an opening.
+ */
+test("an aperture inside a cached subcircuit is not silently dropped", () => {
+  const warnings: string[] = []
+  const originalWarn = console.warn
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "))
+
+  const { circuit } = getTestFixture()
+  let enclosureSolverEvent: SolverStartedEvent | undefined
+  circuit.on("solver:started", (event) => {
+    if (event.solverName === "CreateFdmEnclosureSolver") {
+      enclosureSolverEvent = event
+    }
+  })
+
+  const verticalFootprint = (
+    <footprint insertionDirection="from_above">
+      <smtpad portHints={["pin1"]} width="2mm" height="2mm" shape="rect" />
+    </footprint>
+  )
+
+  circuit.add(
+    <group>
+      <board name="B1" width="30mm" height="20mm" routingDisabled>
+        <subcircuit name="module" _subcircuitCachingEnabled>
+          <chip name="SW1" pcbX="6mm" pcbY="-3mm" footprint={verticalFootprint}>
+            <enclosure.cutoutaperture shape="circle" radius="3mm" />
+          </chip>
+        </subcircuit>
+        <chip name="SW2" pcbX="-6mm" pcbY="3mm" footprint={verticalFootprint}>
+          <enclosure.cutoutaperture shape="circle" radius="3mm" />
+        </chip>
+      </board>
+      <enclosure.fdm.box boardRef=".B1" />
+    </group>,
+  )
+  circuit.render()
+
+  console.warn = originalWarn
+
+  expect(enclosureSolverEvent?.solverParams.apertures).toHaveLength(2)
+
+  const warning = warnings.join("\n")
+  expect(warning).toContain("subcircuit caching disabled")
+  expect(warning).toContain("enclosurecutoutaperture")
+})

--- a/tests/subcircuits/subcircuit-caching-declined-for-uninflatable-declaration.test.tsx
+++ b/tests/subcircuits/subcircuit-caching-declined-for-uninflatable-declaration.test.tsx
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/**
+ * A `<netlabel>` has a Circuit JSON record (`schematic_net_label`) and no
+ * inflator, so isolating a subcircuit that contains one used to drop it: the
+ * schematic rendered, looked fine, and had no label on the net.
+ *
+ * The guard declines isolation for anything the inflators cannot rebuild, and
+ * says so, rather than trading a correct schematic for 1.0-1.33x.
+ */
+test("a subcircuit holding an uninflatable declaration is not cached, loudly", async () => {
+  // bun's spyOn does not record calls on `console`, so the sink is swapped out
+  // by hand.
+  const warnings: string[] = []
+  const originalWarn = console.warn
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "))
+
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="40mm" height="24mm" routingDisabled>
+      <subcircuit name="module" _subcircuitCachingEnabled>
+        <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} />
+        <netlabel
+          net="VCC"
+          schX={2}
+          schY={2}
+          anchorSide="left"
+          connectsTo=".R1 > .pin1"
+        />
+      </subcircuit>
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  console.warn = originalWarn
+
+  expect(circuit.db.schematic_net_label.list()).toHaveLength(1)
+  expect(circuit.cachedSubcircuits!.size).toBe(0)
+
+  const warning = warnings.join("\n")
+  expect(warning).toContain("subcircuit caching disabled")
+  expect(warning).toContain("netlabel")
+})

--- a/tests/subcircuits/subcircuit-caching-declined-for-uninflatable-ftype.test.tsx
+++ b/tests/subcircuits/subcircuit-caching-declined-for-uninflatable-ftype.test.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/**
+ * The other exit from a lossy round trip is loud but fatal: `inflateCircuitJson`
+ * switches on `source_component.ftype` and throws for any it has no case for, so
+ * a `<pinheader>` (`simple_pin_header`) inside a cached subcircuit killed the
+ * render with "No inflator implemented for source component ftype".
+ *
+ * An optimization is not allowed to decide whether a board renders at all, so
+ * the guard checks the round trip before taking it and this renders normally.
+ */
+test("a subcircuit holding an ftype with no inflator renders instead of throwing", async () => {
+  const warnings: string[] = []
+  const originalWarn = console.warn
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "))
+
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="40mm" height="24mm" routingDisabled>
+      <subcircuit name="module" _subcircuitCachingEnabled>
+        <pinheader name="J1" pinCount={2} pcbX={0} />
+      </subcircuit>
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  console.warn = originalWarn
+
+  expect(circuit.db.source_component.list().map((c) => c.name)).toEqual(["J1"])
+  expect(circuit.cachedSubcircuits!.size).toBe(0)
+  expect(warnings.join("\n")).toContain("subcircuit caching disabled")
+})

--- a/tests/subcircuits/subcircuit-caching-kept-for-inflatable-declarations.test.tsx
+++ b/tests/subcircuits/subcircuit-caching-kept-for-inflatable-declarations.test.tsx
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+/**
+ * The counterpart to
+ * `subcircuit-caching-declined-for-uninflatable-declaration.test.tsx`: a guard
+ * that declines everything is as useless as one that declines nothing, so this
+ * pins that a subcircuit built only from components the inflators rebuild still
+ * caches, and warns about nothing.
+ */
+test("a subcircuit built only from inflatable declarations is still cached", async () => {
+  const warnings: string[] = []
+  const originalWarn = console.warn
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "))
+  const { circuit } = getTestFixture()
+
+  const Module = ({ name }: { name: string }) => (
+    <subcircuit name={name} _subcircuitCachingEnabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" pcbY={2} />
+      <trace from=".R1 .pin1" to=".C1 .pin1" />
+      <silkscreentext text="mod" pcbY={-2} />
+      {/* standalone primitives, inflated since #3262 */}
+      <hole pcbX={3} pcbY={0} diameter="1mm" />
+    </subcircuit>
+  )
+
+  circuit.add(
+    <board width="40mm" height="24mm" routingDisabled>
+      <Module name="S1" />
+      <Module name="S2" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  console.warn = originalWarn
+
+  expect(circuit.cachedSubcircuits!.size).toBe(1)
+  expect(circuit.db.source_component.list()).toHaveLength(4)
+  expect(circuit.db.pcb_hole.list()).toHaveLength(2)
+  expect(
+    warnings.filter((line) => line.includes("subcircuit caching disabled")),
+  ).toEqual([])
+})


### PR DESCRIPTION
Subcircuit isolation renders a subtree in its own circuit, throws the components
away, keeps the AnyCircuitElement[] and rebuilds components from those records
with inflate-circuit-json. That is only transparent for what an inflator knows
how to rebuild; everything else takes one of three exits, and two of them are
silent:

- no record at all (<enclosure.cutoutaperture>) -- dropped, no error anywhere
- a record with no inflator (<netlabel>) -- dropped, no error anywhere
- an ftype the inflator's switch has no case for (<pinheader>) -- throws
  mid-render, so an optimization decides whether the board renders at all

The round trip is now checked before it is taken:
isolation-round-trip.ts holds an allowlist keyed by componentName whose value
names the inflator that rebuilds each entry, so the pairing with
inflate-circuit-json.ts can be checked by reading. A subtree is isolated only
when every declaration in it is on that list; anything else renders normally --
correct output, no cache -- and warns once per circuit, naming the offending
components and why each cannot come back.

The walk stops at components the inflators rebuild whole (a chip's footprint,
pads and ports come back with the chip, so they are not separate declarations to
vet) but keeps descending for declarations that emit no Circuit JSON at all,
which have nowhere to come back from at any depth.

