### PR TITLE
Add RunFrame autorouter constructor args repro

### DIFF
--- a/tests/utils/autorouting/default-autorouter-solver-constructor-args-repro.test.ts
+++ b/tests/utils/autorouting/default-autorouter-solver-constructor-args-repro.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { SOLVERS } from "lib/solvers"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+import { getLocalAutorouterStrategy } from "lib/utils/autorouting/localAutorouterStrategies"
+
+test.failing(
+  "default autorouter emits constructor args that RunFrame can replay",
+  () => {
+    const simpleRouteJson: SimpleRouteJson = {
+      layerCount: 2,
+      minTraceWidth: 0.15,
+      obstacles: [],
+      connections: [],
+      bounds: { minX: -1, maxX: 1, minY: -1, maxY: 1 },
+    }
+    const strategy = getLocalAutorouterStrategy("default")
+
+    strategy.create({
+      simpleRouteJson,
+      commonAutorouterOptions: {},
+      onSolverStarted: ({ solverName, solverConstructorArgs }) => {
+        const SolverClass = SOLVERS[solverName] as new (
+          ...args: any[]
+        ) => unknown
+
+        expect(() => new SolverClass(...solverConstructorArgs)).not.toThrow()
+      },
+    })
+  },
+)


### PR DESCRIPTION
## Summary

- add a focused expected-failing test for replaying the default autorouter's emitted constructor arguments
- reconstruct the registered solver exactly as RunFrame does
- keep the change repro-only, with no production-code fix

## Reproduction

The default local autorouter strategy emits:

```ts
solverConstructorArgs: [details.solverParams]
```

For the capacity autorouter, `solverParams` is the wrapper `{ input, options }`. RunFrame prefers `solverConstructorArgs` and therefore calls the solver with that wrapper as argument 1 instead of calling it with `input, options`.

`AutoroutingPipelineSolver7_MultiGraph` then treats the wrapper as `SimpleRouteJson` and fails while evaluating `srj.obstacles.map(...)`.

The new `test.failing` exercises the real `defaultLocalAutorouterStrategy`, captures its emitted constructor tuple, and passes that tuple to the registered solver constructor. It will become an unexpected pass once the emitted tuple is reconstructable.

## Regression source

This behavior was introduced in https://github.com/tscircuit/core/pull/3277 when the default autorouter adapter began forwarding `solverConstructorArgs: [details.solverParams]`.

The corresponding RunFrame replay support was added in https://github.com/tscircuit/runframe/pull/4617.

## Impact

After a successful online autoroute, opening **RunFrame → Solvers** and selecting `AutoroutingPipelineSolver7_MultiGraph` shows:

```text
Failed to instantiate solver: Cannot read properties of undefined (reading 'map')
```

The PCB autorouting itself completes; only solver reconstruction in the debugger fails.

## Validation

- `bun test tests/utils/autorouting/default-autorouter-solver-constructor-args-repro.test.ts`
- `bunx tsc --noEmit`
- `bunx biome check tests/utils/autorouting/default-autorouter-solver-constructor-args-repro.test.ts`
