### PR TITLE
fix(pushbutton): create a port for every leg, not just two

### DIFF
--- a/lib/components/normal-components/PushButton.ts
+++ b/lib/components/normal-components/PushButton.ts
@@ -28,8 +28,19 @@ export class PushButton extends NormalComponent<
   }
 
   override initPorts() {
+    // A 4-leg tactile switch has four physical legs. Hardcoding pinCount: 2
+    // meant pins 3 and 4 never got ports — so those pads had no pcb_port, could
+    // not join a net, and vanished from connectivity analysis entirely. (It also
+    // left the pin3/pin4 lookups below undefined, which is what crashed when
+    // internallyConnectedPins was set.)
+    //
+    // With a footprint, let NormalComponent derive the ports from it, so a
+    // 4-leg part gets 4 and a 2-pin part gets 2. With no footprint there is
+    // nothing to derive from, so keep the historical 2-pin default — a bare
+    // <pushbutton /> is still a two-terminal switch schematically.
+    const hasFootprint = Boolean(this.props.footprint)
     super.initPorts({
-      pinCount: 2,
+      ...(hasFootprint ? {} : { pinCount: 2 }),
       ignoreSymbolPorts: true,
     })
 
@@ -39,25 +50,32 @@ export class PushButton extends NormalComponent<
     const symPort2 = symbol.ports.find((p) => p.labels.includes("2"))
 
     const ports = this.selectAll("port")
-    const pin1Port = ports.find((p) => p.props.pinNumber === 1)! as Port
-    const pin2Port = ports.find((p) => p.props.pinNumber === 2)! as Port
-    const pin3Port = ports.find((p) => p.props.pinNumber === 3)! as Port
-    const pin4Port = ports.find((p) => p.props.pinNumber === 4)! as Port
+    const getPortByPinNumber = (pinNumber: number) =>
+      ports.find((p) => p.props.pinNumber === pinNumber) as Port | undefined
 
+    const pin1Port = getPortByPinNumber(1)
     const { internallyConnectedPins } = this._parsedProps
 
-    pin1Port.schematicSymbolPortDef = symPort1!
+    // The schematic symbol only ever has two terminals ("1" and "2") — the
+    // extra legs of a 4-leg switch are the same two electrical nodes — so the
+    // mapping below assigns the symbol's second terminal to whichever pin
+    // represents it.
+    if (pin1Port) pin1Port.schematicSymbolPortDef = symPort1!
 
-    if (!internallyConnectedPins || internallyConnectedPins.length === 0) {
+    const pin2Port = getPortByPinNumber(2)
+    if (
+      pin2Port &&
+      (!internallyConnectedPins || internallyConnectedPins.length === 0)
+    ) {
       pin2Port.schematicSymbolPortDef = symPort2!
     }
 
     // Find the lowest-numbered pin that's not connected to pin1
-    for (const [pn, port] of [
-      [2, pin2Port],
-      [3, pin3Port],
-      [4, pin4Port],
-    ] as const) {
+    for (const pn of [2, 3, 4] as const) {
+      const port = getPortByPinNumber(pn)
+      // A 2-pin pushbutton simply has no pin3/pin4 — skip rather than crash.
+      if (!port) continue
+
       const internallyConnectedRow = internallyConnectedPins?.find(
         ([pin1, pin2]) => pin1 === `pin${pn}` || pin2 === `pin${pn}`,
       )

--- a/tests/components/normal-components/pushbutton-four-leg-ports.test.tsx
+++ b/tests/components/normal-components/pushbutton-four-leg-ports.test.tsx
@@ -1,0 +1,84 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// A 4-leg tactile switch must expose all four legs on the PCB. Previously
+// PushButton hardcoded pinCount: 2, so pins 3 and 4 got no ports at all — the
+// pads existed as copper but had no pcb_port, so they could not join a net and
+// were invisible to connectivity checks. A real board shipped with two such
+// pads left unrouted and the buttons dead.
+test("4-leg pushbutton creates a port for every leg", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <pushbutton
+        name="SW1"
+        footprint={
+          <footprint>
+            <platedhole
+              portHints={["pin1"]}
+              pcbX="-6.25mm"
+              pcbY="2.5mm"
+              shape="circle"
+              holeDiameter="1.2mm"
+              outerDiameter="2.5mm"
+            />
+            <platedhole
+              portHints={["pin2"]}
+              pcbX="6.25mm"
+              pcbY="2.5mm"
+              shape="circle"
+              holeDiameter="1.2mm"
+              outerDiameter="2.5mm"
+            />
+            <platedhole
+              portHints={["pin3"]}
+              pcbX="-6.25mm"
+              pcbY="-2.5mm"
+              shape="circle"
+              holeDiameter="1.2mm"
+              outerDiameter="2.5mm"
+            />
+            <platedhole
+              portHints={["pin4"]}
+              pcbX="6.25mm"
+              pcbY="-2.5mm"
+              shape="circle"
+              holeDiameter="1.2mm"
+              outerDiameter="2.5mm"
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+  const circuitJson = circuit.getCircuitJson()
+
+  const pcbPorts = circuitJson.filter((e: any) => e.type === "pcb_port")
+  const sourcePorts = circuitJson.filter((e: any) => e.type === "source_port")
+
+  // Every declared pin must reach the PCB, or it cannot be connected to.
+  expect(sourcePorts).toHaveLength(4)
+  expect(pcbPorts).toHaveLength(4)
+})
+
+// A pushbutton with no footprint has nothing to derive pins from and stays a
+// two-terminal schematic part.
+test("footprint-less pushbutton still has two pins", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <pushbutton name="SW1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+  const circuitJson = circuit.getCircuitJson()
+
+  expect(circuitJson.filter((e: any) => e.type === "source_port")).toHaveLength(
+    2,
+  )
+})


### PR DESCRIPTION
Hello,

Full disclosure, a LLM helped me prepare this PR but this is not a hallucinated issue. I made these designs using TSCircuit, had them printed by PCBWAY and then realised the mistake once they arrived and then had an LLM help me with the PR to fix it. I am a self admitted noob when it comes to PCB design and software. So if this PR is off the mark initially please do provide feedback and I'll be happy to learn and fix.

Here is a photo of the printed board with a bad soldering job that works around the issue :D :

<img width="1440" height="1920" alt="image" src="https://github.com/user-attachments/assets/ec62144f-9605-4025-ad6c-a45416f42170" />


## Problem

`PushButton.initPorts()` hardcodes `pinCount: 2`. A 4-leg tactile switch
therefore only ever gets two ports — pins 3 and 4 exist as copper pads in the
footprint but get no `pcb_port`, so they cannot join a net and are invisible to
connectivity analysis.

This is not theoretical: I shipped a board where both push-button ground legs
were left unrouted. The build succeeded, no DRC complained, and the buttons were
dead on arrival, because from the netlist's point of view those pads did not
exist.

The same hardcoded count also leaves the `pin3Port` / `pin4Port` lookups
`undefined` while typed non-null:

```ts
const pin3Port = ports.find((p) => p.props.pinNumber === 3)! as Port
```

which is what throws `cannot set schematicSymbolPortDef of undefined` whenever
`internallyConnectedPins` is passed to a `<pushbutton>`.

## Fix

Derive the pin count from the resolved footprint instead of hardcoding it, so a
4-leg part gets four ports and a 2-pin part gets two. With no footprint there is
nothing to derive from, so the previous 2-pin default is kept — a bare
`<pushbutton />` is still a two-terminal switch schematically.

The schematic symbol genuinely has only two terminals, and the existing loop
already maps pins 2..4 onto the symbol's second terminal; it now skips absent
pins rather than dereferencing `undefined`.

## Verification

Ports on a 4-leg tactile footprint:

| | source_ports | pcb_ports |
|---|---|---|
| before | 4 | 2 |
| after | 4 | 4 |

`pin4` goes from `pcb_port_id: null` to a real port.

Full suite, compared against a pristine checkout of the same base commit:

| | pass | fail |
|---|---|---|
| `main` (baseline) | 1376 | 25 |
| this branch | 1380 | 23 |

No regressions — and it fixes two pre-existing failures. The remaining 23 are
present on `main` too.

Adds `pushbutton-four-leg-ports.test.tsx`: a 4-leg footprint yields four ports,
and a footprint-less pushbutton still yields two.

## Related

Related to #3115 (pushbutton default internal pin connections absent) but does
not close it. That issue asks for pin1↔pin3 / pin2↔pin4 to be emitted as
internal connections; this PR does not add those. It is arguably a prerequisite,
since those pins previously did not exist to be connected.
