### PR TITLE
fix: skip unnamed trace warnings for net connections

### DIFF
--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -324,7 +324,7 @@ export class Trace
 
     this.source_trace_id = trace.source_trace_id
 
-    if (!props.name) {
+    if (!props.name && nets.length === 0) {
       db.source_unnamed_trace_warning.insert({
         message: `${this.getString()} is missing a name. Add a name prop to make the trace easier to identify.`,
         source_trace_id: trace.source_trace_id,

--- a/tests/components/primitive-components/source-unnamed-trace-warning-net.test.tsx
+++ b/tests/components/primitive-components/source-unnamed-trace-warning-net.test.tsx
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("net-connected trace does not emit source_unnamed_trace_warning", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <resistor name="R1" resistance="10k" footprint="0402" />
+      <trace from=".R1 > .pin1" to="net.GND" />
+    </board>,
+  )
+
+  circuit.render()
+
+  expect(circuit.db.source_trace.list()).toHaveLength(1)
+  expect(circuit.db.source_unnamed_trace_warning.list()).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary

- suppress `source_unnamed_trace_warning` when an unnamed trace resolves to a net
- preserve the warning for unnamed port-to-port traces
- add regression coverage for a trace connected to `net.GND`

## Testing

- `bun test tests/components/primitive-components/source-unnamed-trace-warning.test.tsx tests/components/primitive-components/source-unnamed-trace-warning-net.test.tsx`
- `bunx biome check lib/components/primitive-components/Trace/Trace.ts tests/components/primitive-components/source-unnamed-trace-warning-net.test.tsx`
- `bunx tsc --noEmit`
