### PR TITLE
Emit fanout solver events for debugger tracking

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -1352,14 +1352,6 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
               useLaserPrefabSolver: phaseIsLaserPrefabPreset,
               autorouterVersion,
               effort,
-              onSolverStarted: ({ solverName, solverParams }) =>
-                this.root?.emit("solver:started", {
-                  type: "solver:started",
-                  solverName,
-                  solverParams,
-                  solverConstructorArgs: [solverParams],
-                  componentName: this.getString(),
-                }),
             }
             autorouter = localAutorouterStrategy.create({
               simpleRouteJson,
@@ -1368,6 +1360,18 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
               fanoutBounds: routingPhasePlan.fanoutBounds,
               fanoutRoutingLayers: routingPhasePlan.fanoutRoutingLayers,
               componentNamesById: getPcbComponentNamesById(db),
+              onSolverStarted: ({
+                solverName,
+                solverParams,
+                solverConstructorArgs,
+              }) =>
+                this.root?.emit("solver:started", {
+                  type: "solver:started",
+                  solverName,
+                  solverParams,
+                  solverConstructorArgs,
+                  componentName: this.getString(),
+                }),
             })
           }
 

--- a/lib/solvers.ts
+++ b/lib/solvers.ts
@@ -12,6 +12,7 @@ import {
 } from "@tscircuit/capacity-autorouter"
 import { CopperPourPipelineSolver } from "@tscircuit/copper-pour-solver"
 import { CreateFdmEnclosureSolver } from "@tscircuit/create-fdm-enclosure"
+import { FanoutSolver } from "@tscircuit/fanout-solver"
 import { LayoutPipelineSolver } from "@tscircuit/matchpack"
 import { SchematicTracePipelineSolver } from "@tscircuit/schematic-trace-solver"
 import { PackSolver2 } from "calculate-packing"
@@ -31,6 +32,7 @@ export const SOLVERS = {
   AutoroutingPipelineSolver9_PreloadedTraceGraph,
   CopperPourPipelineSolver,
   CreateFdmEnclosureSolver,
+  FanoutSolver,
   SchematicTracePipelineSolver,
 }
 

--- a/lib/utils/autorouting/FanoutAutorouter.ts
+++ b/lib/utils/autorouting/FanoutAutorouter.ts
@@ -36,6 +36,11 @@ export interface FanoutAutorouterOptions {
   fanoutRoutingLayers?: string[]
   /** Used to name components in fanout failure messages. */
   componentNamesById?: ReadonlyMap<string, string>
+  onSolverStarted?: (details: {
+    solverName: "FanoutSolver"
+    solverParams: ReturnType<FanoutSolver["getConstructorParams"]>[0]
+    solverConstructorArgs: ReturnType<FanoutSolver["getConstructorParams"]>
+  }) => void
 }
 
 export interface ResolveFanoutBoundsOptions extends FanoutAutorouterOptions {
@@ -451,6 +456,12 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
           : {}),
       },
     )
