### PR TITLE
Update capacity autorouter to 0.0.815

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/breakout-point-solver": "github:tscircuit/breakout-point-solver#bac9629",
-    "@tscircuit/capacity-autorouter": "^0.0.803",
+    "@tscircuit/capacity-autorouter": "^0.0.815",
     "@tscircuit/checks": "^0.0.162",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

- update `@tscircuit/capacity-autorouter` from `^0.0.803` to `^0.0.815`
- keep the peer dependency unchanged because it already accepts all versions

## Why

This brings `@tscircuit/core` onto the latest published capacity autorouter release.

## Validation

- `bunx tsc --noEmit`
- `bun test tests/utils/autorouting` (34 passed)
- `bun run build`
- `bun test --timeout 30000 tests/repros/repro-bq25895-cross-net-trace-overlap.test.tsx` (1 passed)

The full `bun test` run was stopped after the BQ25895 repro exceeded the suite's default 5-second timeout; rerunning that repro with a 30-second timeout passed in 6.9 seconds.