+    const solverConstructorArgs = fanoutSolver.getConstructorParams()
+    this.options.onSolverStarted?.({
+      solverName: "FanoutSolver",
+      solverParams: solverConstructorArgs[0],
+      solverConstructorArgs,
+    })
     fanoutSolver.solve()
     if (fanoutSolver.failed) {
       throw new Error(

--- a/lib/utils/autorouting/localAutorouterStrategies.ts
+++ b/lib/utils/autorouting/localAutorouterStrategies.ts
@@ -3,6 +3,7 @@ import type {
   AutoroutingPhaseProps,
   PlatformConfig,
 } from "@tscircuit/props"
+import type { SolverName } from "lib/solvers"
 import {
   type AutorouterOptions,
   TscircuitAutorouter,
@@ -22,6 +23,11 @@ export interface LocalAutorouterStrategyContext {
   fanoutBounds?: SimpleRouteBounds
   fanoutRoutingLayers?: string[]
   componentNamesById?: ReadonlyMap<string, string>
+  onSolverStarted?: (details: {
+    solverName: SolverName
+    solverParams: unknown
+    solverConstructorArgs: readonly unknown[]
+  }) => void
 }
 
 export interface LocalAutorouterStrategy {
@@ -38,8 +44,15 @@ export interface LocalAutoroutingStage {
 
 const defaultLocalAutorouterStrategy: LocalAutorouterStrategy = {
   cacheable: true,
-  create: ({ simpleRouteJson, commonAutorouterOptions }) =>
-    new TscircuitAutorouter(simpleRouteJson, commonAutorouterOptions),
+  create: ({ simpleRouteJson, commonAutorouterOptions, onSolverStarted }) =>
+    new TscircuitAutorouter(simpleRouteJson, {
+      ...commonAutorouterOptions,
+      onSolverStarted: (details) =>
+        onSolverStarted?.({
+          ...details,
+          solverConstructorArgs: [details.solverParams],
+        }),
+    }),
 }
 
 const createFanoutAutorouterStrategy = (
@@ -53,6 +66,7 @@ const createFanoutAutorouterStrategy = (
     fanoutBounds,
     fanoutRoutingLayers,
     componentNamesById,
+    onSolverStarted,
   }) =>
     new FanoutAutorouter(simpleRouteJson, {
       mode,
@@ -60,6 +74,7 @@ const createFanoutAutorouterStrategy = (
       fanoutBounds,
       fanoutRoutingLayers,
       componentNamesById,
+      onSolverStarted,
     }),
 })
 

--- a/tests/breakout/fanout-breakout-routes-before-global.test.tsx
+++ b/tests/breakout/fanout-breakout-routes-before-global.test.tsx
@@ -9,9 +9,9 @@ const signalPinNumbers = [6, 7, 10, 11]
 test("fanout breakout routes signals and plane drops before global routing", async () => {
   const { circuit } = getTestFixture()
   const autoroutingPhaseIoStack = createAutoroutingPhaseIoStack(circuit)
-  const solverNames: string[] = []
+  const solverStartedEvents: SolverStartedEvent[] = []
   circuit.on("solver:started", (event: SolverStartedEvent) => {
-    solverNames.push(event.solverName)
+    solverStartedEvents.push(event)
   })
   const createBgaPads = () =>
     Array.from({ length: 16 }, (_, padIndex) => {
@@ -93,7 +93,30 @@ test("fanout breakout routes signals and plane drops before global routing", asy
   await circuit.renderUntilSettled()
 
   expect(circuit.db.pcb_autorouting_error.list()).toEqual([])
-  expect(solverNames).toContain("AutoroutingPipelineSolver7_MultiGraph")
+  expect(
+    solverStartedEvents.some(
+      (event) => event.solverName === "AutoroutingPipelineSolver7_MultiGraph",
+    ),
+  ).toBe(true)
+  const fanoutSolverEvents = solverStartedEvents.filter(
+    (event) => event.solverName === "FanoutSolver",
+  )
+  expect(fanoutSolverEvents).toHaveLength(2)
+  for (const fanoutSolverEvent of fanoutSolverEvents) {
+    expect(fanoutSolverEvent.solverParams).toMatchObject({
+      connections: expect.any(Array),
+      obstacles: expect.any(Array),
+    })
+    expect(fanoutSolverEvent.solverConstructorArgs).toEqual([
+      fanoutSolverEvent.solverParams,
+      expect.objectContaining({
+        buses: expect.any(Array),
+        borderDistribution: "even",
+        compactBusTracks: true,
+        sharedBoundary: expect.any(Object),
+      }),
+    ])
+  }
   expect(autoroutingPhaseIoStack).toHaveLength(3)
   expect(
     autoroutingPhaseIoStack.map(


### PR DESCRIPTION
## Summary

- forward solver lifecycle metadata through local fanout routing stages
- emit FanoutSolver start events with the exact input and options constructor tuple
- register FanoutSolver in the exported SOLVERS map so runframe can reconstruct it
- cover multi-breakout fanout event emission in the existing integration test

## Testing

- bun test (1416 passed, 37 skipped, 0 failed)
- bunx tsc --noEmit
- bun run build
- targeted fanout and capacity autorouter event tests