### PR TITLE
Route parent connections through routed child traces

### DIFF
--- a/lib/utils/autorouting/SimpleRouteJson.ts
+++ b/lib/utils/autorouting/SimpleRouteJson.ts
@@ -2,7 +2,7 @@ import type {
   SimpleRouteJson as AutorouterSimpleRouteJson,
   SimplifiedPcbTrace as AutorouterSimplifiedPcbTrace,
 } from "@tscircuit/capacity-autorouter"
-import type { PcbGroup } from "circuit-json"
+import type { PcbGroup, PcbTrace, SourceTrace } from "circuit-json"
 import type { CircuitJsonMetadata, Obstacle } from "../obstacles/types"
 
 export type { CircuitJsonMetadata, Obstacle } from "../obstacles/types"
@@ -21,6 +21,8 @@ export type SimplifiedPcbTrace = Omit<
 > & {
   type: "pcb_trace"
   pcb_trace_id: string
+  source_trace_id?: SourceTrace["source_trace_id"]
+  subcircuit_id?: PcbTrace["subcircuit_id"]
   connection_name?: string
   connectsTo?: string[]
   route: Array<

--- a/lib/utils/autorouting/addPreservedTraceConnectionPointsToConnections.ts
+++ b/lib/utils/autorouting/addPreservedTraceConnectionPointsToConnections.ts
@@ -1,0 +1,107 @@
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type {
+  SimpleRouteConnection,
+  SimplifiedPcbTrace,
+} from "./SimpleRouteJson"
+import { getPreservedTraceConnectionPoints } from "./getPreservedRoutedSubcircuitTraces"
+
+const getElectricalConnectivityKeys = ({
+  ids,
+  connMap,
+}: {
+  ids: Array<string | undefined>
+  connMap: ConnectivityMap
+}) =>
+  new Set(
+    ids
+      .map((id) => (id ? connMap.getNetConnectedToId(id) : null))
+      .filter((id): id is string => Boolean(id)),
+  )
+
+/**
+ * Adds points sampled along electrically matching preserved traces to parent
+ * connections. The sampled IDs are already in each trace's `connectsTo`, so
+ * the autorouter can choose any of them as an existing-copper attachment.
+ */
+export const addPreservedTraceConnectionPointsToConnections = ({
+  connections,
+  preservedTraces,
+  connMap,
+  excludedConnectionPointIds = new Set(),
+}: {
+  connections: SimpleRouteConnection[]
+  preservedTraces: SimplifiedPcbTrace[]
+  connMap: ConnectivityMap
+  /**
+   * Connections containing one of these points already have an explicit
+   * child/parent handoff and must not attach to the child trace elsewhere.
+   */
+  excludedConnectionPointIds?: ReadonlySet<string>
+}): void => {
+  const connectionsByElectricalKey = new Map<string, SimpleRouteConnection[]>()
+  for (const connection of connections) {
+    if (
+      connection.pointsToConnect.some(
+        (point) =>
+          point.pointId && excludedConnectionPointIds.has(point.pointId),
+      )
+    ) {
+      continue
+    }
+
+    const electricalKeys = getElectricalConnectivityKeys({
+      ids: [
+        connection.name,
+        connection.source_trace_id,
+        ...connection.pointsToConnect.flatMap((point) => [
+          point.pointId,
+          point.pcb_port_id,
+        ]),
+      ],
+      connMap,
+    })
+    for (const electricalKey of electricalKeys) {
+      const matchingConnections =
+        connectionsByElectricalKey.get(electricalKey) ?? []
+      matchingConnections.push(connection)
+      connectionsByElectricalKey.set(electricalKey, matchingConnections)
+    }
+  }
+
+  for (const trace of preservedTraces) {
+    const electricalKeys = getElectricalConnectivityKeys({
+      ids: [
+        trace.pcb_trace_id,
+        trace.source_trace_id,
+        trace.connection_name,
+        ...(trace.connectsTo ?? []),
+      ],
+      connMap,
+    })
+    const matchingConnections = new Set(
+      Array.from(electricalKeys).flatMap(
+        (electricalKey) => connectionsByElectricalKey.get(electricalKey) ?? [],
+      ),
+    )
+    if (matchingConnections.size === 0) continue
+
+    const traceConnectionPoints = getPreservedTraceConnectionPoints(trace)
+    trace.connectsTo ??= []
+    trace.connectsTo.push(
+      ...traceConnectionPoints.map((point) => point.pointId),
+    )
+
+    for (const connection of matchingConnections) {
+      const existingPointIds = new Set(
+        connection.pointsToConnect.flatMap((point) =>
+          point.pointId ? [point.pointId] : [],
+        ),
+      )
+      for (const point of traceConnectionPoints) {
+        if (existingPointIds.has(point.pointId)) continue
+        existingPointIds.add(point.pointId)
+        connection.pointsToConnect.push(point)
+      }
+    }
+  }
+}

--- a/lib/utils/autorouting/getPreservedRoutedSubcircuitTraces.ts
+++ b/lib/utils/autorouting/getPreservedRoutedSubcircuitTraces.ts
@@ -1,6 +1,6 @@
 import type { CircuitJsonUtilObjects } from "@tscircuit/circuit-json-util"
 import type { LayerRef, PcbTrace } from "circuit-json"
-import type { SimplifiedPcbTrace } from "./SimpleRouteJson"
+import type { SimpleRoutePoint, SimplifiedPcbTrace } from "./SimpleRouteJson"
 
 type PreservedTrace = PcbTrace & {
   connection_name?: string
@@ -9,6 +9,102 @@ type PreservedTrace = PcbTrace & {
 
 const getLayerName = (layer: LayerRef | { name: string }): string =>
   typeof layer === "string" ? layer : layer.name
+
+const PRESERVED_TRACE_CONNECTION_POINT_SPACING_MM = 0.5
+
+type WireRoutePoint = Extract<
+  SimplifiedPcbTrace["route"][number],
+  { route_type: "wire" }
+>
+
+export type PreservedTraceConnectionPoint = SimpleRoutePoint & {
+  pointId: string
+}
+
+const getConnectionPointKey = (point: {
+  x: number
+  y: number
+  layer: string
+}) => `${point.x.toFixed(6)}:${point.y.toFixed(6)}:${point.layer}`
+
+/**
+ * Samples legal parent-connection attachment points along already-routed child
+ * copper. Each point receives a stable ID that is also placed in the
+ * preserved trace's `connectsTo` array, allowing the autorouter's MST to treat
+ * the sampled points as alternative contacts on the same copper rather than
+ * terminals that all need new routes.
+ */
+export const getPreservedTraceConnectionPoints = (
+  trace: Pick<SimplifiedPcbTrace, "pcb_trace_id" | "route">,
+): PreservedTraceConnectionPoint[] => {
+  const sampledPoints: Array<{ x: number; y: number; layer: string }> = []
+  const sampledPointKeys = new Set<string>()
+
+  const addPoint = (point: { x: number; y: number; layer: string }) => {
+    const key = getConnectionPointKey(point)
+    if (sampledPointKeys.has(key)) return
+    sampledPointKeys.add(key)
+    sampledPoints.push(point)
+  }
+
+  let previousWirePoint: WireRoutePoint | undefined
+  for (const routePoint of trace.route) {
+    if (routePoint.route_type === "wire") {
+      if (previousWirePoint?.layer === routePoint.layer) {
+        const dx = routePoint.x - previousWirePoint.x
+        const dy = routePoint.y - previousWirePoint.y
+        const segmentLength = Math.hypot(dx, dy)
+        const segmentCount = Math.max(
+          1,
+          Math.ceil(
+            segmentLength / PRESERVED_TRACE_CONNECTION_POINT_SPACING_MM,
+          ),
+        )
+        for (
+          let segmentIndex = 0;
+          segmentIndex < segmentCount;
+          segmentIndex++
+        ) {
+          const t = segmentIndex / segmentCount
+          addPoint({
+            x: previousWirePoint.x + dx * t,
+            y: previousWirePoint.y + dy * t,
+            layer: routePoint.layer,
+          })
+        }
+      }
+      addPoint({
+        x: routePoint.x,
+        y: routePoint.y,
+        layer: routePoint.layer,
+      })
+      previousWirePoint = routePoint
+      continue
+    }
+
+    if (routePoint.route_type === "via") {
+      addPoint({
+        x: routePoint.x,
+        y: routePoint.y,
+        layer: routePoint.from_layer,
+      })
+      addPoint({
+        x: routePoint.x,
+        y: routePoint.y,
+        layer: routePoint.to_layer,
+      })
+    } else if (routePoint.route_type === "through_obstacle") {
+      addPoint({ ...routePoint.start, layer: routePoint.from_layer })
+      addPoint({ ...routePoint.end, layer: routePoint.to_layer })
+    }
+    previousWirePoint = undefined
+  }
+
+  return sampledPoints.map((point, pointIndex) => ({
+    ...point,
+    pointId: `pcb_trace_route_point_${trace.pcb_trace_id}_${pointIndex}`,
+  }))
+}
 
 const getPreservedTraceConnectionName = (trace: PreservedTrace) =>
   trace.source_trace_id ?? trace.connection_name ?? trace.pcb_trace_id
@@ -97,13 +193,15 @@ export const getPreservedRoutedSubcircuitTraces = ({
     .map((trace) => {
       const preservedTrace = trace as PreservedTrace
       const connectionName = getPreservedTraceConnectionName(preservedTrace)
-      return {
+      const simplifiedTrace: SimplifiedPcbTrace = {
         type: "pcb_trace" as const,
         pcb_trace_id: trace.pcb_trace_id,
         source_trace_id: trace.source_trace_id,
+        subcircuit_id: trace.subcircuit_id,
         connection_name: connectionName,
         connectsTo: getPhysicalConnectionIdsForPreservedTrace(preservedTrace),
         route: getSimpleRouteForPreservedTrace(preservedTrace),
       }
+      return simplifiedTrace
     })
     .filter((trace) => trace.route.length >= 2)

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -21,6 +21,7 @@ import type {
   SimpleRouteJson,
   SimpleRoutePoint,
 } from "./SimpleRouteJson"
+import { addPreservedTraceConnectionPointsToConnections } from "./addPreservedTraceConnectionPointsToConnections"
 import { expandSrjBoundsToIncludeConnectionPoints } from "./expand-srj-bounds-to-include-connection-points"
 import { getDescendantSubcircuitIds } from "./getAncestorSubcircuitIds"
 import {
@@ -736,6 +737,27 @@ export const getSimpleRouteJsonFromCircuitJson = ({
     conn.width ??= nominalTraceWidth ?? defaultTraceWidth
   }
 
+  // Child subcircuits route first. Give each electrically matching parent
+  // connection many possible attachment points along that preserved copper.
+  // The matching point IDs are also present in the preserved trace's
+  // `connectsTo`, so the router knows they are alternatives on an existing
+  // route rather than additional terminals that all need to be connected.
+  addPreservedTraceConnectionPointsToConnections({
+    connections: allConns,
+    preservedTraces: preservedRoutedSubcircuitTraces.filter(
+      (trace) =>
+        Boolean(trace.source_trace_id) &&
+        (!subcircuit_id || trace.subcircuit_id !== subcircuit_id),
+    ),
+    connMap: sharedConnMap,
+    // A breakout point is an explicit child/parent boundary. Connections that
+    // contain one must keep using that boundary instead of bypassing it via an
+    // interior point sampled from the child trace.
+    excludedConnectionPointIds: new Set(
+      breakoutPoints.map((point) => point.pcb_breakout_point_id),
+    ),
+  })
+
   bounds = expandSrjBoundsToIncludeConnectionPoints({
     bounds,
     connections: allConns,
@@ -761,39 +783,6 @@ export const getSimpleRouteJsonFromCircuitJson = ({
     subcircuitId: subcircuit_id,
     planeTerminatedSourceTraceLayers,
   })
-
-  if (subcircuit_id) {
-    const pointIdToConn = new Map<string, SimpleRouteConnection>()
-    for (const conn of allConns) {
-      for (const pt of conn.pointsToConnect) {
-        if (pt.pointId) pointIdToConn.set(pt.pointId, conn)
-      }
-    }
-
-    const existingTraces = db.pcb_trace.list().filter((t) => {
-      return relevantSubcircuitIds?.has(t.subcircuit_id!)
-    })
-
-    for (const tr of existingTraces) {
-      const tracePortIds = new Set<string>()
-      for (const seg of tr.route as any[]) {
-        if (seg.start_pcb_port_id) tracePortIds.add(seg.start_pcb_port_id)
-        if (seg.end_pcb_port_id) tracePortIds.add(seg.end_pcb_port_id)
-      }
-      if (tracePortIds.size < 2) continue
-
-      const firstId = tracePortIds.values().next().value
-      if (!firstId) continue
-      const conn = pointIdToConn.get(firstId)
-      if (!conn) continue
-      if (![...tracePortIds].every((pid) => pointIdToConn.get(pid) === conn)) {
-        continue
-      }
-
-      conn.externallyConnectedPointIds ??= []
-      conn.externallyConnectedPointIds.push([...tracePortIds])
-    }
-  }
 
   const resolvedMinViaHoleDiameter =
     minViaHoleDiameter ?? board?.min_via_hole_diameter

--- a/tests/breakout/default-breakout-one-point-net.test.tsx
+++ b/tests/breakout/default-breakout-one-point-net.test.tsx
@@ -68,6 +68,11 @@ test("parent net routing uses the child breakout point", async () => {
   expect(parentNetConnection!.pointsToConnect).not.toContainEqual(
     expect.objectContaining({ pcb_port_id: innerPcbPort?.pcb_port_id }),
   )
+  expect(
+    parentNetConnection!.pointsToConnect.some((point) =>
+      point.pointId?.startsWith("pcb_trace_route_point_"),
+    ),
+  ).toBe(false)
   expect(onePointConnections).toEqual([])
   expect(circuit.db.pcb_autorouting_error.list()).toEqual([])
   expect(circuit.db.pcb_trace_error.list()).toEqual([])

--- a/tests/fixtures/get-test-autorouting-server.tsx
+++ b/tests/fixtures/get-test-autorouting-server.tsx
@@ -1,8 +1,27 @@
 import { serve } from "bun"
 import { afterEach } from "bun:test"
 import { MultilayerIjump } from "@tscircuit/infgrid-ijump-astar"
+import { TscircuitAutorouter } from "lib/utils/autorouting/CapacityMeshAutorouter"
 import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
 import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+
+const solveSimpleRouteJson = (simpleRouteJson: SimpleRouteJson) => {
+  // The legacy A* test router only accepts two-terminal connections. Use the
+  // production capacity router when the input exercises SRJ multi-terminal or
+  // preconnected-point semantics.
+  if (
+    simpleRouteJson.connections.some(
+      (connection) => connection.pointsToConnect.length > 2,
+    )
+  ) {
+    return new TscircuitAutorouter(simpleRouteJson).solveSync()
+  }
+
+  return new MultilayerIjump({
+    input: simpleRouteJson,
+    OBSTACLE_MARGIN: 0.2,
+  }).solveAndMapToTraces()
+}
 
 export const getTestAutoroutingServer = ({
   requireDisplayName = false,
@@ -50,12 +69,7 @@ export const getTestAutoroutingServer = ({
           )
         }
 
-        const autorouter = new MultilayerIjump({
-          input: simpleRouteJson,
-          OBSTACLE_MARGIN: 0.2,
-        })
-
-        const traces = autorouter.solveAndMapToTraces()
+        const traces = solveSimpleRouteJson(simpleRouteJson)
 
         // Simulate failure in the first trace if the flag is set
         if (failInFirstTrace && traces.length > 0) {
@@ -107,12 +121,7 @@ export const getTestAutoroutingServer = ({
           circuitJson: body.input_circuit_json,
         })
 
-        const autorouter = new MultilayerIjump({
-          input: simpleRouteJson as any,
-          OBSTACLE_MARGIN: 0.2,
-        })
-
-        const traces = autorouter.solveAndMapToTraces()
+        const traces = solveSimpleRouteJson(simpleRouteJson)
 
         // Simulate failure in the first trace if the flag is set
         if (failInFirstTrace && traces.length > 0) {

--- a/tests/repros/__snapshots__/repro-rp2040-subcircuit-autorouting-slowdown-srj.snap.svg
+++ b/tests/repros/__snapshots__/repro-rp2040-subcircuit-autorouting-slowdown-srj.snap.svg
@@ -319,7 +319,7 @@ top" data-x="0" data-y="0" cx="403.5784708156924" cy="306.6456730911779" r="3" f
     font-size="18"
     font-weight="700"
     text-anchor="middle"
-  >AUTOROUTING PHASE 2 START: 47 CONNECTIONS, 20 TRACES</text>
+  >AUTOROUTING PHASE 2 START: 48 CONNECTIONS, 20 TRACES</text>
   </g>
   <g transform="translate(0, 36) scale(1, 1) translate(0, 0)">
     <rect width="100%" height="100%" fill="#fff"/><g><polyline data-points="6.01,3 6.01,5.2" data-type="line" data-label="" points="448.95635673624287,239.40543959519295 448.95635673624287,217.1410499683745" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,5.2 5.01,6.2 3.21,6.2" data-type="line" data-label="" points="448.95635673624287,217.1410499683745 438.83617963314356,207.02087286527518 420.61986084756484,207.02087286527518" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,3 -5.529646512479694,3.5396465124796936 -6.455000999999999,3.5396465124796936 -6.455000999999999,1.465000999999999 -4.99,0" data-type="line" data-label="" points="337.63440860215053,239.40543959519295 332.17309032278615,233.94412131582857 322.8083390259329,233.94412131582857 322.8083390259329,254.9399013282733 337.63440860215053,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,0 -4.99,-3" data-type="line" data-label="" points="337.63440860215053,269.76597090449087 337.63440860215053,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,-3 6.01,0" data-type="line" data-label="" points="448.95635673624287,300.1265022137888 448.95635673624287,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,0 6.01,3" data-type="line" data-label="" points="448.95635673624287,269.76597090449087 448.95635673624287,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,-3 -5.43500637465368,-3.44500637465368 -5.43500637465368,-4.047838102925986" data-type="line" data-label="" points="337.63440860215053,300.1265022137888 333.1308652786471,304.6300455372922 333.1308652786471,310.73080939077533" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-5.43500637465368,-4.047838102925986 -5.4245847631116435,-4.058259714468022 -4.486844477579665,-4.996 -1.024,-4.996" data-type="line" data-label="" points="333.1308652786471,310.73080939077533 333.23633383315223,310.8362779452805 342.72643159944676,320.326375711575 377.77103099304236,320.326375711575" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-1.024,-4.996 -1.0565206313402955,-5.028520631340296 -1.218231781216708,-5.028520631340296 -1.8897111498764123,-5.7 -2.1900000000000004,-5.7" data-type="line" data-label="" points="377.77103099304236,320.326375711575 377.441916444374,320.65549026024337 375.8053709680788,320.65549026024337 369.00988083616534,327.4509803921569 365.97090449082856,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,-3 3.3099999999999996,-5.7 3.21,-5.7" data-type="line" data-label="" points="448.95635673624287,300.1265022137888 421.63187855787476,327.4509803921569 420.61986084756484,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,0 -4.893,0.097 -4.302,0.097" data-type="line" data-label="" points="337.63440860215053,269.76597090449087 338.6160657811512,268.7843137254902 344.5970904490828,268.7843137254902" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.302,0.097 -4.288943945821694,0.11005605417830638 -4.286,0.113 -2.275,0.113" data-type="line" data-label="" points="344.5970904490828,268.7843137254902 344.729220029635,268.65218414493813 344.75901328273244,268.62239089184067 365.11068943706516,268.62239089184067" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-2.275,0.113 -2.244249772519263,0.08224977251926317 -2.2158546998677835,0.08224977251926317 -2.1336049273485203,0 0,0" data-type="line" data-label="" points="365.11068943706516,268.62239089184067 365.4218871851308,268.9335886399063 365.70925034921913,268.9335886399063 366.5416326138037,269.76597090449087 388.13409234661606,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-2.1900000000000004,-5.7 -1.6949990000000001,-6.195001 3.205601519423781,-6.195001 3.205601519423781,-5.704398480576219 3.21,-5.7" data-type="line" data-label="" points="365.97090449082856,327.4509803921569 370.98040227703984,332.4604781783682 420.57534744514896,332.4604781783682 420.57534744514896,327.4954937945728 420.61986084756484,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.6001499999999997,3.42505 0.6000000000000001,4.609999999999999 2.1900000000000004,6.2" data-type="line" data-label="" points="394.2077166350411,235.1038583175206 394.20619860847563,223.11195445920308 410.29728020240356,207.02087286527518" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="2.60065,3.42505 4.376,5.2 4.99,5.2" data-type="line" data-label="" points="414.45313092979126,235.1038583175206 432.41998734977864,217.1410499683745 438.6337760910816,217.1410499683745" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-0.20005000000000006,3.42505 -0.13950168668368562,3.3645016866836857 -0.13950168668368562,2.9535032821423663 0.3194245814319227,2.494577014026758 0.8592828639703756,2.494577014026758 1.912,1.4418598779971337 1.912,0.183" data-type="line" data-label="" points="386.10955091714106,235.1038583175206 386.7223105711961,235.71661797157566 386.7223105711961,239.87599461462506 391.36672568179046,244.52040972521945 396.83018711165465,244.52040972521945 407.48387096774195,255.17409358130672 407.48387096774195,267.9139784946237" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="1.912,0.183 1.9436380797842585,0.1513619202157414 1.9436380797842585,0.040008943074291245 -0.22,-2.123629136709967 -0.22,-4.88" data-type="line" data-label="" points="407.48387096774195,267.9139784946237 407.8040539383606,268.2341614652424 407.8040539383606,269.36107331487125 385.9076533839342,291.2574738692976 385.9076533839342,319.15243516761547" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-0.22,-4.88 -0.21318894664096233,-4.873188946640962 0.6136221067180759,-5.7 2.1900000000000004,-5.7" data-type="line" data-label="" points="385.9076533839342,319.15243516761547 385.97658245018636,319.08350610136335 394.3440567409799,327.4509803921569 410.29728020240356,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.6001500000000002,-3.42505 0.6001500000000002,-3.877755644979012 0.2132985229154284,-4.264607122063584 0.014999959211144831,-4.4629056857678675 -1.9729056857678664,-4.4629056857678675 -3.21,-5.7" data-type="line" data-label="" points="394.2077166350411,304.42808349146117 394.2077166350411,309.00954479422154 390.2927111743497,312.92455025491296 388.2858945903721,314.93136683889054 368.16793739893365,314.93136683889054 355.6483238456673,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.20005000000000006,3.42505 0.2,3.425 0.2,4.168" data-type="line" data-label="" points="390.15863377609105,235.1038583175206 390.1581277672359,235.10436432637576 390.1581277672359,227.58507273877296" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.2,4.168 0.27936590381920134,4.088634096180799 0.27936590381920134,3.987284978680325 0.9416508824995262,3.325 3.504,3.325" data-type="line" data-label="" points="390.1581277672359,227.58507273877296 390.96132476983377,228.38826974137083 390.96132476983377,229.41394075971846 397.663766046801,236.11638203668568 423.595192915876,236.11638203668568" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="3.504,3.325 3.57064426757843,3.2583557324215704 3.597101639481161,3.2583557324215704 3.855457371902731,3 4.99,3" data-type="line" data-label="" points="423.595192915876,236.11638203668568 424.26964470667605,236.79083382748573 424.53739799601425,236.79083382748573 427.1520037637215,239.40543959519295 438.6337760910816,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="3.42495,2.60065 3.4908956959818003,2.5351043040181995 3.8971994246110677,2.5351043040181995 4.99,1.442303728629267 4.99,0" data-type="line" data-label="" points="422.79519291587604,243.44693232131567 423.462575038399,244.1102663729974 427.57444072977677,244.1102663729974 438.6337760910816,255.1696017343022 438.6337760910816,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="3.42495,-1.0002499999999999 3.42586277369945,-1.0008627736994502 3.9241425465514554,-1.0008627736994502 4.99,-2.0667202271479947 4.99,-3" data-type="line" data-label="" points="422.79519291587604,279.88867805186595 422.8044303473695,279.8948794302285 427.8471098955239,279.8948794302285 438.6337760910816,290.6815456257862 438.6337760910816,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.20005000000000006,-3.42505 0.20005000000000006,-3.816510276013182 -0.05328439803899088,-4.069844674052173 -4.786964793197829,-4.069844674052173 -5.273849820226906,-4.55672970108125 -5.504757750627475,-4.55672970108125 -5.8704683410416765,-4.191019110667049 -5.8704683410416765,-3.1395316589583233 -6.01,-3" data-type="line" data-label="" points="390.15863377609105,304.42808349146117 390.15863377609105,308.38973081354266 387.59484480162945,310.9535197880043 339.6891608531529,310.9535197880043 334.7617981507713,315.8808824903859 332.42496900060746,315.8808824903859 328.7239130571367,312.17982654691514 328.7239130571367,301.53858731393626 327.31182795698925,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-3.42495,-1.0002500000000003 -3.9705639153548153,-1.0002500000000003 -4.115023392569576,-0.8557905227852396 -4.14420947721476,-0.8557905227852396 -4.2,-0.8" data-type="line" data-label="" points="353.47299177735607,279.88867805186595 347.95128232404994,279.88867805186595 346.4893268304154,278.42672255823146 346.1939584848601,278.42672255823146 345.629348513599,277.86211258697034" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.2,-0.8 -5.353921230245549,-0.8 -5.421178286452751,-0.732742943792798 -5.476257056207201,-0.732742943792798 -5.52,-0.689" data-type="line" data-label="" points="345.629348513599,277.86211258697034 333.9514613004878,277.86211258697034 333.2708079802378,277.1814592667203 332.71340107570194,277.1814592667203 332.2707147375079,276.7387729285263" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-5.52,-0.689 -5.52,-0.4900000000000002 -6.01,0" data-type="line" data-label="" points="332.2707147375079,276.7387729285263 332.2707147375079,274.7248576850095 327.31182795698925,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-3.42495,2.60065 -4.332948259642237,2.60065 -4.574662324196864,2.3589359354453725 -5.368935935445372,2.3589359354453725 -6.01,3" data-type="line" data-label="" points="353.47299177735607,243.44693232131567 344.2838885804707,243.44693232131567 341.8376994388679,245.8931214629185 333.79950982471473,245.8931214629185 327.31182795698925,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><rect data-type="rect" data-label="top" data-x="-3.42495" data-y="2.60065" x="349.17191650853886" y="242.43491461100575" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -339,11 +339,11 @@ source_trace_33" data-x="-2.60065" data-y="-3.42505" x="360.80303605313094" y="3
 source_trace_34" data-x="-2.20055" data-y="-3.42505" x="364.852118912081" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_35" data-x="-1.8004499999999999" data-y="-3.42505" x="368.90120177103097" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_36" data-x="-1.40035" data-y="-3.42505" x="372.950284629981" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-1.0002499999999999" data-y="-3.42505" x="376.99936748893106" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_64" data-x="-0.6001499999999997" data-y="-3.42505" x="381.0484503478811" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_65" data-x="-0.20005000000000006" data-y="-3.42505" x="385.09753320683114" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.20005000000000006" data-y="-3.42505" x="389.14661606578113" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.6001500000000002" data-y="-3.42505" x="393.1956989247312" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_57" data-x="1.0002500000000003" data-y="-3.42505" x="397.2447817836812" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_58" data-x="1.4003500000000004" data-y="-3.42505" x="401.29386464263126" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_59" data-x="1.8004500000000005" data-y="-3.42505" x="405.3429475015813" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_65" data-x="-0.6001499999999997" data-y="-3.42505" x="381.0484503478811" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_66" data-x="-0.20005000000000006" data-y="-3.42505" x="385.09753320683114" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.20005000000000006" data-y="-3.42505" x="389.14661606578113" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.6001500000000002" data-y="-3.42505" x="393.1956989247312" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_58" data-x="1.0002500000000003" data-y="-3.42505" x="397.2447817836812" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_59" data-x="1.4003500000000004" data-y="-3.42505" x="401.29386464263126" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_60" data-x="1.8004500000000005" data-y="-3.42505" x="405.3429475015813" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_37" data-x="2.20055" data-y="-3.42505" x="409.3920303605313" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_38" data-x="2.60065" data-y="-3.42505" x="413.44111321948134" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_39" data-x="3.42495" data-y="-2.60065" x="418.49411764705883" y="295.07299177735615" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -356,18 +356,20 @@ source_trace_45" data-x="3.42495" data-y="0.20005000000000006" x="418.4941176470
 source_trace_46" data-x="3.42495" data-y="0.6001500000000002" x="418.49411764705883" y="262.6803289057559" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_47" data-x="3.42495" data-y="1.0002500000000003" x="418.49411764705883" y="258.63124604680587" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_48" data-x="3.42495" data-y="1.4003500000000004" x="418.49411764705883" y="254.58216318785583" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_55" data-x="3.42495" data-y="1.8004500000000005" x="418.49411764705883" y="250.53308032890578" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_56" data-x="3.42495" data-y="2.20055" x="418.49411764705883" y="246.48399746995574" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.42495" data-y="2.60065" x="418.49411764705883" y="242.43491461100575" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.60065" data-y="3.42505" x="413.44111321948134" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_66" data-x="2.20055" data-y="3.42505" x="409.3920303605313" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_67" data-x="1.8004499999999999" data-y="3.42505" x="405.3429475015813" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_60" data-x="1.40035" data-y="3.42505" x="401.29386464263126" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_62" data-x="1.0002499999999999" data-y="3.42505" x="397.2447817836812" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.6001499999999997" data-y="3.42505" x="393.1956989247312" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.20005000000000006" data-y="3.42505" x="389.14661606578113" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-0.20005000000000006" data-y="3.42505" x="385.09753320683114" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_56" data-x="3.42495" data-y="1.8004500000000005" x="418.49411764705883" y="250.53308032890578" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_57" data-x="3.42495" data-y="2.20055" x="418.49411764705883" y="246.48399746995574" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.42495" data-y="2.60065" x="418.49411764705883" y="242.43491461100575" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.60065" data-y="3.42505" x="413.44111321948134" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_67" data-x="2.20055" data-y="3.42505" x="409.3920303605313" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_68" data-x="1.8004499999999999" data-y="3.42505" x="405.3429475015813" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_61" data-x="1.40035" data-y="3.42505" x="401.29386464263126" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_63" data-x="1.0002499999999999" data-y="3.42505" x="397.2447817836812" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.6001499999999997" data-y="3.42505" x="393.1956989247312" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55" data-x="0.20005000000000006" data-y="3.42505" x="389.14661606578113" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-0.20005000000000006" data-y="3.42505" x="385.09753320683114" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_54" data-x="-0.6001500000000002" data-y="3.42505" x="381.0484503478811" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_53" data-x="-1.0002500000000003" data-y="3.42505" x="376.99936748893106" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_52" data-x="-1.4003500000000004" data-y="3.42505" x="372.950284629981" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_51" data-x="-1.8004500000000005" data-y="3.42505" x="368.90120177103097" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_50" data-x="-2.20055" data-y="3.42505" x="364.852118912081" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_49" data-x="-2.60065" data-y="3.42505" x="360.80303605313094" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0" data-y="0" x="372.44781783681213" y="254.07969639468695" width="31.372549019607845" height="31.372549019607845" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="3" x="324.5793801391525" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="3" x="334.9019607843137" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="0" x="324.5793801391525" y="266.5275142314991" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="0" x="334.9019607843137" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="-3" x="324.5793801391525" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="-3" x="334.9019607843137" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="-3" x="435.90132827324476" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="-3" x="446.2239089184061" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="0" x="435.90132827324476" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="0" x="446.2239089184061" y="266.5275142314991" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="3" x="435.90132827324476" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="3" x="446.2239089184061" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-3.21" data-y="-5.7" x="352.91587602783045" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-2.1900000000000004" data-y="-5.7" x="363.2384566729918" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.1900000000000004" data-y="-5.7" x="407.5648323845668" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.21" data-y="-5.7" x="417.887413029728" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="5.2" x="435.90132827324476" y="213.9025932953827" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="5.2" x="446.2239089184061" y="213.9025932953827" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.1900000000000004" data-y="6.2" x="407.5648323845668" y="203.7824161922834" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.21" data-y="6.2" x="417.887413029728" y="203.7824161922834" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_49" data-x="-2.60065" data-y="3.42505" x="360.80303605313094" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0" data-y="0" x="372.44781783681213" y="254.07969639468695" width="31.372549019607845" height="31.372549019607845" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="3" x="324.5793801391525" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="3" x="334.9019607843137" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="0" x="324.5793801391525" y="266.5275142314991" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="0" x="334.9019607843137" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="-3" x="324.5793801391525" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="-3" x="334.9019607843137" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="-3" x="435.90132827324476" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="-3" x="446.2239089184061" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="0" x="435.90132827324476" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="0" x="446.2239089184061" y="266.5275142314991" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55" data-x="4.99" data-y="3" x="435.90132827324476" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="3" x="446.2239089184061" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-3.21" data-y="-5.7" x="352.91587602783045" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-2.1900000000000004" data-y="-5.7" x="363.2384566729918" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.1900000000000004" data-y="-5.7" x="407.5648323845668" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.21" data-y="-5.7" x="417.887413029728" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="5.2" x="435.90132827324476" y="213.9025932953827" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="5.2" x="446.2239089184061" y="213.9025932953827" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.1900000000000004" data-y="6.2" x="407.5648323845668" y="203.7824161922834" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.21" data-y="6.2" x="417.887413029728" y="203.7824161922834" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_21" data-x="-34.25" data-y="10.775" x="40" y="153.38393421884888" width="3.0360531309297585" height="14.674256799493975" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_22" data-x="-33.75" data-y="10.775" x="45.060088551549654" y="153.38393421884888" width="3.0360531309297585" height="14.674256799493975" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_23" data-x="-33.25" data-y="10.775" x="50.12017710309931" y="153.38393421884888" width="3.0360531309297585" height="14.674256799493975" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -391,22 +393,23 @@ source_trace_50" data-x="18.85" data-y="18.635" x="573.8393421884884" y="78.1404
 source_trace_51" data-x="18.85" data-y="17.365" x="573.8393421884884" y="90.99304237824164" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="18.85" data-y="16.095" x="573.8393421884884" y="103.84566729917778" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_52" data-x="23.15" data-y="16.095" x="617.3561037318152" y="103.84566729917778" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_53" data-x="23.15" data-y="17.365" x="617.3561037318152" y="90.99304237824164" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_54" data-x="23.15" data-y="18.635" x="617.3561037318152" y="78.14041745730552" width="10.120177103099309" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="23.15" data-y="19.905" x="617.3561037318152" y="65.2877925363694" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_55" data-x="27.095" data-y="-19.15" x="659.3042378241619" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_56" data-x="28.365" data-y="-19.15" x="672.1568627450981" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_61" data-x="29.635" data-y="-19.15" x="685.0094876660341" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_63" data-x="30.905" data-y="-19.15" x="697.8621125869704" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_57" data-x="30.905" data-y="-14.85" x="697.8621125869704" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_58" data-x="29.635" data-y="-14.85" x="685.0094876660341" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_59" data-x="28.365" data-y="-14.85" x="672.1568627450981" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="27.095" data-y="-14.85" x="659.3042378241619" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_60" data-x="12.175" data-y="-13" x="507.29917773561044" y="396.52118912080965" width="8.096141682479413" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_61" data-x="13.825" data-y="-13" x="523.9974699557242" y="396.52118912080965" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_62" data-x="15.175" data-y="-15" x="537.6597090449084" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_63" data-x="16.825" data-y="-15" x="554.358001265022" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_64" data-x="-13.9125" data-y="-12" x="242.15053763440858" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_65" data-x="-12.0875" data-y="-12" x="260.6198608475648" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_67" data-x="-1.1375" data-y="-18.05" x="369.91777356103734" y="449.39911448450357" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_66" data-x="-1.1375" data-y="-19.95" x="369.91777356103734" y="468.62745098039227" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="1.1375" data-y="-19" x="392.94117647058823" y="459.0132827324479" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_54" data-x="23.15" data-y="18.635" x="617.3561037318152" y="78.14041745730552" width="10.120177103099309" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55" data-x="23.15" data-y="19.905" x="617.3561037318152" y="65.2877925363694" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_56" data-x="27.095" data-y="-19.15" x="659.3042378241619" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_57" data-x="28.365" data-y="-19.15" x="672.1568627450981" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_62" data-x="29.635" data-y="-19.15" x="685.0094876660341" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_64" data-x="30.905" data-y="-19.15" x="697.8621125869704" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_58" data-x="30.905" data-y="-14.85" x="697.8621125869704" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_59" data-x="29.635" data-y="-14.85" x="685.0094876660341" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_60" data-x="28.365" data-y="-14.85" x="672.1568627450981" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="27.095" data-y="-14.85" x="659.3042378241619" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_61" data-x="12.175" data-y="-13" x="507.29917773561044" y="396.52118912080965" width="8.096141682479413" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_62" data-x="13.825" data-y="-13" x="523.9974699557242" y="396.52118912080965" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_63" data-x="15.175" data-y="-15" x="537.6597090449084" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_64" data-x="16.825" data-y="-15" x="554.358001265022" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_65" data-x="-13.9125" data-y="-12" x="242.15053763440858" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_66" data-x="-12.0875" data-y="-12" x="260.6198608475648" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_68" data-x="-1.1375" data-y="-18.05" x="369.91777356103734" y="449.39911448450357" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_67" data-x="-1.1375" data-y="-19.95" x="369.91777356103734" y="468.62745098039227" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="1.1375" data-y="-19" x="392.94117647058823" y="459.0132827324479" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_39
 bottom
 source_trace_39" data-x="-32" data-y="-25.43" x="56.69829222011384" y="519.5319418089819" width="15.180265654648906" height="15.180265654648906" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -443,8 +446,12 @@ top" data-x="-4.302" data-y="0.097" x="342.32005060088545" y="266.50727387729285
 bottom" data-x="-2.275" data-y="0.113" x="362.83364958886784" y="266.3453510436433" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="bottom
 top" data-x="1.912" data-y="0.183" x="405.20683111954463" y="265.6369386464263" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 bottom" data-x="-0.22" data-y="-4.88" x="383.63061353573687" y="316.8753953194181" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="bottom
-top" data-x="0.2" data-y="4.168" x="387.8810879190386" y="225.30803289057562" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-bottom" data-x="3.504" data-y="3.325" x="421.3181530676786" y="233.83934218848833" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55
+top
+source_trace_55" data-x="0.2" data-y="4.168" x="387.8810879190386" y="225.30803289057562" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55
+bottom
+source_trace_55" data-x="3.504" data-y="3.325" x="421.3181530676786" y="233.83934218848833" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 bottom" data-x="-4.2" data-y="-0.8" x="343.35230866540167" y="275.58507273877296" width="4.554079696394638" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="bottom
 top" data-x="-5.52" data-y="-0.689" x="329.99367488931057" y="274.46173308032894" width="4.554079696394638" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><circle data-type="circle" data-label="" data-x="-5.43500637465368" data-y="-4.047838102925986" cx="333.1308652786471" cy="310.73080939077533" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-1.024" data-y="-4.996" cx="377.77103099304236" cy="320.326375711575" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-4.302" data-y="0.097" cx="344.5970904490828" cy="268.7843137254902" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-2.275" data-y="0.113" cx="365.11068943706516" cy="268.62239089184067" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="1.912" data-y="0.183" cx="407.48387096774195" cy="267.9139784946237" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-0.22" data-y="-4.88" cx="385.9076533839342" cy="319.15243516761547" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="0.2" data-y="4.168" cx="390.1581277672359" cy="227.58507273877296" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="3.504" data-y="3.325" cx="423.595192915876" cy="236.11638203668568" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-4.2" data-y="-0.8" cx="345.629348513599" cy="277.86211258697034" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-5.52" data-y="-0.689" cx="332.2707147375079" cy="276.7387729285263" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><g><circle data-type="point" data-label="source_trace_21
 source_trace_21
@@ -452,189 +459,237 @@ top" data-x="-34.25" data-y="10.775" cx="41.51802656546488" cy="160.721062618595
 source_trace_21
 top" data-x="-3.42495" data-y="2.20055" cx="353.47299177735607" cy="247.4960151802657" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_22
 source_trace_22
-top" data-x="-33.75" data-y="10.775" cx="46.578115117014534" cy="160.72106261859585" r="3" fill="hsl(7.23404255319149, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_22
+top" data-x="-33.75" data-y="10.775" cx="46.578115117014534" cy="160.72106261859585" r="3" fill="hsl(7.083333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_22
 source_trace_22
-top" data-x="-3.42495" data-y="1.8004499999999999" cx="353.47299177735607" cy="251.54509803921573" r="3" fill="hsl(7.23404255319149, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
+top" data-x="-3.42495" data-y="1.8004499999999999" cx="353.47299177735607" cy="251.54509803921573" r="3" fill="hsl(7.083333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
 source_trace_23
-top" data-x="-33.25" data-y="10.775" cx="51.63820366856419" cy="160.72106261859585" r="3" fill="hsl(14.46808510638298, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
+top" data-x="-33.25" data-y="10.775" cx="51.63820366856419" cy="160.72106261859585" r="3" fill="hsl(14.166666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
 source_trace_23
-top" data-x="-3.42495" data-y="1.40035" cx="353.47299177735607" cy="255.59418089816575" r="3" fill="hsl(14.46808510638298, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
+top" data-x="-3.42495" data-y="1.40035" cx="353.47299177735607" cy="255.59418089816575" r="3" fill="hsl(14.166666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
 source_trace_24
-top" data-x="-32.75" data-y="10.775" cx="56.69829222011384" cy="160.72106261859585" r="3" fill="hsl(21.70212765957447, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
+top" data-x="-32.75" data-y="10.775" cx="56.69829222011384" cy="160.72106261859585" r="3" fill="hsl(21.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
 source_trace_24
-top" data-x="-3.42495" data-y="1.0002499999999999" cx="353.47299177735607" cy="259.6432637571158" r="3" fill="hsl(21.70212765957447, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
+top" data-x="-3.42495" data-y="1.0002499999999999" cx="353.47299177735607" cy="259.6432637571158" r="3" fill="hsl(21.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
 source_trace_25
-top" data-x="-32.25" data-y="10.775" cx="61.7583807716635" cy="160.72106261859585" r="3" fill="hsl(28.93617021276596, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
+top" data-x="-32.25" data-y="10.775" cx="61.7583807716635" cy="160.72106261859585" r="3" fill="hsl(28.333333333333332, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
 source_trace_25
-top" data-x="-3.42495" data-y="0.6001499999999997" cx="353.47299177735607" cy="263.69234661606583" r="3" fill="hsl(28.93617021276596, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
+top" data-x="-3.42495" data-y="0.6001499999999997" cx="353.47299177735607" cy="263.69234661606583" r="3" fill="hsl(28.333333333333332, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
 source_trace_26
-top" data-x="-31.75" data-y="10.775" cx="66.8184693232131" cy="160.72106261859585" r="3" fill="hsl(36.170212765957444, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
+top" data-x="-31.75" data-y="10.775" cx="66.8184693232131" cy="160.72106261859585" r="3" fill="hsl(35.416666666666664, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
 source_trace_26
-top" data-x="-3.42495" data-y="0.20005000000000006" cx="353.47299177735607" cy="267.7414294750159" r="3" fill="hsl(36.170212765957444, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
+top" data-x="-3.42495" data-y="0.20005000000000006" cx="353.47299177735607" cy="267.7414294750159" r="3" fill="hsl(35.416666666666664, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
 source_trace_27
-top" data-x="-31.25" data-y="10.775" cx="71.87855787476275" cy="160.72106261859585" r="3" fill="hsl(43.40425531914894, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
+top" data-x="-31.25" data-y="10.775" cx="71.87855787476275" cy="160.72106261859585" r="3" fill="hsl(42.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
 source_trace_27
-top" data-x="-3.42495" data-y="-0.20005000000000006" cx="353.47299177735607" cy="271.79051233396586" r="3" fill="hsl(43.40425531914894, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
+top" data-x="-3.42495" data-y="-0.20005000000000006" cx="353.47299177735607" cy="271.79051233396586" r="3" fill="hsl(42.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
 source_trace_28
-top" data-x="-30.75" data-y="10.775" cx="76.9386464263124" cy="160.72106261859585" r="3" fill="hsl(50.638297872340424, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
+top" data-x="-30.75" data-y="10.775" cx="76.9386464263124" cy="160.72106261859585" r="3" fill="hsl(49.583333333333336, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
 source_trace_28
-top" data-x="-3.42495" data-y="-0.6001500000000002" cx="353.47299177735607" cy="275.8395951929159" r="3" fill="hsl(50.638297872340424, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
+top" data-x="-3.42495" data-y="-0.6001500000000002" cx="353.47299177735607" cy="275.8395951929159" r="3" fill="hsl(49.583333333333336, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
 source_trace_29
-top" data-x="-30.25" data-y="10.775" cx="81.99873497786206" cy="160.72106261859585" r="3" fill="hsl(57.87234042553192, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
+top" data-x="-30.25" data-y="10.775" cx="81.99873497786206" cy="160.72106261859585" r="3" fill="hsl(56.666666666666664, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
 source_trace_29
-top" data-x="-3.42495" data-y="-1.4003500000000004" cx="353.47299177735607" cy="283.937760910816" r="3" fill="hsl(57.87234042553192, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
+top" data-x="-3.42495" data-y="-1.4003500000000004" cx="353.47299177735607" cy="283.937760910816" r="3" fill="hsl(56.666666666666664, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
 source_trace_30
-top" data-x="-29.75" data-y="10.775" cx="87.05882352941171" cy="160.72106261859585" r="3" fill="hsl(65.1063829787234, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
+top" data-x="-29.75" data-y="10.775" cx="87.05882352941171" cy="160.72106261859585" r="3" fill="hsl(63.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
 source_trace_30
-top" data-x="-3.42495" data-y="-1.8004500000000005" cx="353.47299177735607" cy="287.98684376976604" r="3" fill="hsl(65.1063829787234, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
+top" data-x="-3.42495" data-y="-1.8004500000000005" cx="353.47299177735607" cy="287.98684376976604" r="3" fill="hsl(63.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
 source_trace_31
-top" data-x="27.555" data-y="6.8500000000000005" cx="666.9955724225174" cy="200.44275774826065" r="3" fill="hsl(72.34042553191489, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
+top" data-x="27.555" data-y="6.8500000000000005" cx="666.9955724225174" cy="200.44275774826065" r="3" fill="hsl(70.83333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
 source_trace_31
-top" data-x="-3.42495" data-y="-2.20055" cx="353.47299177735607" cy="292.035926628716" r="3" fill="hsl(72.34042553191489, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
+top" data-x="-3.42495" data-y="-2.20055" cx="353.47299177735607" cy="292.035926628716" r="3" fill="hsl(70.83333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
 source_trace_32
-top" data-x="28.825" data-y="6.85" cx="679.8481973434535" cy="200.44275774826065" r="3" fill="hsl(79.57446808510639, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
+top" data-x="28.825" data-y="6.85" cx="679.8481973434535" cy="200.44275774826065" r="3" fill="hsl(77.91666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
 source_trace_32
-top" data-x="-3.42495" data-y="-2.60065" cx="353.47299177735607" cy="296.08500948766607" r="3" fill="hsl(79.57446808510639, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
+top" data-x="-3.42495" data-y="-2.60065" cx="353.47299177735607" cy="296.08500948766607" r="3" fill="hsl(77.91666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
 source_trace_33
-top" data-x="30.095" data-y="6.85" cx="692.7008222643897" cy="200.44275774826065" r="3" fill="hsl(86.80851063829788, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
+top" data-x="30.095" data-y="6.85" cx="692.7008222643897" cy="200.44275774826065" r="3" fill="hsl(85, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
 source_trace_33
-top" data-x="-2.60065" data-y="-3.42505" cx="361.81505376344086" cy="304.42808349146117" r="3" fill="hsl(86.80851063829788, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
+top" data-x="-2.60065" data-y="-3.42505" cx="361.81505376344086" cy="304.42808349146117" r="3" fill="hsl(85, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
 source_trace_34
-top" data-x="31.365" data-y="6.85" cx="705.5534471853257" cy="200.44275774826065" r="3" fill="hsl(94.04255319148936, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
+top" data-x="31.365" data-y="6.85" cx="705.5534471853257" cy="200.44275774826065" r="3" fill="hsl(92.08333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
 source_trace_34
-top" data-x="-2.20055" data-y="-3.42505" cx="365.8641366223909" cy="304.42808349146117" r="3" fill="hsl(94.04255319148936, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
+top" data-x="-2.20055" data-y="-3.42505" cx="365.8641366223909" cy="304.42808349146117" r="3" fill="hsl(92.08333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
 source_trace_35
-top" data-x="32.635" data-y="6.85" cx="718.4060721062618" cy="200.44275774826065" r="3" fill="hsl(101.27659574468085, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
+top" data-x="32.635" data-y="6.85" cx="718.4060721062618" cy="200.44275774826065" r="3" fill="hsl(99.16666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
 source_trace_35
-top" data-x="-1.8004499999999999" data-y="-3.42505" cx="369.9132194813409" cy="304.42808349146117" r="3" fill="hsl(101.27659574468085, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
+top" data-x="-1.8004499999999999" data-y="-3.42505" cx="369.9132194813409" cy="304.42808349146117" r="3" fill="hsl(99.16666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
 source_trace_36
-top" data-x="33.905" data-y="6.85" cx="731.258697027198" cy="200.44275774826065" r="3" fill="hsl(108.51063829787235, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
+top" data-x="33.905" data-y="6.85" cx="731.258697027198" cy="200.44275774826065" r="3" fill="hsl(106.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
 source_trace_36
-top" data-x="-1.40035" data-y="-3.42505" cx="373.96230234029093" cy="304.42808349146117" r="3" fill="hsl(108.51063829787235, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
+top" data-x="-1.40035" data-y="-3.42505" cx="373.96230234029093" cy="304.42808349146117" r="3" fill="hsl(106.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
 source_trace_37
-top" data-x="35.175" data-y="6.85" cx="744.1113219481341" cy="200.44275774826065" r="3" fill="hsl(115.74468085106383, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
+top" data-x="35.175" data-y="6.85" cx="744.1113219481341" cy="200.44275774826065" r="3" fill="hsl(113.33333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
 source_trace_37
-top" data-x="2.20055" data-y="-3.42505" cx="410.4040480708412" cy="304.42808349146117" r="3" fill="hsl(115.74468085106383, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
+top" data-x="2.20055" data-y="-3.42505" cx="410.4040480708412" cy="304.42808349146117" r="3" fill="hsl(113.33333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
 source_trace_38
-top" data-x="36.445" data-y="6.85" cx="756.9639468690702" cy="200.44275774826065" r="3" fill="hsl(122.97872340425532, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
+top" data-x="36.445" data-y="6.85" cx="756.9639468690702" cy="200.44275774826065" r="3" fill="hsl(120.41666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
 source_trace_38
-top" data-x="2.60065" data-y="-3.42505" cx="414.45313092979126" cy="304.42808349146117" r="3" fill="hsl(122.97872340425532, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
+top" data-x="2.60065" data-y="-3.42505" cx="414.45313092979126" cy="304.42808349146117" r="3" fill="hsl(120.41666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
 source_trace_39
-top" data-x="-32" data-y="-25.43" cx="64.2884250474383" cy="527.1220746363063" r="3" fill="hsl(130.2127659574468, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
+top" data-x="-32" data-y="-25.43" cx="64.2884250474383" cy="527.1220746363063" r="3" fill="hsl(127.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
 source_trace_39
-top" data-x="3.42495" data-y="-2.60065" cx="422.79519291587604" cy="296.08500948766607" r="3" fill="hsl(130.2127659574468, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
+top" data-x="3.42495" data-y="-2.60065" cx="422.79519291587604" cy="296.08500948766607" r="3" fill="hsl(127.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
 source_trace_40
-top" data-x="-32" data-y="-22.89" cx="64.2884250474383" cy="501.416824794434" r="3" fill="hsl(137.4468085106383, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
+top" data-x="-32" data-y="-22.89" cx="64.2884250474383" cy="501.416824794434" r="3" fill="hsl(134.58333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
 source_trace_40
-top" data-x="3.42495" data-y="-2.20055" cx="422.79519291587604" cy="292.035926628716" r="3" fill="hsl(137.4468085106383, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
+top" data-x="3.42495" data-y="-2.20055" cx="422.79519291587604" cy="292.035926628716" r="3" fill="hsl(134.58333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
 source_trace_41
-top" data-x="-32" data-y="-20.35" cx="64.2884250474383" cy="475.7115749525617" r="3" fill="hsl(144.68085106382978, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
+top" data-x="-32" data-y="-20.35" cx="64.2884250474383" cy="475.7115749525617" r="3" fill="hsl(141.66666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
 source_trace_41
-top" data-x="3.42495" data-y="-1.8004499999999999" cx="422.79519291587604" cy="287.98684376976604" r="3" fill="hsl(144.68085106382978, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
+top" data-x="3.42495" data-y="-1.8004499999999999" cx="422.79519291587604" cy="287.98684376976604" r="3" fill="hsl(141.66666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
 source_trace_42
-top" data-x="-32" data-y="-17.81" cx="64.2884250474383" cy="450.0063251106895" r="3" fill="hsl(151.91489361702128, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
+top" data-x="-32" data-y="-17.81" cx="64.2884250474383" cy="450.0063251106895" r="3" fill="hsl(148.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
 source_trace_42
-top" data-x="3.42495" data-y="-1.40035" cx="422.79519291587604" cy="283.937760910816" r="3" fill="hsl(151.91489361702128, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
+top" data-x="3.42495" data-y="-1.40035" cx="422.79519291587604" cy="283.937760910816" r="3" fill="hsl(148.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
 source_trace_43
-top" data-x="-32" data-y="-15.27" cx="64.2884250474383" cy="424.30107526881727" r="3" fill="hsl(159.14893617021278, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
+top" data-x="-32" data-y="-15.27" cx="64.2884250474383" cy="424.30107526881727" r="3" fill="hsl(155.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
 source_trace_43
-top" data-x="3.42495" data-y="-0.6001499999999997" cx="422.79519291587604" cy="275.8395951929159" r="3" fill="hsl(159.14893617021278, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
+top" data-x="3.42495" data-y="-0.6001499999999997" cx="422.79519291587604" cy="275.8395951929159" r="3" fill="hsl(155.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
 source_trace_44
-top" data-x="-32" data-y="-12.73" cx="64.2884250474383" cy="398.595825426945" r="3" fill="hsl(166.38297872340425, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
+top" data-x="-32" data-y="-12.73" cx="64.2884250474383" cy="398.595825426945" r="3" fill="hsl(162.91666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
 source_trace_44
-top" data-x="3.42495" data-y="-0.20005000000000006" cx="422.79519291587604" cy="271.79051233396586" r="3" fill="hsl(166.38297872340425, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
+top" data-x="3.42495" data-y="-0.20005000000000006" cx="422.79519291587604" cy="271.79051233396586" r="3" fill="hsl(162.91666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
 source_trace_45
-top" data-x="-32" data-y="-10.19" cx="64.2884250474383" cy="372.8905755850728" r="3" fill="hsl(173.61702127659575, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
+top" data-x="-32" data-y="-10.19" cx="64.2884250474383" cy="372.8905755850728" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
 source_trace_45
-top" data-x="3.42495" data-y="0.20005000000000006" cx="422.79519291587604" cy="267.7414294750159" r="3" fill="hsl(173.61702127659575, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
+top" data-x="3.42495" data-y="0.20005000000000006" cx="422.79519291587604" cy="267.7414294750159" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
 source_trace_46
-top" data-x="-32" data-y="-7.649999999999999" cx="64.2884250474383" cy="347.18532574320056" r="3" fill="hsl(180.85106382978722, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
+top" data-x="-32" data-y="-7.649999999999999" cx="64.2884250474383" cy="347.18532574320056" r="3" fill="hsl(177.08333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
 source_trace_46
-top" data-x="3.42495" data-y="0.6001500000000002" cx="422.79519291587604" cy="263.69234661606583" r="3" fill="hsl(180.85106382978722, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
+top" data-x="3.42495" data-y="0.6001500000000002" cx="422.79519291587604" cy="263.69234661606583" r="3" fill="hsl(177.08333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
 source_trace_47
-top" data-x="-32" data-y="-5.109999999999999" cx="64.2884250474383" cy="321.4800759013283" r="3" fill="hsl(188.08510638297872, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
+top" data-x="-32" data-y="-5.109999999999999" cx="64.2884250474383" cy="321.4800759013283" r="3" fill="hsl(184.16666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
 source_trace_47
-top" data-x="3.42495" data-y="1.0002500000000003" cx="422.79519291587604" cy="259.6432637571158" r="3" fill="hsl(188.08510638297872, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
+top" data-x="3.42495" data-y="1.0002500000000003" cx="422.79519291587604" cy="259.6432637571158" r="3" fill="hsl(184.16666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
 source_trace_48
-top" data-x="-32" data-y="-2.5700000000000003" cx="64.2884250474383" cy="295.7748260594561" r="3" fill="hsl(195.31914893617022, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
+top" data-x="-32" data-y="-2.5700000000000003" cx="64.2884250474383" cy="295.7748260594561" r="3" fill="hsl(191.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
 source_trace_48
-top" data-x="3.42495" data-y="1.4003500000000004" cx="422.79519291587604" cy="255.59418089816575" r="3" fill="hsl(195.31914893617022, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
+top" data-x="3.42495" data-y="1.4003500000000004" cx="422.79519291587604" cy="255.59418089816575" r="3" fill="hsl(191.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
 source_trace_49
-top" data-x="18.85" data-y="19.905" cx="578.899430740038" cy="68.3238456672992" r="3" fill="hsl(202.5531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
+top" data-x="18.85" data-y="19.905" cx="578.899430740038" cy="68.3238456672992" r="3" fill="hsl(198.33333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
 source_trace_49
-top" data-x="-2.60065" data-y="3.42505" cx="361.81505376344086" cy="235.1038583175206" r="3" fill="hsl(202.5531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
+top" data-x="-2.60065" data-y="3.42505" cx="361.81505376344086" cy="235.1038583175206" r="3" fill="hsl(198.33333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
 source_trace_50
-top" data-x="18.85" data-y="18.635" cx="578.899430740038" cy="81.1764705882353" r="3" fill="hsl(209.7872340425532, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
+top" data-x="18.85" data-y="18.635" cx="578.899430740038" cy="81.1764705882353" r="3" fill="hsl(205.41666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
 source_trace_50
-top" data-x="-2.20055" data-y="3.42505" cx="365.8641366223909" cy="235.1038583175206" r="3" fill="hsl(209.7872340425532, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
+top" data-x="-2.20055" data-y="3.42505" cx="365.8641366223909" cy="235.1038583175206" r="3" fill="hsl(205.41666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
 source_trace_51
-top" data-x="18.85" data-y="17.365" cx="578.899430740038" cy="94.02909550917144" r="3" fill="hsl(217.0212765957447, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
+top" data-x="18.85" data-y="17.365" cx="578.899430740038" cy="94.02909550917144" r="3" fill="hsl(212.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
 source_trace_51
-top" data-x="-1.8004500000000005" data-y="3.42505" cx="369.9132194813409" cy="235.1038583175206" r="3" fill="hsl(217.0212765957447, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
+top" data-x="-1.8004500000000005" data-y="3.42505" cx="369.9132194813409" cy="235.1038583175206" r="3" fill="hsl(212.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
 source_trace_52
-top" data-x="23.15" data-y="16.095" cx="622.4161922833649" cy="106.88172043010758" r="3" fill="hsl(224.25531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
+top" data-x="23.15" data-y="16.095" cx="622.4161922833649" cy="106.88172043010758" r="3" fill="hsl(219.58333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
 source_trace_52
-top" data-x="-1.4003500000000004" data-y="3.42505" cx="373.96230234029093" cy="235.1038583175206" r="3" fill="hsl(224.25531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
+top" data-x="-1.4003500000000004" data-y="3.42505" cx="373.96230234029093" cy="235.1038583175206" r="3" fill="hsl(219.58333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
 source_trace_53
-top" data-x="23.15" data-y="17.365" cx="622.4161922833649" cy="94.02909550917144" r="3" fill="hsl(231.48936170212767, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
+top" data-x="23.15" data-y="17.365" cx="622.4161922833649" cy="94.02909550917144" r="3" fill="hsl(226.66666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
 source_trace_53
-top" data-x="-1.0002500000000003" data-y="3.42505" cx="378.011385199241" cy="235.1038583175206" r="3" fill="hsl(231.48936170212767, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
+top" data-x="-1.0002500000000003" data-y="3.42505" cx="378.011385199241" cy="235.1038583175206" r="3" fill="hsl(226.66666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
 source_trace_54
-top" data-x="23.15" data-y="18.635" cx="622.4161922833649" cy="81.1764705882353" r="3" fill="hsl(238.72340425531914, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
+top" data-x="23.15" data-y="18.635" cx="622.4161922833649" cy="81.1764705882353" r="3" fill="hsl(233.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
 source_trace_54
-top" data-x="-0.6001500000000002" data-y="3.42505" cx="382.060468058191" cy="235.1038583175206" r="3" fill="hsl(238.72340425531914, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+top" data-x="-0.6001500000000002" data-y="3.42505" cx="382.060468058191" cy="235.1038583175206" r="3" fill="hsl(233.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
 source_trace_55
-top" data-x="27.095" data-y="-19.15" cx="662.3402909550916" cy="463.56736242884256" r="3" fill="hsl(245.95744680851064, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+top" data-x="23.15" data-y="19.905" cx="622.4161922833649" cy="68.3238456672992" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
 source_trace_55
-top" data-x="3.42495" data-y="1.8004500000000005" cx="422.79519291587604" cy="251.54509803921573" r="3" fill="hsl(245.95744680851064, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
+top" data-x="0.20005000000000006" data-y="3.42505" cx="390.15863377609105" cy="235.1038583175206" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.20005000000000006" data-y="3.42505" cx="390.15863377609105" cy="235.1038583175206" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.2" data-y="3.425" cx="390.1581277672359" cy="235.10436432637576" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.2" data-y="3.7965" cx="390.1581277672359" cy="231.34471853257435" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.2" data-y="4.168" cx="390.1581277672359" cy="227.58507273877296" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.2" data-y="4.168" cx="390.1581277672359" cy="227.58507273877296" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.27936590381920134" data-y="4.088634096180799" cx="390.96132476983377" cy="228.38826974137083" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.27936590381920134" data-y="3.987284978680325" cx="390.96132476983377" cy="229.41394075971846" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.6105083931593638" data-y="3.6561424893401626" cx="394.3125454083174" cy="232.76516139820205" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.9416508824995262" data-y="3.325" cx="397.663766046801" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="1.368709068749605" data-y="3.325" cx="401.9856705249802" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="1.7957672549996841" data-y="3.325" cx="406.30757500315934" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="2.2228254412497632" data-y="3.325" cx="410.62947948133854" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="2.649883627499842" data-y="3.325" cx="414.95138395951767" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="3.0769418137499214" data-y="3.325" cx="419.27328843769686" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="3.504" data-y="3.325" cx="423.595192915876" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.504" data-y="3.325" cx="423.595192915876" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.57064426757843" data-y="3.2583557324215704" cx="424.26964470667605" cy="236.79083382748573" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.597101639481161" data-y="3.2583557324215704" cx="424.53739799601425" cy="236.79083382748573" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.855457371902731" data-y="3" cx="427.1520037637215" cy="239.40543959519295" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="4.233638247935154" data-y="3" cx="430.97926120617484" cy="239.40543959519295" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="4.611819123967577" data-y="3" cx="434.80651864862824" cy="239.40543959519295" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="4.99" data-y="3" cx="438.6337760910816" cy="239.40543959519295" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
 source_trace_56
-top" data-x="28.365" data-y="-19.15" cx="675.1929158760279" cy="463.56736242884256" r="3" fill="hsl(253.19148936170214, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
+top" data-x="27.095" data-y="-19.15" cx="662.3402909550916" cy="463.56736242884256" r="3" fill="hsl(247.91666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
 source_trace_56
-top" data-x="3.42495" data-y="2.20055" cx="422.79519291587604" cy="247.4960151802657" r="3" fill="hsl(253.19148936170214, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
+top" data-x="3.42495" data-y="1.8004500000000005" cx="422.79519291587604" cy="251.54509803921573" r="3" fill="hsl(247.91666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
 source_trace_57
-top" data-x="30.905" data-y="-14.85" cx="700.8981657179002" cy="420.05060088551556" r="3" fill="hsl(260.4255319148936, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
+top" data-x="28.365" data-y="-19.15" cx="675.1929158760279" cy="463.56736242884256" r="3" fill="hsl(255, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
 source_trace_57
-top" data-x="1.0002500000000003" data-y="-3.42505" cx="398.25679949399114" cy="304.42808349146117" r="3" fill="hsl(260.4255319148936, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
+top" data-x="3.42495" data-y="2.20055" cx="422.79519291587604" cy="247.4960151802657" r="3" fill="hsl(255, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
 source_trace_58
-top" data-x="29.635" data-y="-14.85" cx="688.0455407969639" cy="420.05060088551556" r="3" fill="hsl(267.6595744680851, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
+top" data-x="30.905" data-y="-14.85" cx="700.8981657179002" cy="420.05060088551556" r="3" fill="hsl(262.0833333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
 source_trace_58
-top" data-x="1.4003500000000004" data-y="-3.42505" cx="402.3058823529412" cy="304.42808349146117" r="3" fill="hsl(267.6595744680851, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
+top" data-x="1.0002500000000003" data-y="-3.42505" cx="398.25679949399114" cy="304.42808349146117" r="3" fill="hsl(262.0833333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
 source_trace_59
-top" data-x="28.365" data-y="-14.85" cx="675.1929158760279" cy="420.05060088551556" r="3" fill="hsl(274.8936170212766, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
+top" data-x="29.635" data-y="-14.85" cx="688.0455407969639" cy="420.05060088551556" r="3" fill="hsl(269.1666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
 source_trace_59
-top" data-x="1.8004500000000005" data-y="-3.42505" cx="406.3549652118912" cy="304.42808349146117" r="3" fill="hsl(274.8936170212766, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
+top" data-x="1.4003500000000004" data-y="-3.42505" cx="402.3058823529412" cy="304.42808349146117" r="3" fill="hsl(269.1666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
 source_trace_60
-top" data-x="1.40035" data-y="3.42505" cx="402.3058823529412" cy="235.1038583175206" r="3" fill="hsl(282.1276595744681, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
+top" data-x="28.365" data-y="-14.85" cx="675.1929158760279" cy="420.05060088551556" r="3" fill="hsl(276.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
 source_trace_60
-top" data-x="12.175" data-y="-13" cx="511.3472485768501" cy="401.3282732447818" r="3" fill="hsl(282.1276595744681, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
+top" data-x="1.8004500000000005" data-y="-3.42505" cx="406.3549652118912" cy="304.42808349146117" r="3" fill="hsl(276.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
 source_trace_61
-top" data-x="13.825" data-y="-13" cx="528.0455407969639" cy="401.3282732447818" r="3" fill="hsl(289.36170212765956, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
+top" data-x="1.40035" data-y="3.42505" cx="402.3058823529412" cy="235.1038583175206" r="3" fill="hsl(283.3333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
 source_trace_61
-top" data-x="29.635" data-y="-19.15" cx="688.0455407969639" cy="463.56736242884256" r="3" fill="hsl(289.36170212765956, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
+top" data-x="12.175" data-y="-13" cx="511.3472485768501" cy="401.3282732447818" r="3" fill="hsl(283.3333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
 source_trace_62
-top" data-x="1.0002499999999999" data-y="3.42505" cx="398.25679949399114" cy="235.1038583175206" r="3" fill="hsl(296.59574468085106, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
+top" data-x="13.825" data-y="-13" cx="528.0455407969639" cy="401.3282732447818" r="3" fill="hsl(290.4166666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
 source_trace_62
-top" data-x="15.175" data-y="-15" cx="541.707779886148" cy="421.56862745098044" r="3" fill="hsl(296.59574468085106, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
+top" data-x="29.635" data-y="-19.15" cx="688.0455407969639" cy="463.56736242884256" r="3" fill="hsl(290.4166666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
 source_trace_63
-top" data-x="16.825" data-y="-15" cx="558.4060721062618" cy="421.56862745098044" r="3" fill="hsl(303.82978723404256, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
+top" data-x="1.0002499999999999" data-y="3.42505" cx="398.25679949399114" cy="235.1038583175206" r="3" fill="hsl(297.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
 source_trace_63
-top" data-x="30.905" data-y="-19.15" cx="700.8981657179002" cy="463.56736242884256" r="3" fill="hsl(303.82978723404256, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
+top" data-x="15.175" data-y="-15" cx="541.707779886148" cy="421.56862745098044" r="3" fill="hsl(297.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
 source_trace_64
-top" data-x="-0.6001499999999997" data-y="-3.42505" cx="382.060468058191" cy="304.42808349146117" r="3" fill="hsl(311.06382978723406, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
+top" data-x="16.825" data-y="-15" cx="558.4060721062618" cy="421.56862745098044" r="3" fill="hsl(304.5833333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
 source_trace_64
-top" data-x="-13.9125" data-y="-12" cx="247.33712839974697" cy="391.2080961416825" r="3" fill="hsl(311.06382978723406, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
+top" data-x="30.905" data-y="-19.15" cx="700.8981657179002" cy="463.56736242884256" r="3" fill="hsl(304.5833333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
 source_trace_65
-top" data-x="-0.20005000000000006" data-y="-3.42505" cx="386.10955091714106" cy="304.42808349146117" r="3" fill="hsl(318.29787234042556, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
+top" data-x="-0.6001499999999997" data-y="-3.42505" cx="382.060468058191" cy="304.42808349146117" r="3" fill="hsl(311.6666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
 source_trace_65
-top" data-x="-12.0875" data-y="-12" cx="265.8064516129032" cy="391.2080961416825" r="3" fill="hsl(318.29787234042556, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
+top" data-x="-13.9125" data-y="-12" cx="247.33712839974697" cy="391.2080961416825" r="3" fill="hsl(311.6666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
 source_trace_66
-top" data-x="2.20055" data-y="3.42505" cx="410.4040480708412" cy="235.1038583175206" r="3" fill="hsl(325.531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
+top" data-x="-0.20005000000000006" data-y="-3.42505" cx="386.10955091714106" cy="304.42808349146117" r="3" fill="hsl(318.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
 source_trace_66
-top" data-x="-1.1375" data-y="-19.95" cx="376.6223908918406" cy="471.663504111322" r="3" fill="hsl(325.531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
+top" data-x="-12.0875" data-y="-12" cx="265.8064516129032" cy="391.2080961416825" r="3" fill="hsl(318.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
 source_trace_67
-top" data-x="1.8004499999999999" data-y="3.42505" cx="406.3549652118912" cy="235.1038583175206" r="3" fill="hsl(332.7659574468085, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
+top" data-x="2.20055" data-y="3.42505" cx="410.4040480708412" cy="235.1038583175206" r="3" fill="hsl(325.8333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
 source_trace_67
-top" data-x="-1.1375" data-y="-18.05" cx="376.6223908918406" cy="452.43516761543333" r="3" fill="hsl(332.7659574468085, 100%, 50%)"/></g><g id="crosshair__stack1__stack1" style="display: none"><line id="crosshair-h__stack1__stack1" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack1" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack1" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+top" data-x="-1.1375" data-y="-19.95" cx="376.6223908918406" cy="471.663504111322" r="3" fill="hsl(325.8333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_68
+source_trace_68
+top" data-x="1.8004499999999999" data-y="3.42505" cx="406.3549652118912" cy="235.1038583175206" r="3" fill="hsl(332.9166666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_68
+source_trace_68
+top" data-x="-1.1375" data-y="-18.05" cx="376.6223908918406" cy="452.43516761543333" r="3" fill="hsl(332.9166666666667, 100%, 50%)"/></g><g id="crosshair__stack1__stack1" style="display: none"><line id="crosshair-h__stack1__stack1" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack1" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack1" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
               document.currentScript.parentElement.addEventListener('mousemove', (e) => {
                 const svg = e.currentTarget;
                 const rect = svg.getBoundingClientRect();
@@ -691,7 +746,7 @@ top" data-x="-1.1375" data-y="-18.05" cx="376.6223908918406" cy="452.43516761543
     font-size="18"
     font-weight="700"
     text-anchor="middle"
-  >AUTOROUTING PHASE 2 END: 47 CONNECTIONS, 20 TRACES</text>
+  >AUTOROUTING PHASE 2 END: 48 CONNECTIONS, 20 TRACES</text>
   </g>
   <g transform="translate(0, 36) scale(1, 1) translate(0, 0)">
     <rect width="100%" height="100%" fill="#fff"/><g><polyline data-points="6.01,3 6.01,5.2" data-type="line" data-label="" points="448.95635673624287,239.40543959519295 448.95635673624287,217.1410499683745" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,5.2 5.01,6.2 3.21,6.2" data-type="line" data-label="" points="448.95635673624287,217.1410499683745 438.83617963314356,207.02087286527518 420.61986084756484,207.02087286527518" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,3 -5.529646512479694,3.5396465124796936 -6.455000999999999,3.5396465124796936 -6.455000999999999,1.465000999999999 -4.99,0" data-type="line" data-label="" points="337.63440860215053,239.40543959519295 332.17309032278615,233.94412131582857 322.8083390259329,233.94412131582857 322.8083390259329,254.9399013282733 337.63440860215053,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,0 -4.99,-3" data-type="line" data-label="" points="337.63440860215053,269.76597090449087 337.63440860215053,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,-3 6.01,0" data-type="line" data-label="" points="448.95635673624287,300.1265022137888 448.95635673624287,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,0 6.01,3" data-type="line" data-label="" points="448.95635673624287,269.76597090449087 448.95635673624287,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,-3 -5.43500637465368,-3.44500637465368 -5.43500637465368,-4.047838102925986" data-type="line" data-label="" points="337.63440860215053,300.1265022137888 333.1308652786471,304.6300455372922 333.1308652786471,310.73080939077533" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-5.43500637465368,-4.047838102925986 -5.4245847631116435,-4.058259714468022 -4.486844477579665,-4.996 -1.024,-4.996" data-type="line" data-label="" points="333.1308652786471,310.73080939077533 333.23633383315223,310.8362779452805 342.72643159944676,320.326375711575 377.77103099304236,320.326375711575" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-1.024,-4.996 -1.0565206313402955,-5.028520631340296 -1.218231781216708,-5.028520631340296 -1.8897111498764123,-5.7 -2.1900000000000004,-5.7" data-type="line" data-label="" points="377.77103099304236,320.326375711575 377.441916444374,320.65549026024337 375.8053709680788,320.65549026024337 369.00988083616534,327.4509803921569 365.97090449082856,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,-3 3.3099999999999996,-5.7 3.21,-5.7" data-type="line" data-label="" points="448.95635673624287,300.1265022137888 421.63187855787476,327.4509803921569 420.61986084756484,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,0 -4.893,0.097 -4.302,0.097" data-type="line" data-label="" points="337.63440860215053,269.76597090449087 338.6160657811512,268.7843137254902 344.5970904490828,268.7843137254902" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.302,0.097 -4.288943945821694,0.11005605417830638 -4.286,0.113 -2.275,0.113" data-type="line" data-label="" points="344.5970904490828,268.7843137254902 344.729220029635,268.65218414493813 344.75901328273244,268.62239089184067 365.11068943706516,268.62239089184067" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-2.275,0.113 -2.244249772519263,0.08224977251926317 -2.2158546998677835,0.08224977251926317 -2.1336049273485203,0 0,0" data-type="line" data-label="" points="365.11068943706516,268.62239089184067 365.4218871851308,268.9335886399063 365.70925034921913,268.9335886399063 366.5416326138037,269.76597090449087 388.13409234661606,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-2.1900000000000004,-5.7 -1.6949990000000001,-6.195001 3.205601519423781,-6.195001 3.205601519423781,-5.704398480576219 3.21,-5.7" data-type="line" data-label="" points="365.97090449082856,327.4509803921569 370.98040227703984,332.4604781783682 420.57534744514896,332.4604781783682 420.57534744514896,327.4954937945728 420.61986084756484,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.6001499999999997,3.42505 0.6000000000000001,4.609999999999999 2.1900000000000004,6.2" data-type="line" data-label="" points="394.2077166350411,235.1038583175206 394.20619860847563,223.11195445920308 410.29728020240356,207.02087286527518" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="2.60065,3.42505 4.376,5.2 4.99,5.2" data-type="line" data-label="" points="414.45313092979126,235.1038583175206 432.41998734977864,217.1410499683745 438.6337760910816,217.1410499683745" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-0.20005000000000006,3.42505 -0.13950168668368562,3.3645016866836857 -0.13950168668368562,2.9535032821423663 0.3194245814319227,2.494577014026758 0.8592828639703756,2.494577014026758 1.912,1.4418598779971337 1.912,0.183" data-type="line" data-label="" points="386.10955091714106,235.1038583175206 386.7223105711961,235.71661797157566 386.7223105711961,239.87599461462506 391.36672568179046,244.52040972521945 396.83018711165465,244.52040972521945 407.48387096774195,255.17409358130672 407.48387096774195,267.9139784946237" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="1.912,0.183 1.9436380797842585,0.1513619202157414 1.9436380797842585,0.040008943074291245 -0.22,-2.123629136709967 -0.22,-4.88" data-type="line" data-label="" points="407.48387096774195,267.9139784946237 407.8040539383606,268.2341614652424 407.8040539383606,269.36107331487125 385.9076533839342,291.2574738692976 385.9076533839342,319.15243516761547" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-0.22,-4.88 -0.21318894664096233,-4.873188946640962 0.6136221067180759,-5.7 2.1900000000000004,-5.7" data-type="line" data-label="" points="385.9076533839342,319.15243516761547 385.97658245018636,319.08350610136335 394.3440567409799,327.4509803921569 410.29728020240356,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.6001500000000002,-3.42505 0.6001500000000002,-3.877755644979012 0.2132985229154284,-4.264607122063584 0.014999959211144831,-4.4629056857678675 -1.9729056857678664,-4.4629056857678675 -3.21,-5.7" data-type="line" data-label="" points="394.2077166350411,304.42808349146117 394.2077166350411,309.00954479422154 390.2927111743497,312.92455025491296 388.2858945903721,314.93136683889054 368.16793739893365,314.93136683889054 355.6483238456673,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.20005000000000006,3.42505 0.2,3.425 0.2,4.168" data-type="line" data-label="" points="390.15863377609105,235.1038583175206 390.1581277672359,235.10436432637576 390.1581277672359,227.58507273877296" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.2,4.168 0.27936590381920134,4.088634096180799 0.27936590381920134,3.987284978680325 0.9416508824995262,3.325 3.504,3.325" data-type="line" data-label="" points="390.1581277672359,227.58507273877296 390.96132476983377,228.38826974137083 390.96132476983377,229.41394075971846 397.663766046801,236.11638203668568 423.595192915876,236.11638203668568" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="3.504,3.325 3.57064426757843,3.2583557324215704 3.597101639481161,3.2583557324215704 3.855457371902731,3 4.99,3" data-type="line" data-label="" points="423.595192915876,236.11638203668568 424.26964470667605,236.79083382748573 424.53739799601425,236.79083382748573 427.1520037637215,239.40543959519295 438.6337760910816,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="3.42495,2.60065 3.4908956959818003,2.5351043040181995 3.8971994246110677,2.5351043040181995 4.99,1.442303728629267 4.99,0" data-type="line" data-label="" points="422.79519291587604,243.44693232131567 423.462575038399,244.1102663729974 427.57444072977677,244.1102663729974 438.6337760910816,255.1696017343022 438.6337760910816,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="3.42495,-1.0002499999999999 3.42586277369945,-1.0008627736994502 3.9241425465514554,-1.0008627736994502 4.99,-2.0667202271479947 4.99,-3" data-type="line" data-label="" points="422.79519291587604,279.88867805186595 422.8044303473695,279.8948794302285 427.8471098955239,279.8948794302285 438.6337760910816,290.6815456257862 438.6337760910816,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.20005000000000006,-3.42505 0.20005000000000006,-3.816510276013182 -0.05328439803899088,-4.069844674052173 -4.786964793197829,-4.069844674052173 -5.273849820226906,-4.55672970108125 -5.504757750627475,-4.55672970108125 -5.8704683410416765,-4.191019110667049 -5.8704683410416765,-3.1395316589583233 -6.01,-3" data-type="line" data-label="" points="390.15863377609105,304.42808349146117 390.15863377609105,308.38973081354266 387.59484480162945,310.9535197880043 339.6891608531529,310.9535197880043 334.7617981507713,315.8808824903859 332.42496900060746,315.8808824903859 328.7239130571367,312.17982654691514 328.7239130571367,301.53858731393626 327.31182795698925,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-3.42495,-1.0002500000000003 -3.9705639153548153,-1.0002500000000003 -4.115023392569576,-0.8557905227852396 -4.14420947721476,-0.8557905227852396 -4.2,-0.8" data-type="line" data-label="" points="353.47299177735607,279.88867805186595 347.95128232404994,279.88867805186595 346.4893268304154,278.42672255823146 346.1939584848601,278.42672255823146 345.629348513599,277.86211258697034" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.2,-0.8 -5.353921230245549,-0.8 -5.421178286452751,-0.732742943792798 -5.476257056207201,-0.732742943792798 -5.52,-0.689" data-type="line" data-label="" points="345.629348513599,277.86211258697034 333.9514613004878,277.86211258697034 333.2708079802378,277.1814592667203 332.71340107570194,277.1814592667203 332.2707147375079,276.7387729285263" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-5.52,-0.689 -5.52,-0.4900000000000002 -6.01,0" data-type="line" data-label="" points="332.2707147375079,276.7387729285263 332.2707147375079,274.7248576850095 327.31182795698925,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-3.42495,2.60065 -4.332948259642237,2.60065 -4.574662324196864,2.3589359354453725 -5.368935935445372,2.3589359354453725 -6.01,3" data-type="line" data-label="" points="353.47299177735607,243.44693232131567 344.2838885804707,243.44693232131567 341.8376994388679,245.8931214629185 333.79950982471473,245.8931214629185 327.31182795698925,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><rect data-type="rect" data-label="top" data-x="-3.42495" data-y="2.60065" x="349.17191650853886" y="242.43491461100575" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -711,11 +766,11 @@ source_trace_33" data-x="-2.60065" data-y="-3.42505" x="360.80303605313094" y="3
 source_trace_34" data-x="-2.20055" data-y="-3.42505" x="364.852118912081" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_35" data-x="-1.8004499999999999" data-y="-3.42505" x="368.90120177103097" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_36" data-x="-1.40035" data-y="-3.42505" x="372.950284629981" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-1.0002499999999999" data-y="-3.42505" x="376.99936748893106" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_64" data-x="-0.6001499999999997" data-y="-3.42505" x="381.0484503478811" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_65" data-x="-0.20005000000000006" data-y="-3.42505" x="385.09753320683114" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.20005000000000006" data-y="-3.42505" x="389.14661606578113" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.6001500000000002" data-y="-3.42505" x="393.1956989247312" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_57" data-x="1.0002500000000003" data-y="-3.42505" x="397.2447817836812" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_58" data-x="1.4003500000000004" data-y="-3.42505" x="401.29386464263126" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_59" data-x="1.8004500000000005" data-y="-3.42505" x="405.3429475015813" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_65" data-x="-0.6001499999999997" data-y="-3.42505" x="381.0484503478811" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_66" data-x="-0.20005000000000006" data-y="-3.42505" x="385.09753320683114" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.20005000000000006" data-y="-3.42505" x="389.14661606578113" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.6001500000000002" data-y="-3.42505" x="393.1956989247312" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_58" data-x="1.0002500000000003" data-y="-3.42505" x="397.2447817836812" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_59" data-x="1.4003500000000004" data-y="-3.42505" x="401.29386464263126" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_60" data-x="1.8004500000000005" data-y="-3.42505" x="405.3429475015813" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_37" data-x="2.20055" data-y="-3.42505" x="409.3920303605313" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_38" data-x="2.60065" data-y="-3.42505" x="413.44111321948134" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_39" data-x="3.42495" data-y="-2.60065" x="418.49411764705883" y="295.07299177735615" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -728,18 +783,20 @@ source_trace_45" data-x="3.42495" data-y="0.20005000000000006" x="418.4941176470
 source_trace_46" data-x="3.42495" data-y="0.6001500000000002" x="418.49411764705883" y="262.6803289057559" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_47" data-x="3.42495" data-y="1.0002500000000003" x="418.49411764705883" y="258.63124604680587" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_48" data-x="3.42495" data-y="1.4003500000000004" x="418.49411764705883" y="254.58216318785583" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_55" data-x="3.42495" data-y="1.8004500000000005" x="418.49411764705883" y="250.53308032890578" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_56" data-x="3.42495" data-y="2.20055" x="418.49411764705883" y="246.48399746995574" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.42495" data-y="2.60065" x="418.49411764705883" y="242.43491461100575" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.60065" data-y="3.42505" x="413.44111321948134" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_66" data-x="2.20055" data-y="3.42505" x="409.3920303605313" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_67" data-x="1.8004499999999999" data-y="3.42505" x="405.3429475015813" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_60" data-x="1.40035" data-y="3.42505" x="401.29386464263126" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_62" data-x="1.0002499999999999" data-y="3.42505" x="397.2447817836812" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.6001499999999997" data-y="3.42505" x="393.1956989247312" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.20005000000000006" data-y="3.42505" x="389.14661606578113" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-0.20005000000000006" data-y="3.42505" x="385.09753320683114" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_56" data-x="3.42495" data-y="1.8004500000000005" x="418.49411764705883" y="250.53308032890578" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_57" data-x="3.42495" data-y="2.20055" x="418.49411764705883" y="246.48399746995574" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.42495" data-y="2.60065" x="418.49411764705883" y="242.43491461100575" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.60065" data-y="3.42505" x="413.44111321948134" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_67" data-x="2.20055" data-y="3.42505" x="409.3920303605313" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_68" data-x="1.8004499999999999" data-y="3.42505" x="405.3429475015813" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_61" data-x="1.40035" data-y="3.42505" x="401.29386464263126" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_63" data-x="1.0002499999999999" data-y="3.42505" x="397.2447817836812" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.6001499999999997" data-y="3.42505" x="393.1956989247312" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55" data-x="0.20005000000000006" data-y="3.42505" x="389.14661606578113" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-0.20005000000000006" data-y="3.42505" x="385.09753320683114" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_54" data-x="-0.6001500000000002" data-y="3.42505" x="381.0484503478811" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_53" data-x="-1.0002500000000003" data-y="3.42505" x="376.99936748893106" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_52" data-x="-1.4003500000000004" data-y="3.42505" x="372.950284629981" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_51" data-x="-1.8004500000000005" data-y="3.42505" x="368.90120177103097" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_50" data-x="-2.20055" data-y="3.42505" x="364.852118912081" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_49" data-x="-2.60065" data-y="3.42505" x="360.80303605313094" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0" data-y="0" x="372.44781783681213" y="254.07969639468695" width="31.372549019607845" height="31.372549019607845" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="3" x="324.5793801391525" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="3" x="334.9019607843137" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="0" x="324.5793801391525" y="266.5275142314991" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="0" x="334.9019607843137" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="-3" x="324.5793801391525" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="-3" x="334.9019607843137" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="-3" x="435.90132827324476" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="-3" x="446.2239089184061" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="0" x="435.90132827324476" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="0" x="446.2239089184061" y="266.5275142314991" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="3" x="435.90132827324476" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="3" x="446.2239089184061" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-3.21" data-y="-5.7" x="352.91587602783045" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-2.1900000000000004" data-y="-5.7" x="363.2384566729918" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.1900000000000004" data-y="-5.7" x="407.5648323845668" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.21" data-y="-5.7" x="417.887413029728" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="5.2" x="435.90132827324476" y="213.9025932953827" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="5.2" x="446.2239089184061" y="213.9025932953827" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.1900000000000004" data-y="6.2" x="407.5648323845668" y="203.7824161922834" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.21" data-y="6.2" x="417.887413029728" y="203.7824161922834" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_49" data-x="-2.60065" data-y="3.42505" x="360.80303605313094" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0" data-y="0" x="372.44781783681213" y="254.07969639468695" width="31.372549019607845" height="31.372549019607845" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="3" x="324.5793801391525" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="3" x="334.9019607843137" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="0" x="324.5793801391525" y="266.5275142314991" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="0" x="334.9019607843137" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="-3" x="324.5793801391525" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-4.99" data-y="-3" x="334.9019607843137" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="-3" x="435.90132827324476" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="-3" x="446.2239089184061" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="0" x="435.90132827324476" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="0" x="446.2239089184061" y="266.5275142314991" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55" data-x="4.99" data-y="3" x="435.90132827324476" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="3" x="446.2239089184061" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-3.21" data-y="-5.7" x="352.91587602783045" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-2.1900000000000004" data-y="-5.7" x="363.2384566729918" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.1900000000000004" data-y="-5.7" x="407.5648323845668" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.21" data-y="-5.7" x="417.887413029728" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="5.2" x="435.90132827324476" y="213.9025932953827" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="6.01" data-y="5.2" x="446.2239089184061" y="213.9025932953827" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.1900000000000004" data-y="6.2" x="407.5648323845668" y="203.7824161922834" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.21" data-y="6.2" x="417.887413029728" y="203.7824161922834" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_21" data-x="-34.25" data-y="10.775" x="40" y="153.38393421884888" width="3.0360531309297585" height="14.674256799493975" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_22" data-x="-33.75" data-y="10.775" x="45.060088551549654" y="153.38393421884888" width="3.0360531309297585" height="14.674256799493975" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_23" data-x="-33.25" data-y="10.775" x="50.12017710309931" y="153.38393421884888" width="3.0360531309297585" height="14.674256799493975" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -763,22 +820,23 @@ source_trace_50" data-x="18.85" data-y="18.635" x="573.8393421884884" y="78.1404
 source_trace_51" data-x="18.85" data-y="17.365" x="573.8393421884884" y="90.99304237824164" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="18.85" data-y="16.095" x="573.8393421884884" y="103.84566729917778" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_52" data-x="23.15" data-y="16.095" x="617.3561037318152" y="103.84566729917778" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_53" data-x="23.15" data-y="17.365" x="617.3561037318152" y="90.99304237824164" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_54" data-x="23.15" data-y="18.635" x="617.3561037318152" y="78.14041745730552" width="10.120177103099309" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="23.15" data-y="19.905" x="617.3561037318152" y="65.2877925363694" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_55" data-x="27.095" data-y="-19.15" x="659.3042378241619" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_56" data-x="28.365" data-y="-19.15" x="672.1568627450981" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_61" data-x="29.635" data-y="-19.15" x="685.0094876660341" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_63" data-x="30.905" data-y="-19.15" x="697.8621125869704" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_57" data-x="30.905" data-y="-14.85" x="697.8621125869704" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_58" data-x="29.635" data-y="-14.85" x="685.0094876660341" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_59" data-x="28.365" data-y="-14.85" x="672.1568627450981" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="27.095" data-y="-14.85" x="659.3042378241619" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_60" data-x="12.175" data-y="-13" x="507.29917773561044" y="396.52118912080965" width="8.096141682479413" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_61" data-x="13.825" data-y="-13" x="523.9974699557242" y="396.52118912080965" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_62" data-x="15.175" data-y="-15" x="537.6597090449084" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_63" data-x="16.825" data-y="-15" x="554.358001265022" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_64" data-x="-13.9125" data-y="-12" x="242.15053763440858" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_65" data-x="-12.0875" data-y="-12" x="260.6198608475648" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_67" data-x="-1.1375" data-y="-18.05" x="369.91777356103734" y="449.39911448450357" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_66" data-x="-1.1375" data-y="-19.95" x="369.91777356103734" y="468.62745098039227" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="1.1375" data-y="-19" x="392.94117647058823" y="459.0132827324479" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_54" data-x="23.15" data-y="18.635" x="617.3561037318152" y="78.14041745730552" width="10.120177103099309" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55" data-x="23.15" data-y="19.905" x="617.3561037318152" y="65.2877925363694" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_56" data-x="27.095" data-y="-19.15" x="659.3042378241619" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_57" data-x="28.365" data-y="-19.15" x="672.1568627450981" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_62" data-x="29.635" data-y="-19.15" x="685.0094876660341" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_64" data-x="30.905" data-y="-19.15" x="697.8621125869704" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_58" data-x="30.905" data-y="-14.85" x="697.8621125869704" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_59" data-x="29.635" data-y="-14.85" x="685.0094876660341" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_60" data-x="28.365" data-y="-14.85" x="672.1568627450981" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="27.095" data-y="-14.85" x="659.3042378241619" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_61" data-x="12.175" data-y="-13" x="507.29917773561044" y="396.52118912080965" width="8.096141682479413" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_62" data-x="13.825" data-y="-13" x="523.9974699557242" y="396.52118912080965" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_63" data-x="15.175" data-y="-15" x="537.6597090449084" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_64" data-x="16.825" data-y="-15" x="554.358001265022" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_65" data-x="-13.9125" data-y="-12" x="242.15053763440858" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_66" data-x="-12.0875" data-y="-12" x="260.6198608475648" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_68" data-x="-1.1375" data-y="-18.05" x="369.91777356103734" y="449.39911448450357" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_67" data-x="-1.1375" data-y="-19.95" x="369.91777356103734" y="468.62745098039227" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="1.1375" data-y="-19" x="392.94117647058823" y="459.0132827324479" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_39
 bottom
 source_trace_39" data-x="-32" data-y="-25.43" x="56.69829222011384" y="519.5319418089819" width="15.180265654648906" height="15.180265654648906" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -815,8 +873,12 @@ top" data-x="-4.302" data-y="0.097" x="342.32005060088545" y="266.50727387729285
 bottom" data-x="-2.275" data-y="0.113" x="362.83364958886784" y="266.3453510436433" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="bottom
 top" data-x="1.912" data-y="0.183" x="405.20683111954463" y="265.6369386464263" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 bottom" data-x="-0.22" data-y="-4.88" x="383.63061353573687" y="316.8753953194181" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="bottom
-top" data-x="0.2" data-y="4.168" x="387.8810879190386" y="225.30803289057562" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-bottom" data-x="3.504" data-y="3.325" x="421.3181530676786" y="233.83934218848833" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55
+top
+source_trace_55" data-x="0.2" data-y="4.168" x="387.8810879190386" y="225.30803289057562" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55
+bottom
+source_trace_55" data-x="3.504" data-y="3.325" x="421.3181530676786" y="233.83934218848833" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 bottom" data-x="-4.2" data-y="-0.8" x="343.35230866540167" y="275.58507273877296" width="4.554079696394638" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="bottom
 top" data-x="-5.52" data-y="-0.689" x="329.99367488931057" y="274.46173308032894" width="4.554079696394638" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><circle data-type="circle" data-label="" data-x="-5.43500637465368" data-y="-4.047838102925986" cx="333.1308652786471" cy="310.73080939077533" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-1.024" data-y="-4.996" cx="377.77103099304236" cy="320.326375711575" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-4.302" data-y="0.097" cx="344.5970904490828" cy="268.7843137254902" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-2.275" data-y="0.113" cx="365.11068943706516" cy="268.62239089184067" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="1.912" data-y="0.183" cx="407.48387096774195" cy="267.9139784946237" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-0.22" data-y="-4.88" cx="385.9076533839342" cy="319.15243516761547" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="0.2" data-y="4.168" cx="390.1581277672359" cy="227.58507273877296" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="3.504" data-y="3.325" cx="423.595192915876" cy="236.11638203668568" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-4.2" data-y="-0.8" cx="345.629348513599" cy="277.86211258697034" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-5.52" data-y="-0.689" cx="332.2707147375079" cy="276.7387729285263" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><g><circle data-type="point" data-label="source_trace_21
 source_trace_21
@@ -824,189 +886,237 @@ top" data-x="-34.25" data-y="10.775" cx="41.51802656546488" cy="160.721062618595
 source_trace_21
 top" data-x="-3.42495" data-y="2.20055" cx="353.47299177735607" cy="247.4960151802657" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_22
 source_trace_22
-top" data-x="-33.75" data-y="10.775" cx="46.578115117014534" cy="160.72106261859585" r="3" fill="hsl(7.23404255319149, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_22
+top" data-x="-33.75" data-y="10.775" cx="46.578115117014534" cy="160.72106261859585" r="3" fill="hsl(7.083333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_22
 source_trace_22
-top" data-x="-3.42495" data-y="1.8004499999999999" cx="353.47299177735607" cy="251.54509803921573" r="3" fill="hsl(7.23404255319149, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
+top" data-x="-3.42495" data-y="1.8004499999999999" cx="353.47299177735607" cy="251.54509803921573" r="3" fill="hsl(7.083333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
 source_trace_23
-top" data-x="-33.25" data-y="10.775" cx="51.63820366856419" cy="160.72106261859585" r="3" fill="hsl(14.46808510638298, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
+top" data-x="-33.25" data-y="10.775" cx="51.63820366856419" cy="160.72106261859585" r="3" fill="hsl(14.166666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
 source_trace_23
-top" data-x="-3.42495" data-y="1.40035" cx="353.47299177735607" cy="255.59418089816575" r="3" fill="hsl(14.46808510638298, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
+top" data-x="-3.42495" data-y="1.40035" cx="353.47299177735607" cy="255.59418089816575" r="3" fill="hsl(14.166666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
 source_trace_24
-top" data-x="-32.75" data-y="10.775" cx="56.69829222011384" cy="160.72106261859585" r="3" fill="hsl(21.70212765957447, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
+top" data-x="-32.75" data-y="10.775" cx="56.69829222011384" cy="160.72106261859585" r="3" fill="hsl(21.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
 source_trace_24
-top" data-x="-3.42495" data-y="1.0002499999999999" cx="353.47299177735607" cy="259.6432637571158" r="3" fill="hsl(21.70212765957447, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
+top" data-x="-3.42495" data-y="1.0002499999999999" cx="353.47299177735607" cy="259.6432637571158" r="3" fill="hsl(21.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
 source_trace_25
-top" data-x="-32.25" data-y="10.775" cx="61.7583807716635" cy="160.72106261859585" r="3" fill="hsl(28.93617021276596, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
+top" data-x="-32.25" data-y="10.775" cx="61.7583807716635" cy="160.72106261859585" r="3" fill="hsl(28.333333333333332, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
 source_trace_25
-top" data-x="-3.42495" data-y="0.6001499999999997" cx="353.47299177735607" cy="263.69234661606583" r="3" fill="hsl(28.93617021276596, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
+top" data-x="-3.42495" data-y="0.6001499999999997" cx="353.47299177735607" cy="263.69234661606583" r="3" fill="hsl(28.333333333333332, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
 source_trace_26
-top" data-x="-31.75" data-y="10.775" cx="66.8184693232131" cy="160.72106261859585" r="3" fill="hsl(36.170212765957444, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
+top" data-x="-31.75" data-y="10.775" cx="66.8184693232131" cy="160.72106261859585" r="3" fill="hsl(35.416666666666664, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
 source_trace_26
-top" data-x="-3.42495" data-y="0.20005000000000006" cx="353.47299177735607" cy="267.7414294750159" r="3" fill="hsl(36.170212765957444, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
+top" data-x="-3.42495" data-y="0.20005000000000006" cx="353.47299177735607" cy="267.7414294750159" r="3" fill="hsl(35.416666666666664, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
 source_trace_27
-top" data-x="-31.25" data-y="10.775" cx="71.87855787476275" cy="160.72106261859585" r="3" fill="hsl(43.40425531914894, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
+top" data-x="-31.25" data-y="10.775" cx="71.87855787476275" cy="160.72106261859585" r="3" fill="hsl(42.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
 source_trace_27
-top" data-x="-3.42495" data-y="-0.20005000000000006" cx="353.47299177735607" cy="271.79051233396586" r="3" fill="hsl(43.40425531914894, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
+top" data-x="-3.42495" data-y="-0.20005000000000006" cx="353.47299177735607" cy="271.79051233396586" r="3" fill="hsl(42.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
 source_trace_28
-top" data-x="-30.75" data-y="10.775" cx="76.9386464263124" cy="160.72106261859585" r="3" fill="hsl(50.638297872340424, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
+top" data-x="-30.75" data-y="10.775" cx="76.9386464263124" cy="160.72106261859585" r="3" fill="hsl(49.583333333333336, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
 source_trace_28
-top" data-x="-3.42495" data-y="-0.6001500000000002" cx="353.47299177735607" cy="275.8395951929159" r="3" fill="hsl(50.638297872340424, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
+top" data-x="-3.42495" data-y="-0.6001500000000002" cx="353.47299177735607" cy="275.8395951929159" r="3" fill="hsl(49.583333333333336, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
 source_trace_29
-top" data-x="-30.25" data-y="10.775" cx="81.99873497786206" cy="160.72106261859585" r="3" fill="hsl(57.87234042553192, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
+top" data-x="-30.25" data-y="10.775" cx="81.99873497786206" cy="160.72106261859585" r="3" fill="hsl(56.666666666666664, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
 source_trace_29
-top" data-x="-3.42495" data-y="-1.4003500000000004" cx="353.47299177735607" cy="283.937760910816" r="3" fill="hsl(57.87234042553192, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
+top" data-x="-3.42495" data-y="-1.4003500000000004" cx="353.47299177735607" cy="283.937760910816" r="3" fill="hsl(56.666666666666664, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
 source_trace_30
-top" data-x="-29.75" data-y="10.775" cx="87.05882352941171" cy="160.72106261859585" r="3" fill="hsl(65.1063829787234, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
+top" data-x="-29.75" data-y="10.775" cx="87.05882352941171" cy="160.72106261859585" r="3" fill="hsl(63.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
 source_trace_30
-top" data-x="-3.42495" data-y="-1.8004500000000005" cx="353.47299177735607" cy="287.98684376976604" r="3" fill="hsl(65.1063829787234, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
+top" data-x="-3.42495" data-y="-1.8004500000000005" cx="353.47299177735607" cy="287.98684376976604" r="3" fill="hsl(63.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
 source_trace_31
-top" data-x="27.555" data-y="6.8500000000000005" cx="666.9955724225174" cy="200.44275774826065" r="3" fill="hsl(72.34042553191489, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
+top" data-x="27.555" data-y="6.8500000000000005" cx="666.9955724225174" cy="200.44275774826065" r="3" fill="hsl(70.83333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
 source_trace_31
-top" data-x="-3.42495" data-y="-2.20055" cx="353.47299177735607" cy="292.035926628716" r="3" fill="hsl(72.34042553191489, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
+top" data-x="-3.42495" data-y="-2.20055" cx="353.47299177735607" cy="292.035926628716" r="3" fill="hsl(70.83333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
 source_trace_32
-top" data-x="28.825" data-y="6.85" cx="679.8481973434535" cy="200.44275774826065" r="3" fill="hsl(79.57446808510639, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
+top" data-x="28.825" data-y="6.85" cx="679.8481973434535" cy="200.44275774826065" r="3" fill="hsl(77.91666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
 source_trace_32
-top" data-x="-3.42495" data-y="-2.60065" cx="353.47299177735607" cy="296.08500948766607" r="3" fill="hsl(79.57446808510639, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
+top" data-x="-3.42495" data-y="-2.60065" cx="353.47299177735607" cy="296.08500948766607" r="3" fill="hsl(77.91666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
 source_trace_33
-top" data-x="30.095" data-y="6.85" cx="692.7008222643897" cy="200.44275774826065" r="3" fill="hsl(86.80851063829788, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
+top" data-x="30.095" data-y="6.85" cx="692.7008222643897" cy="200.44275774826065" r="3" fill="hsl(85, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
 source_trace_33
-top" data-x="-2.60065" data-y="-3.42505" cx="361.81505376344086" cy="304.42808349146117" r="3" fill="hsl(86.80851063829788, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
+top" data-x="-2.60065" data-y="-3.42505" cx="361.81505376344086" cy="304.42808349146117" r="3" fill="hsl(85, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
 source_trace_34
-top" data-x="31.365" data-y="6.85" cx="705.5534471853257" cy="200.44275774826065" r="3" fill="hsl(94.04255319148936, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
+top" data-x="31.365" data-y="6.85" cx="705.5534471853257" cy="200.44275774826065" r="3" fill="hsl(92.08333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
 source_trace_34
-top" data-x="-2.20055" data-y="-3.42505" cx="365.8641366223909" cy="304.42808349146117" r="3" fill="hsl(94.04255319148936, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
+top" data-x="-2.20055" data-y="-3.42505" cx="365.8641366223909" cy="304.42808349146117" r="3" fill="hsl(92.08333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
 source_trace_35
-top" data-x="32.635" data-y="6.85" cx="718.4060721062618" cy="200.44275774826065" r="3" fill="hsl(101.27659574468085, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
+top" data-x="32.635" data-y="6.85" cx="718.4060721062618" cy="200.44275774826065" r="3" fill="hsl(99.16666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
 source_trace_35
-top" data-x="-1.8004499999999999" data-y="-3.42505" cx="369.9132194813409" cy="304.42808349146117" r="3" fill="hsl(101.27659574468085, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
+top" data-x="-1.8004499999999999" data-y="-3.42505" cx="369.9132194813409" cy="304.42808349146117" r="3" fill="hsl(99.16666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
 source_trace_36
-top" data-x="33.905" data-y="6.85" cx="731.258697027198" cy="200.44275774826065" r="3" fill="hsl(108.51063829787235, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
+top" data-x="33.905" data-y="6.85" cx="731.258697027198" cy="200.44275774826065" r="3" fill="hsl(106.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
 source_trace_36
-top" data-x="-1.40035" data-y="-3.42505" cx="373.96230234029093" cy="304.42808349146117" r="3" fill="hsl(108.51063829787235, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
+top" data-x="-1.40035" data-y="-3.42505" cx="373.96230234029093" cy="304.42808349146117" r="3" fill="hsl(106.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
 source_trace_37
-top" data-x="35.175" data-y="6.85" cx="744.1113219481341" cy="200.44275774826065" r="3" fill="hsl(115.74468085106383, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
+top" data-x="35.175" data-y="6.85" cx="744.1113219481341" cy="200.44275774826065" r="3" fill="hsl(113.33333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
 source_trace_37
-top" data-x="2.20055" data-y="-3.42505" cx="410.4040480708412" cy="304.42808349146117" r="3" fill="hsl(115.74468085106383, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
+top" data-x="2.20055" data-y="-3.42505" cx="410.4040480708412" cy="304.42808349146117" r="3" fill="hsl(113.33333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
 source_trace_38
-top" data-x="36.445" data-y="6.85" cx="756.9639468690702" cy="200.44275774826065" r="3" fill="hsl(122.97872340425532, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
+top" data-x="36.445" data-y="6.85" cx="756.9639468690702" cy="200.44275774826065" r="3" fill="hsl(120.41666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
 source_trace_38
-top" data-x="2.60065" data-y="-3.42505" cx="414.45313092979126" cy="304.42808349146117" r="3" fill="hsl(122.97872340425532, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
+top" data-x="2.60065" data-y="-3.42505" cx="414.45313092979126" cy="304.42808349146117" r="3" fill="hsl(120.41666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
 source_trace_39
-top" data-x="-32" data-y="-25.43" cx="64.2884250474383" cy="527.1220746363063" r="3" fill="hsl(130.2127659574468, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
+top" data-x="-32" data-y="-25.43" cx="64.2884250474383" cy="527.1220746363063" r="3" fill="hsl(127.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
 source_trace_39
-top" data-x="3.42495" data-y="-2.60065" cx="422.79519291587604" cy="296.08500948766607" r="3" fill="hsl(130.2127659574468, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
+top" data-x="3.42495" data-y="-2.60065" cx="422.79519291587604" cy="296.08500948766607" r="3" fill="hsl(127.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
 source_trace_40
-top" data-x="-32" data-y="-22.89" cx="64.2884250474383" cy="501.416824794434" r="3" fill="hsl(137.4468085106383, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
+top" data-x="-32" data-y="-22.89" cx="64.2884250474383" cy="501.416824794434" r="3" fill="hsl(134.58333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
 source_trace_40
-top" data-x="3.42495" data-y="-2.20055" cx="422.79519291587604" cy="292.035926628716" r="3" fill="hsl(137.4468085106383, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
+top" data-x="3.42495" data-y="-2.20055" cx="422.79519291587604" cy="292.035926628716" r="3" fill="hsl(134.58333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
 source_trace_41
-top" data-x="-32" data-y="-20.35" cx="64.2884250474383" cy="475.7115749525617" r="3" fill="hsl(144.68085106382978, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
+top" data-x="-32" data-y="-20.35" cx="64.2884250474383" cy="475.7115749525617" r="3" fill="hsl(141.66666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
 source_trace_41
-top" data-x="3.42495" data-y="-1.8004499999999999" cx="422.79519291587604" cy="287.98684376976604" r="3" fill="hsl(144.68085106382978, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
+top" data-x="3.42495" data-y="-1.8004499999999999" cx="422.79519291587604" cy="287.98684376976604" r="3" fill="hsl(141.66666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
 source_trace_42
-top" data-x="-32" data-y="-17.81" cx="64.2884250474383" cy="450.0063251106895" r="3" fill="hsl(151.91489361702128, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
+top" data-x="-32" data-y="-17.81" cx="64.2884250474383" cy="450.0063251106895" r="3" fill="hsl(148.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
 source_trace_42
-top" data-x="3.42495" data-y="-1.40035" cx="422.79519291587604" cy="283.937760910816" r="3" fill="hsl(151.91489361702128, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
+top" data-x="3.42495" data-y="-1.40035" cx="422.79519291587604" cy="283.937760910816" r="3" fill="hsl(148.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
 source_trace_43
-top" data-x="-32" data-y="-15.27" cx="64.2884250474383" cy="424.30107526881727" r="3" fill="hsl(159.14893617021278, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
+top" data-x="-32" data-y="-15.27" cx="64.2884250474383" cy="424.30107526881727" r="3" fill="hsl(155.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
 source_trace_43
-top" data-x="3.42495" data-y="-0.6001499999999997" cx="422.79519291587604" cy="275.8395951929159" r="3" fill="hsl(159.14893617021278, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
+top" data-x="3.42495" data-y="-0.6001499999999997" cx="422.79519291587604" cy="275.8395951929159" r="3" fill="hsl(155.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
 source_trace_44
-top" data-x="-32" data-y="-12.73" cx="64.2884250474383" cy="398.595825426945" r="3" fill="hsl(166.38297872340425, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
+top" data-x="-32" data-y="-12.73" cx="64.2884250474383" cy="398.595825426945" r="3" fill="hsl(162.91666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
 source_trace_44
-top" data-x="3.42495" data-y="-0.20005000000000006" cx="422.79519291587604" cy="271.79051233396586" r="3" fill="hsl(166.38297872340425, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
+top" data-x="3.42495" data-y="-0.20005000000000006" cx="422.79519291587604" cy="271.79051233396586" r="3" fill="hsl(162.91666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
 source_trace_45
-top" data-x="-32" data-y="-10.19" cx="64.2884250474383" cy="372.8905755850728" r="3" fill="hsl(173.61702127659575, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
+top" data-x="-32" data-y="-10.19" cx="64.2884250474383" cy="372.8905755850728" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
 source_trace_45
-top" data-x="3.42495" data-y="0.20005000000000006" cx="422.79519291587604" cy="267.7414294750159" r="3" fill="hsl(173.61702127659575, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
+top" data-x="3.42495" data-y="0.20005000000000006" cx="422.79519291587604" cy="267.7414294750159" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
 source_trace_46
-top" data-x="-32" data-y="-7.649999999999999" cx="64.2884250474383" cy="347.18532574320056" r="3" fill="hsl(180.85106382978722, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
+top" data-x="-32" data-y="-7.649999999999999" cx="64.2884250474383" cy="347.18532574320056" r="3" fill="hsl(177.08333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
 source_trace_46
-top" data-x="3.42495" data-y="0.6001500000000002" cx="422.79519291587604" cy="263.69234661606583" r="3" fill="hsl(180.85106382978722, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
+top" data-x="3.42495" data-y="0.6001500000000002" cx="422.79519291587604" cy="263.69234661606583" r="3" fill="hsl(177.08333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
 source_trace_47
-top" data-x="-32" data-y="-5.109999999999999" cx="64.2884250474383" cy="321.4800759013283" r="3" fill="hsl(188.08510638297872, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
+top" data-x="-32" data-y="-5.109999999999999" cx="64.2884250474383" cy="321.4800759013283" r="3" fill="hsl(184.16666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
 source_trace_47
-top" data-x="3.42495" data-y="1.0002500000000003" cx="422.79519291587604" cy="259.6432637571158" r="3" fill="hsl(188.08510638297872, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
+top" data-x="3.42495" data-y="1.0002500000000003" cx="422.79519291587604" cy="259.6432637571158" r="3" fill="hsl(184.16666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
 source_trace_48
-top" data-x="-32" data-y="-2.5700000000000003" cx="64.2884250474383" cy="295.7748260594561" r="3" fill="hsl(195.31914893617022, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
+top" data-x="-32" data-y="-2.5700000000000003" cx="64.2884250474383" cy="295.7748260594561" r="3" fill="hsl(191.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
 source_trace_48
-top" data-x="3.42495" data-y="1.4003500000000004" cx="422.79519291587604" cy="255.59418089816575" r="3" fill="hsl(195.31914893617022, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
+top" data-x="3.42495" data-y="1.4003500000000004" cx="422.79519291587604" cy="255.59418089816575" r="3" fill="hsl(191.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
 source_trace_49
-top" data-x="18.85" data-y="19.905" cx="578.899430740038" cy="68.3238456672992" r="3" fill="hsl(202.5531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
+top" data-x="18.85" data-y="19.905" cx="578.899430740038" cy="68.3238456672992" r="3" fill="hsl(198.33333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
 source_trace_49
-top" data-x="-2.60065" data-y="3.42505" cx="361.81505376344086" cy="235.1038583175206" r="3" fill="hsl(202.5531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
+top" data-x="-2.60065" data-y="3.42505" cx="361.81505376344086" cy="235.1038583175206" r="3" fill="hsl(198.33333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
 source_trace_50
-top" data-x="18.85" data-y="18.635" cx="578.899430740038" cy="81.1764705882353" r="3" fill="hsl(209.7872340425532, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
+top" data-x="18.85" data-y="18.635" cx="578.899430740038" cy="81.1764705882353" r="3" fill="hsl(205.41666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
 source_trace_50
-top" data-x="-2.20055" data-y="3.42505" cx="365.8641366223909" cy="235.1038583175206" r="3" fill="hsl(209.7872340425532, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
+top" data-x="-2.20055" data-y="3.42505" cx="365.8641366223909" cy="235.1038583175206" r="3" fill="hsl(205.41666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
 source_trace_51
-top" data-x="18.85" data-y="17.365" cx="578.899430740038" cy="94.02909550917144" r="3" fill="hsl(217.0212765957447, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
+top" data-x="18.85" data-y="17.365" cx="578.899430740038" cy="94.02909550917144" r="3" fill="hsl(212.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
 source_trace_51
-top" data-x="-1.8004500000000005" data-y="3.42505" cx="369.9132194813409" cy="235.1038583175206" r="3" fill="hsl(217.0212765957447, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
+top" data-x="-1.8004500000000005" data-y="3.42505" cx="369.9132194813409" cy="235.1038583175206" r="3" fill="hsl(212.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
 source_trace_52
-top" data-x="23.15" data-y="16.095" cx="622.4161922833649" cy="106.88172043010758" r="3" fill="hsl(224.25531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
+top" data-x="23.15" data-y="16.095" cx="622.4161922833649" cy="106.88172043010758" r="3" fill="hsl(219.58333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
 source_trace_52
-top" data-x="-1.4003500000000004" data-y="3.42505" cx="373.96230234029093" cy="235.1038583175206" r="3" fill="hsl(224.25531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
+top" data-x="-1.4003500000000004" data-y="3.42505" cx="373.96230234029093" cy="235.1038583175206" r="3" fill="hsl(219.58333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
 source_trace_53
-top" data-x="23.15" data-y="17.365" cx="622.4161922833649" cy="94.02909550917144" r="3" fill="hsl(231.48936170212767, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
+top" data-x="23.15" data-y="17.365" cx="622.4161922833649" cy="94.02909550917144" r="3" fill="hsl(226.66666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
 source_trace_53
-top" data-x="-1.0002500000000003" data-y="3.42505" cx="378.011385199241" cy="235.1038583175206" r="3" fill="hsl(231.48936170212767, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
+top" data-x="-1.0002500000000003" data-y="3.42505" cx="378.011385199241" cy="235.1038583175206" r="3" fill="hsl(226.66666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
 source_trace_54
-top" data-x="23.15" data-y="18.635" cx="622.4161922833649" cy="81.1764705882353" r="3" fill="hsl(238.72340425531914, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
+top" data-x="23.15" data-y="18.635" cx="622.4161922833649" cy="81.1764705882353" r="3" fill="hsl(233.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
 source_trace_54
-top" data-x="-0.6001500000000002" data-y="3.42505" cx="382.060468058191" cy="235.1038583175206" r="3" fill="hsl(238.72340425531914, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+top" data-x="-0.6001500000000002" data-y="3.42505" cx="382.060468058191" cy="235.1038583175206" r="3" fill="hsl(233.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
 source_trace_55
-top" data-x="27.095" data-y="-19.15" cx="662.3402909550916" cy="463.56736242884256" r="3" fill="hsl(245.95744680851064, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+top" data-x="23.15" data-y="19.905" cx="622.4161922833649" cy="68.3238456672992" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
 source_trace_55
-top" data-x="3.42495" data-y="1.8004500000000005" cx="422.79519291587604" cy="251.54509803921573" r="3" fill="hsl(245.95744680851064, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
+top" data-x="0.20005000000000006" data-y="3.42505" cx="390.15863377609105" cy="235.1038583175206" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.20005000000000006" data-y="3.42505" cx="390.15863377609105" cy="235.1038583175206" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.2" data-y="3.425" cx="390.1581277672359" cy="235.10436432637576" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.2" data-y="3.7965" cx="390.1581277672359" cy="231.34471853257435" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.2" data-y="4.168" cx="390.1581277672359" cy="227.58507273877296" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.2" data-y="4.168" cx="390.1581277672359" cy="227.58507273877296" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.27936590381920134" data-y="4.088634096180799" cx="390.96132476983377" cy="228.38826974137083" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.27936590381920134" data-y="3.987284978680325" cx="390.96132476983377" cy="229.41394075971846" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.6105083931593638" data-y="3.6561424893401626" cx="394.3125454083174" cy="232.76516139820205" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.9416508824995262" data-y="3.325" cx="397.663766046801" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="1.368709068749605" data-y="3.325" cx="401.9856705249802" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="1.7957672549996841" data-y="3.325" cx="406.30757500315934" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="2.2228254412497632" data-y="3.325" cx="410.62947948133854" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="2.649883627499842" data-y="3.325" cx="414.95138395951767" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="3.0769418137499214" data-y="3.325" cx="419.27328843769686" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="3.504" data-y="3.325" cx="423.595192915876" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.504" data-y="3.325" cx="423.595192915876" cy="236.11638203668568" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.57064426757843" data-y="3.2583557324215704" cx="424.26964470667605" cy="236.79083382748573" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.597101639481161" data-y="3.2583557324215704" cx="424.53739799601425" cy="236.79083382748573" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.855457371902731" data-y="3" cx="427.1520037637215" cy="239.40543959519295" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="4.233638247935154" data-y="3" cx="430.97926120617484" cy="239.40543959519295" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="4.611819123967577" data-y="3" cx="434.80651864862824" cy="239.40543959519295" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="4.99" data-y="3" cx="438.6337760910816" cy="239.40543959519295" r="3" fill="hsl(240.83333333333334, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
 source_trace_56
-top" data-x="28.365" data-y="-19.15" cx="675.1929158760279" cy="463.56736242884256" r="3" fill="hsl(253.19148936170214, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
+top" data-x="27.095" data-y="-19.15" cx="662.3402909550916" cy="463.56736242884256" r="3" fill="hsl(247.91666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
 source_trace_56
-top" data-x="3.42495" data-y="2.20055" cx="422.79519291587604" cy="247.4960151802657" r="3" fill="hsl(253.19148936170214, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
+top" data-x="3.42495" data-y="1.8004500000000005" cx="422.79519291587604" cy="251.54509803921573" r="3" fill="hsl(247.91666666666666, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
 source_trace_57
-top" data-x="30.905" data-y="-14.85" cx="700.8981657179002" cy="420.05060088551556" r="3" fill="hsl(260.4255319148936, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
+top" data-x="28.365" data-y="-19.15" cx="675.1929158760279" cy="463.56736242884256" r="3" fill="hsl(255, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
 source_trace_57
-top" data-x="1.0002500000000003" data-y="-3.42505" cx="398.25679949399114" cy="304.42808349146117" r="3" fill="hsl(260.4255319148936, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
+top" data-x="3.42495" data-y="2.20055" cx="422.79519291587604" cy="247.4960151802657" r="3" fill="hsl(255, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
 source_trace_58
-top" data-x="29.635" data-y="-14.85" cx="688.0455407969639" cy="420.05060088551556" r="3" fill="hsl(267.6595744680851, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
+top" data-x="30.905" data-y="-14.85" cx="700.8981657179002" cy="420.05060088551556" r="3" fill="hsl(262.0833333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
 source_trace_58
-top" data-x="1.4003500000000004" data-y="-3.42505" cx="402.3058823529412" cy="304.42808349146117" r="3" fill="hsl(267.6595744680851, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
+top" data-x="1.0002500000000003" data-y="-3.42505" cx="398.25679949399114" cy="304.42808349146117" r="3" fill="hsl(262.0833333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
 source_trace_59
-top" data-x="28.365" data-y="-14.85" cx="675.1929158760279" cy="420.05060088551556" r="3" fill="hsl(274.8936170212766, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
+top" data-x="29.635" data-y="-14.85" cx="688.0455407969639" cy="420.05060088551556" r="3" fill="hsl(269.1666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
 source_trace_59
-top" data-x="1.8004500000000005" data-y="-3.42505" cx="406.3549652118912" cy="304.42808349146117" r="3" fill="hsl(274.8936170212766, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
+top" data-x="1.4003500000000004" data-y="-3.42505" cx="402.3058823529412" cy="304.42808349146117" r="3" fill="hsl(269.1666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
 source_trace_60
-top" data-x="1.40035" data-y="3.42505" cx="402.3058823529412" cy="235.1038583175206" r="3" fill="hsl(282.1276595744681, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
+top" data-x="28.365" data-y="-14.85" cx="675.1929158760279" cy="420.05060088551556" r="3" fill="hsl(276.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
 source_trace_60
-top" data-x="12.175" data-y="-13" cx="511.3472485768501" cy="401.3282732447818" r="3" fill="hsl(282.1276595744681, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
+top" data-x="1.8004500000000005" data-y="-3.42505" cx="406.3549652118912" cy="304.42808349146117" r="3" fill="hsl(276.25, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
 source_trace_61
-top" data-x="13.825" data-y="-13" cx="528.0455407969639" cy="401.3282732447818" r="3" fill="hsl(289.36170212765956, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
+top" data-x="1.40035" data-y="3.42505" cx="402.3058823529412" cy="235.1038583175206" r="3" fill="hsl(283.3333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
 source_trace_61
-top" data-x="29.635" data-y="-19.15" cx="688.0455407969639" cy="463.56736242884256" r="3" fill="hsl(289.36170212765956, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
+top" data-x="12.175" data-y="-13" cx="511.3472485768501" cy="401.3282732447818" r="3" fill="hsl(283.3333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
 source_trace_62
-top" data-x="1.0002499999999999" data-y="3.42505" cx="398.25679949399114" cy="235.1038583175206" r="3" fill="hsl(296.59574468085106, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
+top" data-x="13.825" data-y="-13" cx="528.0455407969639" cy="401.3282732447818" r="3" fill="hsl(290.4166666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
 source_trace_62
-top" data-x="15.175" data-y="-15" cx="541.707779886148" cy="421.56862745098044" r="3" fill="hsl(296.59574468085106, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
+top" data-x="29.635" data-y="-19.15" cx="688.0455407969639" cy="463.56736242884256" r="3" fill="hsl(290.4166666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
 source_trace_63
-top" data-x="16.825" data-y="-15" cx="558.4060721062618" cy="421.56862745098044" r="3" fill="hsl(303.82978723404256, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
+top" data-x="1.0002499999999999" data-y="3.42505" cx="398.25679949399114" cy="235.1038583175206" r="3" fill="hsl(297.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
 source_trace_63
-top" data-x="30.905" data-y="-19.15" cx="700.8981657179002" cy="463.56736242884256" r="3" fill="hsl(303.82978723404256, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
+top" data-x="15.175" data-y="-15" cx="541.707779886148" cy="421.56862745098044" r="3" fill="hsl(297.5, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
 source_trace_64
-top" data-x="-0.6001499999999997" data-y="-3.42505" cx="382.060468058191" cy="304.42808349146117" r="3" fill="hsl(311.06382978723406, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
+top" data-x="16.825" data-y="-15" cx="558.4060721062618" cy="421.56862745098044" r="3" fill="hsl(304.5833333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
 source_trace_64
-top" data-x="-13.9125" data-y="-12" cx="247.33712839974697" cy="391.2080961416825" r="3" fill="hsl(311.06382978723406, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
+top" data-x="30.905" data-y="-19.15" cx="700.8981657179002" cy="463.56736242884256" r="3" fill="hsl(304.5833333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
 source_trace_65
-top" data-x="-0.20005000000000006" data-y="-3.42505" cx="386.10955091714106" cy="304.42808349146117" r="3" fill="hsl(318.29787234042556, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
+top" data-x="-0.6001499999999997" data-y="-3.42505" cx="382.060468058191" cy="304.42808349146117" r="3" fill="hsl(311.6666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
 source_trace_65
-top" data-x="-12.0875" data-y="-12" cx="265.8064516129032" cy="391.2080961416825" r="3" fill="hsl(318.29787234042556, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
+top" data-x="-13.9125" data-y="-12" cx="247.33712839974697" cy="391.2080961416825" r="3" fill="hsl(311.6666666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
 source_trace_66
-top" data-x="2.20055" data-y="3.42505" cx="410.4040480708412" cy="235.1038583175206" r="3" fill="hsl(325.531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
+top" data-x="-0.20005000000000006" data-y="-3.42505" cx="386.10955091714106" cy="304.42808349146117" r="3" fill="hsl(318.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
 source_trace_66
-top" data-x="-1.1375" data-y="-19.95" cx="376.6223908918406" cy="471.663504111322" r="3" fill="hsl(325.531914893617, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
+top" data-x="-12.0875" data-y="-12" cx="265.8064516129032" cy="391.2080961416825" r="3" fill="hsl(318.75, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
 source_trace_67
-top" data-x="1.8004499999999999" data-y="3.42505" cx="406.3549652118912" cy="235.1038583175206" r="3" fill="hsl(332.7659574468085, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
+top" data-x="2.20055" data-y="3.42505" cx="410.4040480708412" cy="235.1038583175206" r="3" fill="hsl(325.8333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
 source_trace_67
-top" data-x="-1.1375" data-y="-18.05" cx="376.6223908918406" cy="452.43516761543333" r="3" fill="hsl(332.7659574468085, 100%, 50%)"/></g><g id="crosshair__stack1__stack1__stack1" style="display: none"><line id="crosshair-h__stack1__stack1__stack1" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack1__stack1" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack1__stack1" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+top" data-x="-1.1375" data-y="-19.95" cx="376.6223908918406" cy="471.663504111322" r="3" fill="hsl(325.8333333333333, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_68
+source_trace_68
+top" data-x="1.8004499999999999" data-y="3.42505" cx="406.3549652118912" cy="235.1038583175206" r="3" fill="hsl(332.9166666666667, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_68
+source_trace_68
+top" data-x="-1.1375" data-y="-18.05" cx="376.6223908918406" cy="452.43516761543333" r="3" fill="hsl(332.9166666666667, 100%, 50%)"/></g><g id="crosshair__stack1__stack1__stack1" style="display: none"><line id="crosshair-h__stack1__stack1__stack1" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack1__stack1" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack1__stack1" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
               document.currentScript.parentElement.addEventListener('mousemove', (e) => {
                 const svg = e.currentTarget;
                 const rect = svg.getBoundingClientRect();
@@ -1065,11 +1175,10 @@ top" data-x="-1.1375" data-y="-18.05" cx="376.6223908918406" cy="452.43516761543
     font-size="18"
     font-weight="700"
     text-anchor="middle"
-  >FULL ROUTED CIRCUIT: 58 CONNECTIONS, 20 TRACES</text>
+  >FULL ROUTED CIRCUIT: 49 CONNECTIONS, 20 TRACES</text>
   </g>
   <g transform="translate(0, 36) scale(1, 1) translate(0, 0)">
-    <rect width="100%" height="100%" fill="#fff"/><g><polyline data-points="6.01,3 6.01,5.2" data-type="line" data-label="" points="448.95635673624287,239.40543959519295 448.95635673624287,217.1410499683745" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,5.2 5.01,6.2 3.21,6.2" data-type="line" data-label="" points="448.95635673624287,217.1410499683745 438.83617963314356,207.02087286527518 420.61986084756484,207.02087286527518" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,3 -5.529646512479694,3.5396465124796936 -6.455000999999999,3.5396465124796936 -6.455000999999999,1.465000999999999 -4.99,0" data-type="line" data-label="" points="337.63440860215053,239.40543959519295 332.17309032278615,233.94412131582857 322.8083390259329,233.94412131582857 322.8083390259329,254.9399013282733 337.63440860215053,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,0 -4.99,-3" data-type="line" data-label="" points="337.63440860215053,269.76597090449087 337.63440860215053,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,-3 6.01,0" data-type="line" data-label="" points="448.95635673624287,300.1265022137888 448.95635673624287,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,0 6.01,3" data-type="line" data-label="" points="448.95635673624287,269.76597090449087 448.95635673624287,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,-3 -5.43500637465368,-3.44500637465368 -5.43500637465368,-4.047838102925986" data-type="line" data-label="" points="337.63440860215053,300.1265022137888 333.1308652786471,304.6300455372922 333.1308652786471,310.73080939077533" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-5.43500637465368,-4.047838102925986 -5.4245847631116435,-4.058259714468022 -4.486844477579665,-4.996 -1.024,-4.996" data-type="line" data-label="" points="333.1308652786471,310.73080939077533 333.23633383315223,310.8362779452805 342.72643159944676,320.326375711575 377.77103099304236,320.326375711575" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-1.024,-4.996 -1.0565206313402955,-5.028520631340296 -1.218231781216708,-5.028520631340296 -1.8897111498764123,-5.7 -2.1900000000000004,-5.7" data-type="line" data-label="" points="377.77103099304236,320.326375711575 377.441916444374,320.65549026024337 375.8053709680788,320.65549026024337 369.00988083616534,327.4509803921569 365.97090449082856,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,-3 3.3099999999999996,-5.7 3.21,-5.7" data-type="line" data-label="" points="448.95635673624287,300.1265022137888 421.63187855787476,327.4509803921569 420.61986084756484,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,0 -4.893,0.097 -4.302,0.097" data-type="line" data-label="" points="337.63440860215053,269.76597090449087 338.6160657811512,268.7843137254902 344.5970904490828,268.7843137254902" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.302,0.097 -4.288943945821694,0.11005605417830638 -4.286,0.113 -2.275,0.113" data-type="line" data-label="" points="344.5970904490828,268.7843137254902 344.729220029635,268.65218414493813 344.75901328273244,268.62239089184067 365.11068943706516,268.62239089184067" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-2.275,0.113 -2.244249772519263,0.08224977251926317 -2.2158546998677835,0.08224977251926317 -2.1336049273485203,0 0,0" data-type="line" data-label="" points="365.11068943706516,268.62239089184067 365.4218871851308,268.9335886399063 365.70925034921913,268.9335886399063 366.5416326138037,269.76597090449087 388.13409234661606,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-2.1900000000000004,-5.7 -1.6949990000000001,-6.195001 3.205601519423781,-6.195001 3.205601519423781,-5.704398480576219 3.21,-5.7" data-type="line" data-label="" points="365.97090449082856,327.4509803921569 370.98040227703984,332.4604781783682 420.57534744514896,332.4604781783682 420.57534744514896,327.4954937945728 420.61986084756484,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.6001499999999997,3.42505 0.6000000000000001,4.609999999999999 2.1900000000000004,6.2" data-type="line" data-label="" points="394.2077166350411,235.1038583175206 394.20619860847563,223.11195445920308 410.29728020240356,207.02087286527518" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="2.60065,3.42505 4.376,5.2 4.99,5.2" data-type="line" data-label="" points="414.45313092979126,235.1038583175206 432.41998734977864,217.1410499683745 438.6337760910816,217.1410499683745" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-0.20005000000000006,3.42505 -0.13950168668368562,3.3645016866836857 -0.13950168668368562,2.9535032821423663 0.3194245814319227,2.494577014026758 0.8592828639703756,2.494577014026758 1.912,1.4418598779971337 1.912,0.183" data-type="line" data-label="" points="386.10955091714106,235.1038583175206 386.7223105711961,235.71661797157566 386.7223105711961,239.87599461462506 391.36672568179046,244.52040972521945 396.83018711165465,244.52040972521945 407.48387096774195,255.17409358130672 407.48387096774195,267.9139784946237" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="1.912,0.183 1.9436380797842585,0.1513619202157414 1.9436380797842585,0.040008943074291245 -0.22,-2.123629136709967 -0.22,-4.88" data-type="line" data-label="" points="407.48387096774195,267.9139784946237 407.8040539383606,268.2341614652424 407.8040539383606,269.36107331487125 385.9076533839342,291.2574738692976 385.9076533839342,319.15243516761547" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-0.22,-4.88 -0.21318894664096233,-4.873188946640962 0.6136221067180759,-5.7 2.1900000000000004,-5.7" data-type="line" data-label="" points="385.9076533839342,319.15243516761547 385.97658245018636,319.08350610136335 394.3440567409799,327.4509803921569 410.29728020240356,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.6001500000000002,-3.42505 0.6001500000000002,-3.877755644979012 0.2132985229154284,-4.264607122063584 0.014999959211144831,-4.4629056857678675 -1.9729056857678664,-4.4629056857678675 -3.21,-5.7" data-type="line" data-label="" points="394.2077166350411,304.42808349146117 394.2077166350411,309.00954479422154 390.2927111743497,312.92455025491296 388.2858945903721,314.93136683889054 368.16793739893365,314.93136683889054 355.6483238456673,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.20005000000000006,3.42505 0.2,3.425 0.2,4.168" data-type="line" data-label="" points="390.15863377609105,235.1038583175206 390.1581277672359,235.10436432637576 390.1581277672359,227.58507273877296" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.2,4.168 0.27936590381920134,4.088634096180799 0.27936590381920134,3.987284978680325 0.9416508824995262,3.325 3.504,3.325" data-type="line" data-label="" points="390.1581277672359,227.58507273877296 390.96132476983377,228.38826974137083 390.96132476983377,229.41394075971846 397.663766046801,236.11638203668568 423.595192915876,236.11638203668568" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="3.504,3.325 3.57064426757843,3.2583557324215704 3.597101639481161,3.2583557324215704 3.855457371902731,3 4.99,3" data-type="line" data-label="" points="423.595192915876,236.11638203668568 424.26964470667605,236.79083382748573 424.53739799601425,236.79083382748573 427.1520037637215,239.40543959519295 438.6337760910816,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="3.42495,2.60065 3.4908956959818003,2.5351043040181995 3.8971994246110677,2.5351043040181995 4.99,1.442303728629267 4.99,0" data-type="line" data-label="" points="422.79519291587604,243.44693232131567 423.462575038399,244.1102663729974 427.57444072977677,244.1102663729974 438.6337760910816,255.1696017343022 438.6337760910816,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="3.42495,-1.0002499999999999 3.42586277369945,-1.0008627736994502 3.9241425465514554,-1.0008627736994502 4.99,-2.0667202271479947 4.99,-3" data-type="line" data-label="" points="422.79519291587604,279.88867805186595 422.8044303473695,279.8948794302285 427.8471098955239,279.8948794302285 438.6337760910816,290.6815456257862 438.6337760910816,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.20005000000000006,-3.42505 0.20005000000000006,-3.816510276013182 -0.05328439803899088,-4.069844674052173 -4.786964793197829,-4.069844674052173 -5.273849820226906,-4.55672970108125 -5.504757750627475,-4.55672970108125 -5.8704683410416765,-4.191019110667049 -5.8704683410416765,-3.1395316589583233 -6.01,-3" data-type="line" data-label="" points="390.15863377609105,304.42808349146117 390.15863377609105,308.38973081354266 387.59484480162945,310.9535197880043 339.6891608531529,310.9535197880043 334.7617981507713,315.8808824903859 332.42496900060746,315.8808824903859 328.7239130571367,312.17982654691514 328.7239130571367,301.53858731393626 327.31182795698925,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-3.42495,-1.0002500000000003 -3.9705639153548153,-1.0002500000000003 -4.115023392569576,-0.8557905227852396 -4.14420947721476,-0.8557905227852396 -4.2,-0.8" data-type="line" data-label="" points="353.47299177735607,279.88867805186595 347.95128232404994,279.88867805186595 346.4893268304154,278.42672255823146 346.1939584848601,278.42672255823146 345.629348513599,277.86211258697034" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.2,-0.8 -5.353921230245549,-0.8 -5.421178286452751,-0.732742943792798 -5.476257056207201,-0.732742943792798 -5.52,-0.689" data-type="line" data-label="" points="345.629348513599,277.86211258697034 333.9514613004878,277.86211258697034 333.2708079802378,277.1814592667203 332.71340107570194,277.1814592667203 332.2707147375079,276.7387729285263" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-5.52,-0.689 -5.52,-0.4900000000000002 -6.01,0" data-type="line" data-label="" points="332.2707147375079,276.7387729285263 332.2707147375079,274.7248576850095 327.31182795698925,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-3.42495,2.60065 -4.332948259642237,2.60065 -4.574662324196864,2.3589359354453725 -5.368935935445372,2.3589359354453725 -6.01,3" data-type="line" data-label="" points="353.47299177735607,243.44693232131567 344.2838885804707,243.44693232131567 341.8376994388679,245.8931214629185 333.79950982471473,245.8931214629185 327.31182795698925,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><rect data-type="rect" data-label="top
-source_trace_0" data-x="-3.42495" data-y="2.60065" x="349.17191650853886" y="242.43491461100575" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+    <rect width="100%" height="100%" fill="#fff"/><g><polyline data-points="6.01,3 6.01,5.2" data-type="line" data-label="" points="448.95635673624287,239.40543959519295 448.95635673624287,217.1410499683745" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,5.2 5.01,6.2 3.21,6.2" data-type="line" data-label="" points="448.95635673624287,217.1410499683745 438.83617963314356,207.02087286527518 420.61986084756484,207.02087286527518" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,3 -5.529646512479694,3.5396465124796936 -6.455000999999999,3.5396465124796936 -6.455000999999999,1.465000999999999 -4.99,0" data-type="line" data-label="" points="337.63440860215053,239.40543959519295 332.17309032278615,233.94412131582857 322.8083390259329,233.94412131582857 322.8083390259329,254.9399013282733 337.63440860215053,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,0 -4.99,-3" data-type="line" data-label="" points="337.63440860215053,269.76597090449087 337.63440860215053,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,-3 6.01,0" data-type="line" data-label="" points="448.95635673624287,300.1265022137888 448.95635673624287,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,0 6.01,3" data-type="line" data-label="" points="448.95635673624287,269.76597090449087 448.95635673624287,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,-3 -5.43500637465368,-3.44500637465368 -5.43500637465368,-4.047838102925986" data-type="line" data-label="" points="337.63440860215053,300.1265022137888 333.1308652786471,304.6300455372922 333.1308652786471,310.73080939077533" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-5.43500637465368,-4.047838102925986 -5.4245847631116435,-4.058259714468022 -4.486844477579665,-4.996 -1.024,-4.996" data-type="line" data-label="" points="333.1308652786471,310.73080939077533 333.23633383315223,310.8362779452805 342.72643159944676,320.326375711575 377.77103099304236,320.326375711575" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-1.024,-4.996 -1.0565206313402955,-5.028520631340296 -1.218231781216708,-5.028520631340296 -1.8897111498764123,-5.7 -2.1900000000000004,-5.7" data-type="line" data-label="" points="377.77103099304236,320.326375711575 377.441916444374,320.65549026024337 375.8053709680788,320.65549026024337 369.00988083616534,327.4509803921569 365.97090449082856,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="6.01,-3 3.3099999999999996,-5.7 3.21,-5.7" data-type="line" data-label="" points="448.95635673624287,300.1265022137888 421.63187855787476,327.4509803921569 420.61986084756484,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.99,0 -4.893,0.097 -4.302,0.097" data-type="line" data-label="" points="337.63440860215053,269.76597090449087 338.6160657811512,268.7843137254902 344.5970904490828,268.7843137254902" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.302,0.097 -4.288943945821694,0.11005605417830638 -4.286,0.113 -2.275,0.113" data-type="line" data-label="" points="344.5970904490828,268.7843137254902 344.729220029635,268.65218414493813 344.75901328273244,268.62239089184067 365.11068943706516,268.62239089184067" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-2.275,0.113 -2.244249772519263,0.08224977251926317 -2.2158546998677835,0.08224977251926317 -2.1336049273485203,0 0,0" data-type="line" data-label="" points="365.11068943706516,268.62239089184067 365.4218871851308,268.9335886399063 365.70925034921913,268.9335886399063 366.5416326138037,269.76597090449087 388.13409234661606,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-2.1900000000000004,-5.7 -1.6949990000000001,-6.195001 3.205601519423781,-6.195001 3.205601519423781,-5.704398480576219 3.21,-5.7" data-type="line" data-label="" points="365.97090449082856,327.4509803921569 370.98040227703984,332.4604781783682 420.57534744514896,332.4604781783682 420.57534744514896,327.4954937945728 420.61986084756484,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.6001499999999997,3.42505 0.6000000000000001,4.609999999999999 2.1900000000000004,6.2" data-type="line" data-label="" points="394.2077166350411,235.1038583175206 394.20619860847563,223.11195445920308 410.29728020240356,207.02087286527518" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="2.60065,3.42505 4.376,5.2 4.99,5.2" data-type="line" data-label="" points="414.45313092979126,235.1038583175206 432.41998734977864,217.1410499683745 438.6337760910816,217.1410499683745" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-0.20005000000000006,3.42505 -0.13950168668368562,3.3645016866836857 -0.13950168668368562,2.9535032821423663 0.3194245814319227,2.494577014026758 0.8592828639703756,2.494577014026758 1.912,1.4418598779971337 1.912,0.183" data-type="line" data-label="" points="386.10955091714106,235.1038583175206 386.7223105711961,235.71661797157566 386.7223105711961,239.87599461462506 391.36672568179046,244.52040972521945 396.83018711165465,244.52040972521945 407.48387096774195,255.17409358130672 407.48387096774195,267.9139784946237" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="1.912,0.183 1.9436380797842585,0.1513619202157414 1.9436380797842585,0.040008943074291245 -0.22,-2.123629136709967 -0.22,-4.88" data-type="line" data-label="" points="407.48387096774195,267.9139784946237 407.8040539383606,268.2341614652424 407.8040539383606,269.36107331487125 385.9076533839342,291.2574738692976 385.9076533839342,319.15243516761547" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-0.22,-4.88 -0.21318894664096233,-4.873188946640962 0.6136221067180759,-5.7 2.1900000000000004,-5.7" data-type="line" data-label="" points="385.9076533839342,319.15243516761547 385.97658245018636,319.08350610136335 394.3440567409799,327.4509803921569 410.29728020240356,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.6001500000000002,-3.42505 0.6001500000000002,-3.877755644979012 0.2132985229154284,-4.264607122063584 0.014999959211144831,-4.4629056857678675 -1.9729056857678664,-4.4629056857678675 -3.21,-5.7" data-type="line" data-label="" points="394.2077166350411,304.42808349146117 394.2077166350411,309.00954479422154 390.2927111743497,312.92455025491296 388.2858945903721,314.93136683889054 368.16793739893365,314.93136683889054 355.6483238456673,327.4509803921569" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.20005000000000006,3.42505 0.2,3.425 0.2,4.168" data-type="line" data-label="" points="390.15863377609105,235.1038583175206 390.1581277672359,235.10436432637576 390.1581277672359,227.58507273877296" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.2,4.168 0.27936590381920134,4.088634096180799 0.27936590381920134,3.987284978680325 0.9416508824995262,3.325 3.504,3.325" data-type="line" data-label="" points="390.1581277672359,227.58507273877296 390.96132476983377,228.38826974137083 390.96132476983377,229.41394075971846 397.663766046801,236.11638203668568 423.595192915876,236.11638203668568" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="3.504,3.325 3.57064426757843,3.2583557324215704 3.597101639481161,3.2583557324215704 3.855457371902731,3 4.99,3" data-type="line" data-label="" points="423.595192915876,236.11638203668568 424.26964470667605,236.79083382748573 424.53739799601425,236.79083382748573 427.1520037637215,239.40543959519295 438.6337760910816,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="3.42495,2.60065 3.4908956959818003,2.5351043040181995 3.8971994246110677,2.5351043040181995 4.99,1.442303728629267 4.99,0" data-type="line" data-label="" points="422.79519291587604,243.44693232131567 423.462575038399,244.1102663729974 427.57444072977677,244.1102663729974 438.6337760910816,255.1696017343022 438.6337760910816,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="3.42495,-1.0002499999999999 3.42586277369945,-1.0008627736994502 3.9241425465514554,-1.0008627736994502 4.99,-2.0667202271479947 4.99,-3" data-type="line" data-label="" points="422.79519291587604,279.88867805186595 422.8044303473695,279.8948794302285 427.8471098955239,279.8948794302285 438.6337760910816,290.6815456257862 438.6337760910816,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="0.20005000000000006,-3.42505 0.20005000000000006,-3.816510276013182 -0.05328439803899088,-4.069844674052173 -4.786964793197829,-4.069844674052173 -5.273849820226906,-4.55672970108125 -5.504757750627475,-4.55672970108125 -5.8704683410416765,-4.191019110667049 -5.8704683410416765,-3.1395316589583233 -6.01,-3" data-type="line" data-label="" points="390.15863377609105,304.42808349146117 390.15863377609105,308.38973081354266 387.59484480162945,310.9535197880043 339.6891608531529,310.9535197880043 334.7617981507713,315.8808824903859 332.42496900060746,315.8808824903859 328.7239130571367,312.17982654691514 328.7239130571367,301.53858731393626 327.31182795698925,300.1265022137888" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-3.42495,-1.0002500000000003 -3.9705639153548153,-1.0002500000000003 -4.115023392569576,-0.8557905227852396 -4.14420947721476,-0.8557905227852396 -4.2,-0.8" data-type="line" data-label="" points="353.47299177735607,279.88867805186595 347.95128232404994,279.88867805186595 346.4893268304154,278.42672255823146 346.1939584848601,278.42672255823146 345.629348513599,277.86211258697034" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-4.2,-0.8 -5.353921230245549,-0.8 -5.421178286452751,-0.732742943792798 -5.476257056207201,-0.732742943792798 -5.52,-0.689" data-type="line" data-label="" points="345.629348513599,277.86211258697034 333.9514613004878,277.86211258697034 333.2708079802378,277.1814592667203 332.71340107570194,277.1814592667203 332.2707147375079,276.7387729285263" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="1.5180265654648957" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="-5.52,-0.689 -5.52,-0.4900000000000002 -6.01,0" data-type="line" data-label="" points="332.2707147375079,276.7387729285263 332.2707147375079,274.7248576850095 327.31182795698925,269.76597090449087" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><polyline data-points="-3.42495,2.60065 -4.332948259642237,2.60065 -4.574662324196864,2.3589359354453725 -5.368935935445372,2.3589359354453725 -6.01,3" data-type="line" data-label="" points="353.47299177735607,243.44693232131567 344.2838885804707,243.44693232131567 341.8376994388679,245.8931214629185 333.79950982471473,245.8931214629185 327.31182795698925,239.40543959519295" fill="none" stroke="red" stroke-width="1.5180265654648957"/></g><g><rect data-type="rect" data-label="top" data-x="-3.42495" data-y="2.60065" x="349.17191650853886" y="242.43491461100575" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_21" data-x="-3.42495" data-y="2.20055" x="349.17191650853886" y="246.48399746995574" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_22" data-x="-3.42495" data-y="1.8004499999999999" x="349.17191650853886" y="250.53308032890578" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_23" data-x="-3.42495" data-y="1.40035" x="349.17191650853886" y="254.58216318785583" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -1077,8 +1186,7 @@ source_trace_24" data-x="-3.42495" data-y="1.0002499999999999" x="349.1719165085
 source_trace_25" data-x="-3.42495" data-y="0.6001499999999997" x="349.17191650853886" y="262.6803289057559" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_26" data-x="-3.42495" data-y="0.20005000000000006" x="349.17191650853886" y="266.7294117647059" width="8.602150537634373" height="2.024035420619896" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_27" data-x="-3.42495" data-y="-0.20005000000000006" x="349.17191650853886" y="270.7784946236559" width="8.602150537634373" height="2.024035420619896" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_28" data-x="-3.42495" data-y="-0.6001500000000002" x="349.17191650853886" y="274.827577482606" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_1" data-x="-3.42495" data-y="-1.0002500000000003" x="349.17191650853886" y="278.87666034155603" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_28" data-x="-3.42495" data-y="-0.6001500000000002" x="349.17191650853886" y="274.827577482606" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-3.42495" data-y="-1.0002500000000003" x="349.17191650853886" y="278.87666034155603" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_29" data-x="-3.42495" data-y="-1.4003500000000004" x="349.17191650853886" y="282.9257432005061" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_30" data-x="-3.42495" data-y="-1.8004500000000005" x="349.17191650853886" y="286.97482605945606" width="8.602150537634373" height="2.024035420619896" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_31" data-x="-3.42495" data-y="-2.20055" x="349.17191650853886" y="291.02390891840605" width="8.602150537634373" height="2.024035420619896" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -1087,63 +1195,47 @@ source_trace_33" data-x="-2.60065" data-y="-3.42505" x="360.80303605313094" y="3
 source_trace_34" data-x="-2.20055" data-y="-3.42505" x="364.852118912081" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_35" data-x="-1.8004499999999999" data-y="-3.42505" x="368.90120177103097" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_36" data-x="-1.40035" data-y="-3.42505" x="372.950284629981" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-1.0002499999999999" data-y="-3.42505" x="376.99936748893106" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_64" data-x="-0.6001499999999997" data-y="-3.42505" x="381.0484503478811" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_65" data-x="-0.20005000000000006" data-y="-3.42505" x="385.09753320683114" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_2" data-x="0.20005000000000006" data-y="-3.42505" x="389.14661606578113" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_6" data-x="0.6001500000000002" data-y="-3.42505" x="393.1956989247312" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_57" data-x="1.0002500000000003" data-y="-3.42505" x="397.2447817836812" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_58" data-x="1.4003500000000004" data-y="-3.42505" x="401.29386464263126" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_59" data-x="1.8004500000000005" data-y="-3.42505" x="405.3429475015813" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_65" data-x="-0.6001499999999997" data-y="-3.42505" x="381.0484503478811" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_66" data-x="-0.20005000000000006" data-y="-3.42505" x="385.09753320683114" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.20005000000000006" data-y="-3.42505" x="389.14661606578113" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.6001500000000002" data-y="-3.42505" x="393.1956989247312" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_58" data-x="1.0002500000000003" data-y="-3.42505" x="397.2447817836812" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_59" data-x="1.4003500000000004" data-y="-3.42505" x="401.29386464263126" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_60" data-x="1.8004500000000005" data-y="-3.42505" x="405.3429475015813" y="300.127008222644" width="2.024035420619896" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_37" data-x="2.20055" data-y="-3.42505" x="409.3920303605313" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_38" data-x="2.60065" data-y="-3.42505" x="413.44111321948134" y="300.127008222644" width="2.024035420619839" height="8.602150537634373" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_39" data-x="3.42495" data-y="-2.60065" x="418.49411764705883" y="295.07299177735615" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_40" data-x="3.42495" data-y="-2.20055" x="418.49411764705883" y="291.02390891840605" width="8.602150537634373" height="2.024035420619896" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_41" data-x="3.42495" data-y="-1.8004499999999999" x="418.49411764705883" y="286.97482605945606" width="8.602150537634373" height="2.024035420619896" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_42" data-x="3.42495" data-y="-1.40035" x="418.49411764705883" y="282.9257432005061" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_3" data-x="3.42495" data-y="-1.0002499999999999" x="418.49411764705883" y="278.87666034155603" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_42" data-x="3.42495" data-y="-1.40035" x="418.49411764705883" y="282.9257432005061" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.42495" data-y="-1.0002499999999999" x="418.49411764705883" y="278.87666034155603" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_43" data-x="3.42495" data-y="-0.6001499999999997" x="418.49411764705883" y="274.827577482606" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_44" data-x="3.42495" data-y="-0.20005000000000006" x="418.49411764705883" y="270.7784946236559" width="8.602150537634373" height="2.024035420619896" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_45" data-x="3.42495" data-y="0.20005000000000006" x="418.49411764705883" y="266.7294117647059" width="8.602150537634373" height="2.024035420619896" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_46" data-x="3.42495" data-y="0.6001500000000002" x="418.49411764705883" y="262.6803289057559" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_47" data-x="3.42495" data-y="1.0002500000000003" x="418.49411764705883" y="258.63124604680587" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_48" data-x="3.42495" data-y="1.4003500000000004" x="418.49411764705883" y="254.58216318785583" width="8.602150537634373" height="2.024035420619839" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_55" data-x="3.42495" data-y="1.8004500000000005" x="418.49411764705883" y="250.53308032890578" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_56" data-x="3.42495" data-y="2.20055" x="418.49411764705883" y="246.48399746995574" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_4" data-x="3.42495" data-y="2.60065" x="418.49411764705883" y="242.43491461100575" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_8" data-x="2.60065" data-y="3.42505" x="413.44111321948134" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_66" data-x="2.20055" data-y="3.42505" x="409.3920303605313" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_67" data-x="1.8004499999999999" data-y="3.42505" x="405.3429475015813" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_60" data-x="1.40035" data-y="3.42505" x="401.29386464263126" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_62" data-x="1.0002499999999999" data-y="3.42505" x="397.2447817836812" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_9" data-x="0.6001499999999997" data-y="3.42505" x="393.1956989247312" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_5" data-x="0.20005000000000006" data-y="3.42505" x="389.14661606578113" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_7" data-x="-0.20005000000000006" data-y="3.42505" x="385.09753320683114" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_56" data-x="3.42495" data-y="1.8004500000000005" x="418.49411764705883" y="250.53308032890578" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_57" data-x="3.42495" data-y="2.20055" x="418.49411764705883" y="246.48399746995574" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="3.42495" data-y="2.60065" x="418.49411764705883" y="242.43491461100575" width="8.602150537634373" height="2.0240354206198674" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.60065" data-y="3.42505" x="413.44111321948134" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_67" data-x="2.20055" data-y="3.42505" x="409.3920303605313" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_68" data-x="1.8004499999999999" data-y="3.42505" x="405.3429475015813" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_61" data-x="1.40035" data-y="3.42505" x="401.29386464263126" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_63" data-x="1.0002499999999999" data-y="3.42505" x="397.2447817836812" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="0.6001499999999997" data-y="3.42505" x="393.1956989247312" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55" data-x="0.20005000000000006" data-y="3.42505" x="389.14661606578113" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-0.20005000000000006" data-y="3.42505" x="385.09753320683114" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_54" data-x="-0.6001500000000002" data-y="3.42505" x="381.0484503478811" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_53" data-x="-1.0002500000000003" data-y="3.42505" x="376.99936748893106" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_52" data-x="-1.4003500000000004" data-y="3.42505" x="372.950284629981" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_51" data-x="-1.8004500000000005" data-y="3.42505" x="368.90120177103097" y="230.80278304870342" width="2.024035420619896" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_50" data-x="-2.20055" data-y="3.42505" x="364.852118912081" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_49" data-x="-2.60065" data-y="3.42505" x="360.80303605313094" y="230.80278304870342" width="2.024035420619839" height="8.602150537634401" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_net_0" data-x="0" data-y="0" x="372.44781783681213" y="254.07969639468695" width="31.372549019607845" height="31.372549019607845" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_0" data-x="-6.01" data-y="3" x="324.5793801391525" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_net_0" data-x="-4.99" data-y="3" x="334.9019607843137" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_1" data-x="-6.01" data-y="0" x="324.5793801391525" y="266.5275142314991" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_net_0" data-x="-4.99" data-y="0" x="334.9019607843137" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_2" data-x="-6.01" data-y="-3" x="324.5793801391525" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_net_0" data-x="-4.99" data-y="-3" x="334.9019607843137" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_3" data-x="4.99" data-y="-3" x="435.90132827324476" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_net_0" data-x="6.01" data-y="-3" x="446.2239089184061" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_4" data-x="4.99" data-y="0" x="435.90132827324476" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_net_0" data-x="0" data-y="0" x="372.44781783681213" y="254.07969639468695" width="31.372549019607845" height="31.372549019607845" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="3" x="324.5793801391525" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_net_0" data-x="-4.99" data-y="3" x="334.9019607843137" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="0" x="324.5793801391525" y="266.5275142314991" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_net_0" data-x="-4.99" data-y="0" x="334.9019607843137" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-6.01" data-y="-3" x="324.5793801391525" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_net_0" data-x="-4.99" data-y="-3" x="334.9019607843137" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="-3" x="435.90132827324476" y="296.888045540797" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_net_0" data-x="6.01" data-y="-3" x="446.2239089184061" y="296.888045540797" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="0" x="435.90132827324476" y="266.5275142314991" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_net_0" data-x="6.01" data-y="0" x="446.2239089184061" y="266.5275142314991" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_5" data-x="4.99" data-y="3" x="435.90132827324476" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_net_0" data-x="6.01" data-y="3" x="446.2239089184061" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_6" data-x="-3.21" data-y="-5.7" x="352.91587602783045" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_net_0" data-x="-2.1900000000000004" data-y="-5.7" x="363.2384566729918" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_7" data-x="2.1900000000000004" data-y="-5.7" x="407.5648323845668" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_net_0" data-x="3.21" data-y="-5.7" x="417.887413029728" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_8" data-x="4.99" data-y="5.2" x="435.90132827324476" y="213.9025932953827" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_net_0" data-x="6.01" data-y="5.2" x="446.2239089184061" y="213.9025932953827" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_9" data-x="2.1900000000000004" data-y="6.2" x="407.5648323845668" y="203.7824161922834" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55" data-x="4.99" data-y="3" x="435.90132827324476" y="236.16698292220116" width="5.464895635673656" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_net_0" data-x="6.01" data-y="3" x="446.2239089184061" y="236.16698292220116" width="5.464895635673599" height="6.476913345983547" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="-3.21" data-y="-5.7" x="352.91587602783045" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_net_0" data-x="-2.1900000000000004" data-y="-5.7" x="363.2384566729918" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.1900000000000004" data-y="-5.7" x="407.5648323845668" y="324.2125237191651" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_net_0" data-x="3.21" data-y="-5.7" x="417.887413029728" y="324.2125237191651" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="4.99" data-y="5.2" x="435.90132827324476" y="213.9025932953827" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_net_0" data-x="6.01" data-y="5.2" x="446.2239089184061" y="213.9025932953827" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="2.1900000000000004" data-y="6.2" x="407.5648323845668" y="203.7824161922834" width="5.464895635673599" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_net_0" data-x="3.21" data-y="6.2" x="417.887413029728" y="203.7824161922834" width="5.464895635673656" height="6.476913345983576" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_21" data-x="-34.25" data-y="10.775" x="40" y="153.38393421884888" width="3.0360531309297585" height="14.674256799493975" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_22" data-x="-33.75" data-y="10.775" x="45.060088551549654" y="153.38393421884888" width="3.0360531309297585" height="14.674256799493975" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -1168,22 +1260,23 @@ source_trace_50" data-x="18.85" data-y="18.635" x="573.8393421884884" y="78.1404
 source_trace_51" data-x="18.85" data-y="17.365" x="573.8393421884884" y="90.99304237824164" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="18.85" data-y="16.095" x="573.8393421884884" y="103.84566729917778" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_52" data-x="23.15" data-y="16.095" x="617.3561037318152" y="103.84566729917778" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_53" data-x="23.15" data-y="17.365" x="617.3561037318152" y="90.99304237824164" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_54" data-x="23.15" data-y="18.635" x="617.3561037318152" y="78.14041745730552" width="10.120177103099309" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="23.15" data-y="19.905" x="617.3561037318152" y="65.2877925363694" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_55" data-x="27.095" data-y="-19.15" x="659.3042378241619" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_56" data-x="28.365" data-y="-19.15" x="672.1568627450981" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_61" data-x="29.635" data-y="-19.15" x="685.0094876660341" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_63" data-x="30.905" data-y="-19.15" x="697.8621125869704" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_57" data-x="30.905" data-y="-14.85" x="697.8621125869704" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_58" data-x="29.635" data-y="-14.85" x="685.0094876660341" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_59" data-x="28.365" data-y="-14.85" x="672.1568627450981" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="27.095" data-y="-14.85" x="659.3042378241619" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_60" data-x="12.175" data-y="-13" x="507.29917773561044" y="396.52118912080965" width="8.096141682479413" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_61" data-x="13.825" data-y="-13" x="523.9974699557242" y="396.52118912080965" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_62" data-x="15.175" data-y="-15" x="537.6597090449084" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_63" data-x="16.825" data-y="-15" x="554.358001265022" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_64" data-x="-13.9125" data-y="-12" x="242.15053763440858" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_65" data-x="-12.0875" data-y="-12" x="260.6198608475648" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_67" data-x="-1.1375" data-y="-18.05" x="369.91777356103734" y="449.39911448450357" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_66" data-x="-1.1375" data-y="-19.95" x="369.91777356103734" y="468.62745098039227" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="1.1375" data-y="-19" x="392.94117647058823" y="459.0132827324479" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_54" data-x="23.15" data-y="18.635" x="617.3561037318152" y="78.14041745730552" width="10.120177103099309" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_55" data-x="23.15" data-y="19.905" x="617.3561037318152" y="65.2877925363694" width="10.120177103099309" height="6.072106261859602" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_56" data-x="27.095" data-y="-19.15" x="659.3042378241619" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_57" data-x="28.365" data-y="-19.15" x="672.1568627450981" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_62" data-x="29.635" data-y="-19.15" x="685.0094876660341" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_64" data-x="30.905" data-y="-19.15" x="697.8621125869704" y="458.5072738772929" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_58" data-x="30.905" data-y="-14.85" x="697.8621125869704" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_59" data-x="29.635" data-y="-14.85" x="685.0094876660341" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_60" data-x="28.365" data-y="-14.85" x="672.1568627450981" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="27.095" data-y="-14.85" x="659.3042378241619" y="414.9905123339659" width="6.072106261859631" height="10.120177103099309" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_61" data-x="12.175" data-y="-13" x="507.29917773561044" y="396.52118912080965" width="8.096141682479413" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_62" data-x="13.825" data-y="-13" x="523.9974699557242" y="396.52118912080965" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_63" data-x="15.175" data-y="-15" x="537.6597090449084" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_64" data-x="16.825" data-y="-15" x="554.358001265022" y="416.76154332700827" width="8.09614168247947" height="9.614168247944349" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_65" data-x="-13.9125" data-y="-12" x="242.15053763440858" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_66" data-x="-12.0875" data-y="-12" x="260.6198608475648" y="384.12397216951297" width="10.373181530676788" height="14.168247944339043" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_68" data-x="-1.1375" data-y="-18.05" x="369.91777356103734" y="449.39911448450357" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+source_trace_67" data-x="-1.1375" data-y="-19.95" x="369.91777356103734" y="468.62745098039227" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top" data-x="1.1375" data-y="-19" x="392.94117647058823" y="459.0132827324479" width="13.409234661606547" height="6.072106261859574" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_39
 bottom
 source_trace_39" data-x="-32" data-y="-25.43" x="56.69829222011384" y="519.5319418089819" width="15.180265654648906" height="15.180265654648906" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
@@ -1226,274 +1319,496 @@ source_net_0" data-x="-4.302" data-y="0.097" x="342.32005060088545" y="266.50727
 source_net_0
 bottom
 source_net_0" data-x="-2.275" data-y="0.113" x="362.83364958886784" y="266.3453510436433" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="bottom
-source_trace_7
-top
-source_trace_7" data-x="1.912" data-y="0.183" x="405.20683111954463" y="265.6369386464263" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_7
-bottom
-source_trace_7" data-x="-0.22" data-y="-4.88" x="383.63061353573687" y="316.8753953194181" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="bottom
-source_trace_5
-top
-source_trace_5" data-x="0.2" data-y="4.168" x="387.8810879190386" y="225.30803289057562" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_5
-bottom
-source_trace_5" data-x="3.504" data-y="3.325" x="421.3181530676786" y="233.83934218848833" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
-source_trace_1
-bottom
-source_trace_1" data-x="-4.2" data-y="-0.8" x="343.35230866540167" y="275.58507273877296" width="4.554079696394638" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="bottom
-source_trace_1
-top
-source_trace_1" data-x="-5.52" data-y="-0.689" x="329.99367488931057" y="274.46173308032894" width="4.554079696394638" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><circle data-type="circle" data-label="" data-x="-5.43500637465368" data-y="-4.047838102925986" cx="333.1308652786471" cy="310.73080939077533" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-1.024" data-y="-4.996" cx="377.77103099304236" cy="320.326375711575" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-4.302" data-y="0.097" cx="344.5970904490828" cy="268.7843137254902" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-2.275" data-y="0.113" cx="365.11068943706516" cy="268.62239089184067" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="1.912" data-y="0.183" cx="407.48387096774195" cy="267.9139784946237" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-0.22" data-y="-4.88" cx="385.9076533839342" cy="319.15243516761547" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="0.2" data-y="4.168" cx="390.1581277672359" cy="227.58507273877296" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="3.504" data-y="3.325" cx="423.595192915876" cy="236.11638203668568" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-4.2" data-y="-0.8" cx="345.629348513599" cy="277.86211258697034" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-5.52" data-y="-0.689" cx="332.2707147375079" cy="276.7387729285263" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><g><circle data-type="point" data-label="source_trace_0
-source_trace_0
-top" data-x="-3.42495" data-y="2.60065" cx="353.47299177735607" cy="243.44693232131567" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_0
-source_trace_0
-top" data-x="-6.01" data-y="3" cx="327.31182795698925" cy="239.40543959519295" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_1
-source_trace_1
-top" data-x="-3.42495" data-y="-1.0002500000000003" cx="353.47299177735607" cy="279.88867805186595" r="3" fill="hsl(5.862068965517241, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_1
-source_trace_1
-top" data-x="-6.01" data-y="0" cx="327.31182795698925" cy="269.76597090449087" r="3" fill="hsl(5.862068965517241, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_2
-source_trace_2
-top" data-x="0.20005000000000006" data-y="-3.42505" cx="390.15863377609105" cy="304.42808349146117" r="3" fill="hsl(11.724137931034482, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_2
-source_trace_2
-top" data-x="-6.01" data-y="-3" cx="327.31182795698925" cy="300.1265022137888" r="3" fill="hsl(11.724137931034482, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_3
-source_trace_3
-top" data-x="3.42495" data-y="-1.0002499999999999" cx="422.79519291587604" cy="279.88867805186595" r="3" fill="hsl(17.586206896551722, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_3
-source_trace_3
-top" data-x="4.99" data-y="-3" cx="438.6337760910816" cy="300.1265022137888" r="3" fill="hsl(17.586206896551722, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_4
-source_trace_4
-top" data-x="3.42495" data-y="2.60065" cx="422.79519291587604" cy="243.44693232131567" r="3" fill="hsl(23.448275862068964, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_4
-source_trace_4
-top" data-x="4.99" data-y="0" cx="438.6337760910816" cy="269.76597090449087" r="3" fill="hsl(23.448275862068964, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_5
-source_trace_5
-top" data-x="0.20005000000000006" data-y="3.42505" cx="390.15863377609105" cy="235.1038583175206" r="3" fill="hsl(29.310344827586206, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_5
-source_trace_5
-top" data-x="4.99" data-y="3" cx="438.6337760910816" cy="239.40543959519295" r="3" fill="hsl(29.310344827586206, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_6
-source_trace_6
-top" data-x="0.6001500000000002" data-y="-3.42505" cx="394.2077166350411" cy="304.42808349146117" r="3" fill="hsl(35.172413793103445, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_6
-source_trace_6
-top" data-x="-3.21" data-y="-5.7" cx="355.6483238456673" cy="327.4509803921569" r="3" fill="hsl(35.172413793103445, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_7
-source_trace_7
-top" data-x="-0.20005000000000006" data-y="3.42505" cx="386.10955091714106" cy="235.1038583175206" r="3" fill="hsl(41.03448275862069, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_7
-source_trace_7
-top" data-x="2.1900000000000004" data-y="-5.7" cx="410.29728020240356" cy="327.4509803921569" r="3" fill="hsl(41.03448275862069, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_8
-source_trace_8
-top" data-x="2.60065" data-y="3.42505" cx="414.45313092979126" cy="235.1038583175206" r="3" fill="hsl(46.89655172413793, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_8
-source_trace_8
-top" data-x="4.99" data-y="5.2" cx="438.6337760910816" cy="217.1410499683745" r="3" fill="hsl(46.89655172413793, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_9
-source_trace_9
-top" data-x="0.6001499999999997" data-y="3.42505" cx="394.2077166350411" cy="235.1038583175206" r="3" fill="hsl(52.758620689655174, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_9
-source_trace_9
-top" data-x="2.1900000000000004" data-y="6.2" cx="410.29728020240356" cy="207.02087286527518" r="3" fill="hsl(52.758620689655174, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_21
-source_trace_21
-top" data-x="-34.25" data-y="10.775" cx="41.51802656546488" cy="160.72106261859585" r="3" fill="hsl(58.62068965517241, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_21
-source_trace_21
-top" data-x="-3.42495" data-y="2.20055" cx="353.47299177735607" cy="247.4960151802657" r="3" fill="hsl(58.62068965517241, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_22
-source_trace_22
-top" data-x="-33.75" data-y="10.775" cx="46.578115117014534" cy="160.72106261859585" r="3" fill="hsl(64.48275862068965, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_22
-source_trace_22
-top" data-x="-3.42495" data-y="1.8004499999999999" cx="353.47299177735607" cy="251.54509803921573" r="3" fill="hsl(64.48275862068965, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
-source_trace_23
-top" data-x="-33.25" data-y="10.775" cx="51.63820366856419" cy="160.72106261859585" r="3" fill="hsl(70.34482758620689, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
-source_trace_23
-top" data-x="-3.42495" data-y="1.40035" cx="353.47299177735607" cy="255.59418089816575" r="3" fill="hsl(70.34482758620689, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
-source_trace_24
-top" data-x="-32.75" data-y="10.775" cx="56.69829222011384" cy="160.72106261859585" r="3" fill="hsl(76.20689655172414, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
-source_trace_24
-top" data-x="-3.42495" data-y="1.0002499999999999" cx="353.47299177735607" cy="259.6432637571158" r="3" fill="hsl(76.20689655172414, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
-source_trace_25
-top" data-x="-32.25" data-y="10.775" cx="61.7583807716635" cy="160.72106261859585" r="3" fill="hsl(82.06896551724138, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
-source_trace_25
-top" data-x="-3.42495" data-y="0.6001499999999997" cx="353.47299177735607" cy="263.69234661606583" r="3" fill="hsl(82.06896551724138, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
-source_trace_26
-top" data-x="-31.75" data-y="10.775" cx="66.8184693232131" cy="160.72106261859585" r="3" fill="hsl(87.93103448275862, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
-source_trace_26
-top" data-x="-3.42495" data-y="0.20005000000000006" cx="353.47299177735607" cy="267.7414294750159" r="3" fill="hsl(87.93103448275862, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
-source_trace_27
-top" data-x="-31.25" data-y="10.775" cx="71.87855787476275" cy="160.72106261859585" r="3" fill="hsl(93.79310344827586, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
-source_trace_27
-top" data-x="-3.42495" data-y="-0.20005000000000006" cx="353.47299177735607" cy="271.79051233396586" r="3" fill="hsl(93.79310344827586, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
-source_trace_28
-top" data-x="-30.75" data-y="10.775" cx="76.9386464263124" cy="160.72106261859585" r="3" fill="hsl(99.65517241379311, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
-source_trace_28
-top" data-x="-3.42495" data-y="-0.6001500000000002" cx="353.47299177735607" cy="275.8395951929159" r="3" fill="hsl(99.65517241379311, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
-source_trace_29
-top" data-x="-30.25" data-y="10.775" cx="81.99873497786206" cy="160.72106261859585" r="3" fill="hsl(105.51724137931035, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
-source_trace_29
-top" data-x="-3.42495" data-y="-1.4003500000000004" cx="353.47299177735607" cy="283.937760910816" r="3" fill="hsl(105.51724137931035, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
-source_trace_30
-top" data-x="-29.75" data-y="10.775" cx="87.05882352941171" cy="160.72106261859585" r="3" fill="hsl(111.37931034482759, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
-source_trace_30
-top" data-x="-3.42495" data-y="-1.8004500000000005" cx="353.47299177735607" cy="287.98684376976604" r="3" fill="hsl(111.37931034482759, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
-source_trace_31
-top" data-x="27.555" data-y="6.8500000000000005" cx="666.9955724225174" cy="200.44275774826065" r="3" fill="hsl(117.24137931034483, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
-source_trace_31
-top" data-x="-3.42495" data-y="-2.20055" cx="353.47299177735607" cy="292.035926628716" r="3" fill="hsl(117.24137931034483, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
-source_trace_32
-top" data-x="28.825" data-y="6.85" cx="679.8481973434535" cy="200.44275774826065" r="3" fill="hsl(123.10344827586206, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
-source_trace_32
-top" data-x="-3.42495" data-y="-2.60065" cx="353.47299177735607" cy="296.08500948766607" r="3" fill="hsl(123.10344827586206, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
-source_trace_33
-top" data-x="30.095" data-y="6.85" cx="692.7008222643897" cy="200.44275774826065" r="3" fill="hsl(128.9655172413793, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
-source_trace_33
-top" data-x="-2.60065" data-y="-3.42505" cx="361.81505376344086" cy="304.42808349146117" r="3" fill="hsl(128.9655172413793, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
-source_trace_34
-top" data-x="31.365" data-y="6.85" cx="705.5534471853257" cy="200.44275774826065" r="3" fill="hsl(134.82758620689654, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
-source_trace_34
-top" data-x="-2.20055" data-y="-3.42505" cx="365.8641366223909" cy="304.42808349146117" r="3" fill="hsl(134.82758620689654, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
-source_trace_35
-top" data-x="32.635" data-y="6.85" cx="718.4060721062618" cy="200.44275774826065" r="3" fill="hsl(140.68965517241378, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
-source_trace_35
-top" data-x="-1.8004499999999999" data-y="-3.42505" cx="369.9132194813409" cy="304.42808349146117" r="3" fill="hsl(140.68965517241378, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
-source_trace_36
-top" data-x="33.905" data-y="6.85" cx="731.258697027198" cy="200.44275774826065" r="3" fill="hsl(146.55172413793105, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
-source_trace_36
-top" data-x="-1.40035" data-y="-3.42505" cx="373.96230234029093" cy="304.42808349146117" r="3" fill="hsl(146.55172413793105, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
-source_trace_37
-top" data-x="35.175" data-y="6.85" cx="744.1113219481341" cy="200.44275774826065" r="3" fill="hsl(152.41379310344828, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
-source_trace_37
-top" data-x="2.20055" data-y="-3.42505" cx="410.4040480708412" cy="304.42808349146117" r="3" fill="hsl(152.41379310344828, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
-source_trace_38
-top" data-x="36.445" data-y="6.85" cx="756.9639468690702" cy="200.44275774826065" r="3" fill="hsl(158.27586206896552, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
-source_trace_38
-top" data-x="2.60065" data-y="-3.42505" cx="414.45313092979126" cy="304.42808349146117" r="3" fill="hsl(158.27586206896552, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
-source_trace_39
-top" data-x="-32" data-y="-25.43" cx="64.2884250474383" cy="527.1220746363063" r="3" fill="hsl(164.13793103448276, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
-source_trace_39
-top" data-x="3.42495" data-y="-2.60065" cx="422.79519291587604" cy="296.08500948766607" r="3" fill="hsl(164.13793103448276, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
-source_trace_40
-top" data-x="-32" data-y="-22.89" cx="64.2884250474383" cy="501.416824794434" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
-source_trace_40
-top" data-x="3.42495" data-y="-2.20055" cx="422.79519291587604" cy="292.035926628716" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
-source_trace_41
-top" data-x="-32" data-y="-20.35" cx="64.2884250474383" cy="475.7115749525617" r="3" fill="hsl(175.86206896551724, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
-source_trace_41
-top" data-x="3.42495" data-y="-1.8004499999999999" cx="422.79519291587604" cy="287.98684376976604" r="3" fill="hsl(175.86206896551724, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
-source_trace_42
-top" data-x="-32" data-y="-17.81" cx="64.2884250474383" cy="450.0063251106895" r="3" fill="hsl(181.72413793103448, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
-source_trace_42
-top" data-x="3.42495" data-y="-1.40035" cx="422.79519291587604" cy="283.937760910816" r="3" fill="hsl(181.72413793103448, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
-source_trace_43
-top" data-x="-32" data-y="-15.27" cx="64.2884250474383" cy="424.30107526881727" r="3" fill="hsl(187.58620689655172, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
-source_trace_43
-top" data-x="3.42495" data-y="-0.6001499999999997" cx="422.79519291587604" cy="275.8395951929159" r="3" fill="hsl(187.58620689655172, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
-source_trace_44
-top" data-x="-32" data-y="-12.73" cx="64.2884250474383" cy="398.595825426945" r="3" fill="hsl(193.44827586206895, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
-source_trace_44
-top" data-x="3.42495" data-y="-0.20005000000000006" cx="422.79519291587604" cy="271.79051233396586" r="3" fill="hsl(193.44827586206895, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
-source_trace_45
-top" data-x="-32" data-y="-10.19" cx="64.2884250474383" cy="372.8905755850728" r="3" fill="hsl(199.31034482758622, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
-source_trace_45
-top" data-x="3.42495" data-y="0.20005000000000006" cx="422.79519291587604" cy="267.7414294750159" r="3" fill="hsl(199.31034482758622, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
-source_trace_46
-top" data-x="-32" data-y="-7.649999999999999" cx="64.2884250474383" cy="347.18532574320056" r="3" fill="hsl(205.17241379310346, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
-source_trace_46
-top" data-x="3.42495" data-y="0.6001500000000002" cx="422.79519291587604" cy="263.69234661606583" r="3" fill="hsl(205.17241379310346, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
-source_trace_47
-top" data-x="-32" data-y="-5.109999999999999" cx="64.2884250474383" cy="321.4800759013283" r="3" fill="hsl(211.0344827586207, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
-source_trace_47
-top" data-x="3.42495" data-y="1.0002500000000003" cx="422.79519291587604" cy="259.6432637571158" r="3" fill="hsl(211.0344827586207, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
-source_trace_48
-top" data-x="-32" data-y="-2.5700000000000003" cx="64.2884250474383" cy="295.7748260594561" r="3" fill="hsl(216.89655172413794, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
-source_trace_48
-top" data-x="3.42495" data-y="1.4003500000000004" cx="422.79519291587604" cy="255.59418089816575" r="3" fill="hsl(216.89655172413794, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
-source_trace_49
-top" data-x="18.85" data-y="19.905" cx="578.899430740038" cy="68.3238456672992" r="3" fill="hsl(222.75862068965517, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
-source_trace_49
-top" data-x="-2.60065" data-y="3.42505" cx="361.81505376344086" cy="235.1038583175206" r="3" fill="hsl(222.75862068965517, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
-source_trace_50
-top" data-x="18.85" data-y="18.635" cx="578.899430740038" cy="81.1764705882353" r="3" fill="hsl(228.6206896551724, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
-source_trace_50
-top" data-x="-2.20055" data-y="3.42505" cx="365.8641366223909" cy="235.1038583175206" r="3" fill="hsl(228.6206896551724, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
-source_trace_51
-top" data-x="18.85" data-y="17.365" cx="578.899430740038" cy="94.02909550917144" r="3" fill="hsl(234.48275862068965, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
-source_trace_51
-top" data-x="-1.8004500000000005" data-y="3.42505" cx="369.9132194813409" cy="235.1038583175206" r="3" fill="hsl(234.48275862068965, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
-source_trace_52
-top" data-x="23.15" data-y="16.095" cx="622.4161922833649" cy="106.88172043010758" r="3" fill="hsl(240.3448275862069, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
-source_trace_52
-top" data-x="-1.4003500000000004" data-y="3.42505" cx="373.96230234029093" cy="235.1038583175206" r="3" fill="hsl(240.3448275862069, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
-source_trace_53
-top" data-x="23.15" data-y="17.365" cx="622.4161922833649" cy="94.02909550917144" r="3" fill="hsl(246.20689655172413, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
-source_trace_53
-top" data-x="-1.0002500000000003" data-y="3.42505" cx="378.011385199241" cy="235.1038583175206" r="3" fill="hsl(246.20689655172413, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
-source_trace_54
-top" data-x="23.15" data-y="18.635" cx="622.4161922833649" cy="81.1764705882353" r="3" fill="hsl(252.06896551724137, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
-source_trace_54
-top" data-x="-0.6001500000000002" data-y="3.42505" cx="382.060468058191" cy="235.1038583175206" r="3" fill="hsl(252.06896551724137, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+top" data-x="1.912" data-y="0.183" x="405.20683111954463" y="265.6369386464263" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+bottom" data-x="-0.22" data-y="-4.88" x="383.63061353573687" y="316.8753953194181" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="bottom
 source_trace_55
-top" data-x="27.095" data-y="-19.15" cx="662.3402909550916" cy="463.56736242884256" r="3" fill="hsl(257.9310344827586, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+top
+source_trace_55" data-x="0.2" data-y="4.168" x="387.8810879190386" y="225.30803289057562" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
 source_trace_55
-top" data-x="3.42495" data-y="1.8004500000000005" cx="422.79519291587604" cy="251.54509803921573" r="3" fill="hsl(257.9310344827586, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
+bottom
+source_trace_55" data-x="3.504" data-y="3.325" x="421.3181530676786" y="233.83934218848833" width="4.554079696394695" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="top
+bottom" data-x="-4.2" data-y="-0.8" x="343.35230866540167" y="275.58507273877296" width="4.554079696394638" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><g><rect data-type="rect" data-label="bottom
+top" data-x="-5.52" data-y="-0.689" x="329.99367488931057" y="274.46173308032894" width="4.554079696394638" height="4.554079696394695" fill="rgba(255,0,0,0.75)" stroke="black" stroke-width="0.0988125"/></g><circle data-type="circle" data-label="" data-x="-5.43500637465368" data-y="-4.047838102925986" cx="333.1308652786471" cy="310.73080939077533" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-1.024" data-y="-4.996" cx="377.77103099304236" cy="320.326375711575" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-4.302" data-y="0.097" cx="344.5970904490828" cy="268.7843137254902" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-2.275" data-y="0.113" cx="365.11068943706516" cy="268.62239089184067" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="1.912" data-y="0.183" cx="407.48387096774195" cy="267.9139784946237" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-0.22" data-y="-4.88" cx="385.9076533839342" cy="319.15243516761547" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="0.2" data-y="4.168" cx="390.1581277672359" cy="227.58507273877296" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="3.504" data-y="3.325" cx="423.595192915876" cy="236.11638203668568" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-4.2" data-y="-0.8" cx="345.629348513599" cy="277.86211258697034" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><circle data-type="circle" data-label="" data-x="-5.52" data-y="-0.689" cx="332.2707147375079" cy="276.7387729285263" r="2.2770398481973437" fill="blue" stroke="none" stroke-width="0.0988125"/><g><circle data-type="point" data-label="source_trace_21
+source_trace_21
+top" data-x="-34.25" data-y="10.775" cx="41.51802656546488" cy="160.72106261859585" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_21
+source_trace_21
+top" data-x="-3.42495" data-y="2.20055" cx="353.47299177735607" cy="247.4960151802657" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_22
+source_trace_22
+top" data-x="-33.75" data-y="10.775" cx="46.578115117014534" cy="160.72106261859585" r="3" fill="hsl(6.938775510204081, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_22
+source_trace_22
+top" data-x="-3.42495" data-y="1.8004499999999999" cx="353.47299177735607" cy="251.54509803921573" r="3" fill="hsl(6.938775510204081, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
+source_trace_23
+top" data-x="-33.25" data-y="10.775" cx="51.63820366856419" cy="160.72106261859585" r="3" fill="hsl(13.877551020408163, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_23
+source_trace_23
+top" data-x="-3.42495" data-y="1.40035" cx="353.47299177735607" cy="255.59418089816575" r="3" fill="hsl(13.877551020408163, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
+source_trace_24
+top" data-x="-32.75" data-y="10.775" cx="56.69829222011384" cy="160.72106261859585" r="3" fill="hsl(20.816326530612244, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_24
+source_trace_24
+top" data-x="-3.42495" data-y="1.0002499999999999" cx="353.47299177735607" cy="259.6432637571158" r="3" fill="hsl(20.816326530612244, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
+source_trace_25
+top" data-x="-32.25" data-y="10.775" cx="61.7583807716635" cy="160.72106261859585" r="3" fill="hsl(27.755102040816325, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_25
+source_trace_25
+top" data-x="-3.42495" data-y="0.6001499999999997" cx="353.47299177735607" cy="263.69234661606583" r="3" fill="hsl(27.755102040816325, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
+source_trace_26
+top" data-x="-31.75" data-y="10.775" cx="66.8184693232131" cy="160.72106261859585" r="3" fill="hsl(34.69387755102041, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_26
+source_trace_26
+top" data-x="-3.42495" data-y="0.20005000000000006" cx="353.47299177735607" cy="267.7414294750159" r="3" fill="hsl(34.69387755102041, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
+source_trace_27
+top" data-x="-31.25" data-y="10.775" cx="71.87855787476275" cy="160.72106261859585" r="3" fill="hsl(41.63265306122449, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_27
+source_trace_27
+top" data-x="-3.42495" data-y="-0.20005000000000006" cx="353.47299177735607" cy="271.79051233396586" r="3" fill="hsl(41.63265306122449, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
+source_trace_28
+top" data-x="-30.75" data-y="10.775" cx="76.9386464263124" cy="160.72106261859585" r="3" fill="hsl(48.57142857142857, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_28
+source_trace_28
+top" data-x="-3.42495" data-y="-0.6001500000000002" cx="353.47299177735607" cy="275.8395951929159" r="3" fill="hsl(48.57142857142857, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
+source_trace_29
+top" data-x="-30.25" data-y="10.775" cx="81.99873497786206" cy="160.72106261859585" r="3" fill="hsl(55.51020408163265, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_29
+source_trace_29
+top" data-x="-3.42495" data-y="-1.4003500000000004" cx="353.47299177735607" cy="283.937760910816" r="3" fill="hsl(55.51020408163265, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
+source_trace_30
+top" data-x="-29.75" data-y="10.775" cx="87.05882352941171" cy="160.72106261859585" r="3" fill="hsl(62.44897959183673, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_30
+source_trace_30
+top" data-x="-3.42495" data-y="-1.8004500000000005" cx="353.47299177735607" cy="287.98684376976604" r="3" fill="hsl(62.44897959183673, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
+source_trace_31
+top" data-x="27.555" data-y="6.8500000000000005" cx="666.9955724225174" cy="200.44275774826065" r="3" fill="hsl(69.38775510204081, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_31
+source_trace_31
+top" data-x="-3.42495" data-y="-2.20055" cx="353.47299177735607" cy="292.035926628716" r="3" fill="hsl(69.38775510204081, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
+source_trace_32
+top" data-x="28.825" data-y="6.85" cx="679.8481973434535" cy="200.44275774826065" r="3" fill="hsl(76.3265306122449, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_32
+source_trace_32
+top" data-x="-3.42495" data-y="-2.60065" cx="353.47299177735607" cy="296.08500948766607" r="3" fill="hsl(76.3265306122449, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
+source_trace_33
+top" data-x="30.095" data-y="6.85" cx="692.7008222643897" cy="200.44275774826065" r="3" fill="hsl(83.26530612244898, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_33
+source_trace_33
+top" data-x="-2.60065" data-y="-3.42505" cx="361.81505376344086" cy="304.42808349146117" r="3" fill="hsl(83.26530612244898, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
+source_trace_34
+top" data-x="31.365" data-y="6.85" cx="705.5534471853257" cy="200.44275774826065" r="3" fill="hsl(90.20408163265306, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_34
+source_trace_34
+top" data-x="-2.20055" data-y="-3.42505" cx="365.8641366223909" cy="304.42808349146117" r="3" fill="hsl(90.20408163265306, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
+source_trace_35
+top" data-x="32.635" data-y="6.85" cx="718.4060721062618" cy="200.44275774826065" r="3" fill="hsl(97.14285714285714, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_35
+source_trace_35
+top" data-x="-1.8004499999999999" data-y="-3.42505" cx="369.9132194813409" cy="304.42808349146117" r="3" fill="hsl(97.14285714285714, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
+source_trace_36
+top" data-x="33.905" data-y="6.85" cx="731.258697027198" cy="200.44275774826065" r="3" fill="hsl(104.08163265306122, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_36
+source_trace_36
+top" data-x="-1.40035" data-y="-3.42505" cx="373.96230234029093" cy="304.42808349146117" r="3" fill="hsl(104.08163265306122, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
+source_trace_37
+top" data-x="35.175" data-y="6.85" cx="744.1113219481341" cy="200.44275774826065" r="3" fill="hsl(111.0204081632653, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_37
+source_trace_37
+top" data-x="2.20055" data-y="-3.42505" cx="410.4040480708412" cy="304.42808349146117" r="3" fill="hsl(111.0204081632653, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
+source_trace_38
+top" data-x="36.445" data-y="6.85" cx="756.9639468690702" cy="200.44275774826065" r="3" fill="hsl(117.95918367346938, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_38
+source_trace_38
+top" data-x="2.60065" data-y="-3.42505" cx="414.45313092979126" cy="304.42808349146117" r="3" fill="hsl(117.95918367346938, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
+source_trace_39
+top" data-x="-32" data-y="-25.43" cx="64.2884250474383" cy="527.1220746363063" r="3" fill="hsl(124.89795918367346, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_39
+source_trace_39
+top" data-x="3.42495" data-y="-2.60065" cx="422.79519291587604" cy="296.08500948766607" r="3" fill="hsl(124.89795918367346, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
+source_trace_40
+top" data-x="-32" data-y="-22.89" cx="64.2884250474383" cy="501.416824794434" r="3" fill="hsl(131.83673469387756, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_40
+source_trace_40
+top" data-x="3.42495" data-y="-2.20055" cx="422.79519291587604" cy="292.035926628716" r="3" fill="hsl(131.83673469387756, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
+source_trace_41
+top" data-x="-32" data-y="-20.35" cx="64.2884250474383" cy="475.7115749525617" r="3" fill="hsl(138.77551020408163, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_41
+source_trace_41
+top" data-x="3.42495" data-y="-1.8004499999999999" cx="422.79519291587604" cy="287.98684376976604" r="3" fill="hsl(138.77551020408163, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
+source_trace_42
+top" data-x="-32" data-y="-17.81" cx="64.2884250474383" cy="450.0063251106895" r="3" fill="hsl(145.71428571428572, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_42
+source_trace_42
+top" data-x="3.42495" data-y="-1.40035" cx="422.79519291587604" cy="283.937760910816" r="3" fill="hsl(145.71428571428572, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
+source_trace_43
+top" data-x="-32" data-y="-15.27" cx="64.2884250474383" cy="424.30107526881727" r="3" fill="hsl(152.6530612244898, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_43
+source_trace_43
+top" data-x="3.42495" data-y="-0.6001499999999997" cx="422.79519291587604" cy="275.8395951929159" r="3" fill="hsl(152.6530612244898, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
+source_trace_44
+top" data-x="-32" data-y="-12.73" cx="64.2884250474383" cy="398.595825426945" r="3" fill="hsl(159.59183673469389, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_44
+source_trace_44
+top" data-x="3.42495" data-y="-0.20005000000000006" cx="422.79519291587604" cy="271.79051233396586" r="3" fill="hsl(159.59183673469389, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
+source_trace_45
+top" data-x="-32" data-y="-10.19" cx="64.2884250474383" cy="372.8905755850728" r="3" fill="hsl(166.53061224489795, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_45
+source_trace_45
+top" data-x="3.42495" data-y="0.20005000000000006" cx="422.79519291587604" cy="267.7414294750159" r="3" fill="hsl(166.53061224489795, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
+source_trace_46
+top" data-x="-32" data-y="-7.649999999999999" cx="64.2884250474383" cy="347.18532574320056" r="3" fill="hsl(173.46938775510205, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_46
+source_trace_46
+top" data-x="3.42495" data-y="0.6001500000000002" cx="422.79519291587604" cy="263.69234661606583" r="3" fill="hsl(173.46938775510205, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
+source_trace_47
+top" data-x="-32" data-y="-5.109999999999999" cx="64.2884250474383" cy="321.4800759013283" r="3" fill="hsl(180.40816326530611, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_47
+source_trace_47
+top" data-x="3.42495" data-y="1.0002500000000003" cx="422.79519291587604" cy="259.6432637571158" r="3" fill="hsl(180.40816326530611, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
+source_trace_48
+top" data-x="-32" data-y="-2.5700000000000003" cx="64.2884250474383" cy="295.7748260594561" r="3" fill="hsl(187.3469387755102, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_48
+source_trace_48
+top" data-x="3.42495" data-y="1.4003500000000004" cx="422.79519291587604" cy="255.59418089816575" r="3" fill="hsl(187.3469387755102, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
+source_trace_49
+top" data-x="18.85" data-y="19.905" cx="578.899430740038" cy="68.3238456672992" r="3" fill="hsl(194.28571428571428, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_49
+source_trace_49
+top" data-x="-2.60065" data-y="3.42505" cx="361.81505376344086" cy="235.1038583175206" r="3" fill="hsl(194.28571428571428, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
+source_trace_50
+top" data-x="18.85" data-y="18.635" cx="578.899430740038" cy="81.1764705882353" r="3" fill="hsl(201.22448979591837, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_50
+source_trace_50
+top" data-x="-2.20055" data-y="3.42505" cx="365.8641366223909" cy="235.1038583175206" r="3" fill="hsl(201.22448979591837, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
+source_trace_51
+top" data-x="18.85" data-y="17.365" cx="578.899430740038" cy="94.02909550917144" r="3" fill="hsl(208.16326530612244, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_51
+source_trace_51
+top" data-x="-1.8004500000000005" data-y="3.42505" cx="369.9132194813409" cy="235.1038583175206" r="3" fill="hsl(208.16326530612244, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
+source_trace_52
+top" data-x="23.15" data-y="16.095" cx="622.4161922833649" cy="106.88172043010758" r="3" fill="hsl(215.10204081632654, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_52
+source_trace_52
+top" data-x="-1.4003500000000004" data-y="3.42505" cx="373.96230234029093" cy="235.1038583175206" r="3" fill="hsl(215.10204081632654, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
+source_trace_53
+top" data-x="23.15" data-y="17.365" cx="622.4161922833649" cy="94.02909550917144" r="3" fill="hsl(222.0408163265306, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_53
+source_trace_53
+top" data-x="-1.0002500000000003" data-y="3.42505" cx="378.011385199241" cy="235.1038583175206" r="3" fill="hsl(222.0408163265306, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
+source_trace_54
+top" data-x="23.15" data-y="18.635" cx="622.4161922833649" cy="81.1764705882353" r="3" fill="hsl(228.9795918367347, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_54
+source_trace_54
+top" data-x="-0.6001500000000002" data-y="3.42505" cx="382.060468058191" cy="235.1038583175206" r="3" fill="hsl(228.9795918367347, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="23.15" data-y="19.905" cx="622.4161922833649" cy="68.3238456672992" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.20005000000000006" data-y="3.42505" cx="390.15863377609105" cy="235.1038583175206" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.20005000000000006" data-y="3.42505" cx="390.15863377609105" cy="235.1038583175206" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.2" data-y="3.425" cx="390.1581277672359" cy="235.10436432637576" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.2" data-y="3.7965" cx="390.1581277672359" cy="231.34471853257435" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="0.2" data-y="4.168" cx="390.1581277672359" cy="227.58507273877296" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.2" data-y="4.168" cx="390.1581277672359" cy="227.58507273877296" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.27936590381920134" data-y="4.088634096180799" cx="390.96132476983377" cy="228.38826974137083" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.27936590381920134" data-y="3.987284978680325" cx="390.96132476983377" cy="229.41394075971846" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.6105083931593638" data-y="3.6561424893401626" cx="394.3125454083174" cy="232.76516139820205" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="0.9416508824995262" data-y="3.325" cx="397.663766046801" cy="236.11638203668568" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="1.368709068749605" data-y="3.325" cx="401.9856705249802" cy="236.11638203668568" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="1.7957672549996841" data-y="3.325" cx="406.30757500315934" cy="236.11638203668568" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="2.2228254412497632" data-y="3.325" cx="410.62947948133854" cy="236.11638203668568" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="2.649883627499842" data-y="3.325" cx="414.95138395951767" cy="236.11638203668568" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="3.0769418137499214" data-y="3.325" cx="419.27328843769686" cy="236.11638203668568" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+bottom" data-x="3.504" data-y="3.325" cx="423.595192915876" cy="236.11638203668568" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.504" data-y="3.325" cx="423.595192915876" cy="236.11638203668568" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.57064426757843" data-y="3.2583557324215704" cx="424.26964470667605" cy="236.79083382748573" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.597101639481161" data-y="3.2583557324215704" cx="424.53739799601425" cy="236.79083382748573" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="3.855457371902731" data-y="3" cx="427.1520037637215" cy="239.40543959519295" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="4.233638247935154" data-y="3" cx="430.97926120617484" cy="239.40543959519295" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="4.611819123967577" data-y="3" cx="434.80651864862824" cy="239.40543959519295" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_55
+source_trace_55
+top" data-x="4.99" data-y="3" cx="438.6337760910816" cy="239.40543959519295" r="3" fill="hsl(235.91836734693877, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
 source_trace_56
-top" data-x="28.365" data-y="-19.15" cx="675.1929158760279" cy="463.56736242884256" r="3" fill="hsl(263.7931034482759, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
+top" data-x="27.095" data-y="-19.15" cx="662.3402909550916" cy="463.56736242884256" r="3" fill="hsl(242.85714285714286, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_56
 source_trace_56
-top" data-x="3.42495" data-y="2.20055" cx="422.79519291587604" cy="247.4960151802657" r="3" fill="hsl(263.7931034482759, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
+top" data-x="3.42495" data-y="1.8004500000000005" cx="422.79519291587604" cy="251.54509803921573" r="3" fill="hsl(242.85714285714286, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
 source_trace_57
-top" data-x="30.905" data-y="-14.85" cx="700.8981657179002" cy="420.05060088551556" r="3" fill="hsl(269.6551724137931, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
+top" data-x="28.365" data-y="-19.15" cx="675.1929158760279" cy="463.56736242884256" r="3" fill="hsl(249.79591836734693, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_57
 source_trace_57
-top" data-x="1.0002500000000003" data-y="-3.42505" cx="398.25679949399114" cy="304.42808349146117" r="3" fill="hsl(269.6551724137931, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
+top" data-x="3.42495" data-y="2.20055" cx="422.79519291587604" cy="247.4960151802657" r="3" fill="hsl(249.79591836734693, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
 source_trace_58
-top" data-x="29.635" data-y="-14.85" cx="688.0455407969639" cy="420.05060088551556" r="3" fill="hsl(275.51724137931035, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
+top" data-x="30.905" data-y="-14.85" cx="700.8981657179002" cy="420.05060088551556" r="3" fill="hsl(256.734693877551, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_58
 source_trace_58
-top" data-x="1.4003500000000004" data-y="-3.42505" cx="402.3058823529412" cy="304.42808349146117" r="3" fill="hsl(275.51724137931035, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
+top" data-x="1.0002500000000003" data-y="-3.42505" cx="398.25679949399114" cy="304.42808349146117" r="3" fill="hsl(256.734693877551, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
 source_trace_59
-top" data-x="28.365" data-y="-14.85" cx="675.1929158760279" cy="420.05060088551556" r="3" fill="hsl(281.37931034482756, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
+top" data-x="29.635" data-y="-14.85" cx="688.0455407969639" cy="420.05060088551556" r="3" fill="hsl(263.6734693877551, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_59
 source_trace_59
-top" data-x="1.8004500000000005" data-y="-3.42505" cx="406.3549652118912" cy="304.42808349146117" r="3" fill="hsl(281.37931034482756, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
+top" data-x="1.4003500000000004" data-y="-3.42505" cx="402.3058823529412" cy="304.42808349146117" r="3" fill="hsl(263.6734693877551, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
 source_trace_60
-top" data-x="1.40035" data-y="3.42505" cx="402.3058823529412" cy="235.1038583175206" r="3" fill="hsl(287.2413793103448, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
+top" data-x="28.365" data-y="-14.85" cx="675.1929158760279" cy="420.05060088551556" r="3" fill="hsl(270.61224489795916, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_60
 source_trace_60
-top" data-x="12.175" data-y="-13" cx="511.3472485768501" cy="401.3282732447818" r="3" fill="hsl(287.2413793103448, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
+top" data-x="1.8004500000000005" data-y="-3.42505" cx="406.3549652118912" cy="304.42808349146117" r="3" fill="hsl(270.61224489795916, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
 source_trace_61
-top" data-x="13.825" data-y="-13" cx="528.0455407969639" cy="401.3282732447818" r="3" fill="hsl(293.1034482758621, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
+top" data-x="1.40035" data-y="3.42505" cx="402.3058823529412" cy="235.1038583175206" r="3" fill="hsl(277.55102040816325, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_61
 source_trace_61
-top" data-x="29.635" data-y="-19.15" cx="688.0455407969639" cy="463.56736242884256" r="3" fill="hsl(293.1034482758621, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
+top" data-x="12.175" data-y="-13" cx="511.3472485768501" cy="401.3282732447818" r="3" fill="hsl(277.55102040816325, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
 source_trace_62
-top" data-x="1.0002499999999999" data-y="3.42505" cx="398.25679949399114" cy="235.1038583175206" r="3" fill="hsl(298.9655172413793, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
+top" data-x="13.825" data-y="-13" cx="528.0455407969639" cy="401.3282732447818" r="3" fill="hsl(284.48979591836735, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_62
 source_trace_62
-top" data-x="15.175" data-y="-15" cx="541.707779886148" cy="421.56862745098044" r="3" fill="hsl(298.9655172413793, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
+top" data-x="29.635" data-y="-19.15" cx="688.0455407969639" cy="463.56736242884256" r="3" fill="hsl(284.48979591836735, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
 source_trace_63
-top" data-x="16.825" data-y="-15" cx="558.4060721062618" cy="421.56862745098044" r="3" fill="hsl(304.82758620689657, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
+top" data-x="1.0002499999999999" data-y="3.42505" cx="398.25679949399114" cy="235.1038583175206" r="3" fill="hsl(291.42857142857144, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_63
 source_trace_63
-top" data-x="30.905" data-y="-19.15" cx="700.8981657179002" cy="463.56736242884256" r="3" fill="hsl(304.82758620689657, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
+top" data-x="15.175" data-y="-15" cx="541.707779886148" cy="421.56862745098044" r="3" fill="hsl(291.42857142857144, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
 source_trace_64
-top" data-x="-0.6001499999999997" data-y="-3.42505" cx="382.060468058191" cy="304.42808349146117" r="3" fill="hsl(310.6896551724138, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
+top" data-x="16.825" data-y="-15" cx="558.4060721062618" cy="421.56862745098044" r="3" fill="hsl(298.3673469387755, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_64
 source_trace_64
-top" data-x="-13.9125" data-y="-12" cx="247.33712839974697" cy="391.2080961416825" r="3" fill="hsl(310.6896551724138, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
+top" data-x="30.905" data-y="-19.15" cx="700.8981657179002" cy="463.56736242884256" r="3" fill="hsl(298.3673469387755, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
 source_trace_65
-top" data-x="-0.20005000000000006" data-y="-3.42505" cx="386.10955091714106" cy="304.42808349146117" r="3" fill="hsl(316.55172413793105, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
+top" data-x="-0.6001499999999997" data-y="-3.42505" cx="382.060468058191" cy="304.42808349146117" r="3" fill="hsl(305.3061224489796, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_65
 source_trace_65
-top" data-x="-12.0875" data-y="-12" cx="265.8064516129032" cy="391.2080961416825" r="3" fill="hsl(316.55172413793105, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
+top" data-x="-13.9125" data-y="-12" cx="247.33712839974697" cy="391.2080961416825" r="3" fill="hsl(305.3061224489796, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
 source_trace_66
-top" data-x="2.20055" data-y="3.42505" cx="410.4040480708412" cy="235.1038583175206" r="3" fill="hsl(322.41379310344826, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
+top" data-x="-0.20005000000000006" data-y="-3.42505" cx="386.10955091714106" cy="304.42808349146117" r="3" fill="hsl(312.2448979591837, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_66
 source_trace_66
-top" data-x="-1.1375" data-y="-19.95" cx="376.6223908918406" cy="471.663504111322" r="3" fill="hsl(322.41379310344826, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
+top" data-x="-12.0875" data-y="-12" cx="265.8064516129032" cy="391.2080961416825" r="3" fill="hsl(312.2448979591837, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
 source_trace_67
-top" data-x="1.8004499999999999" data-y="3.42505" cx="406.3549652118912" cy="235.1038583175206" r="3" fill="hsl(328.2758620689655, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
+top" data-x="2.20055" data-y="3.42505" cx="410.4040480708412" cy="235.1038583175206" r="3" fill="hsl(319.18367346938777, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_67
 source_trace_67
-top" data-x="-1.1375" data-y="-18.05" cx="376.6223908918406" cy="452.43516761543333" r="3" fill="hsl(328.2758620689655, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+top" data-x="-1.1375" data-y="-19.95" cx="376.6223908918406" cy="471.663504111322" r="3" fill="hsl(319.18367346938777, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_68
+source_trace_68
+top" data-x="1.8004499999999999" data-y="3.42505" cx="406.3549652118912" cy="235.1038583175206" r="3" fill="hsl(326.1224489795918, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_68
+source_trace_68
+top" data-x="-1.1375" data-y="-18.05" cx="376.6223908918406" cy="452.43516761543333" r="3" fill="hsl(326.1224489795918, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
 source_net_0
-top" data-x="-4.99" data-y="3" cx="337.63440860215053" cy="239.40543959519295" r="3" fill="hsl(334.13793103448273, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+top" data-x="3.21" data-y="-5.7" cx="420.61986084756484" cy="327.4509803921569" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
 source_net_0
-top" data-x="-4.99" data-y="0" cx="337.63440860215053" cy="269.76597090449087" r="3" fill="hsl(334.13793103448273, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+top" data-x="3.21" data-y="6.2" cx="420.61986084756484" cy="207.02087286527518" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
 source_net_0
-top" data-x="-4.99" data-y="-3" cx="337.63440860215053" cy="300.1265022137888" r="3" fill="hsl(334.13793103448273, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+top" data-x="0" data-y="0" cx="388.13409234661606" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
 source_net_0
-top" data-x="6.01" data-y="-3" cx="448.95635673624287" cy="300.1265022137888" r="3" fill="hsl(334.13793103448273, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+top" data-x="6.01" data-y="3" cx="448.95635673624287" cy="239.40543959519295" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
 source_net_0
-top" data-x="6.01" data-y="0" cx="448.95635673624287" cy="269.76597090449087" r="3" fill="hsl(334.13793103448273, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+top" data-x="6.01" data-y="3.44" cx="448.95635673624287" cy="234.95256166982927" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
 source_net_0
-top" data-x="6.01" data-y="3" cx="448.95635673624287" cy="239.40543959519295" r="3" fill="hsl(334.13793103448273, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+top" data-x="6.01" data-y="3.88" cx="448.95635673624287" cy="230.49968374446559" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
 source_net_0
-top" data-x="-2.1900000000000004" data-y="-5.7" cx="365.97090449082856" cy="327.4509803921569" r="3" fill="hsl(334.13793103448273, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+top" data-x="6.01" data-y="4.32" cx="448.95635673624287" cy="226.04680581910188" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
 source_net_0
-top" data-x="3.21" data-y="-5.7" cx="420.61986084756484" cy="327.4509803921569" r="3" fill="hsl(334.13793103448273, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+top" data-x="6.01" data-y="4.76" cx="448.95635673624287" cy="221.59392789373817" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
 source_net_0
-top" data-x="6.01" data-y="5.2" cx="448.95635673624287" cy="217.1410499683745" r="3" fill="hsl(334.13793103448273, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+top" data-x="6.01" data-y="5.2" cx="448.95635673624287" cy="217.1410499683745" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
 source_net_0
-top" data-x="3.21" data-y="6.2" cx="420.61986084756484" cy="207.02087286527518" r="3" fill="hsl(334.13793103448273, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+top" data-x="6.01" data-y="5.2" cx="448.95635673624287" cy="217.1410499683745" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
 source_net_0
-top" data-x="0" data-y="0" cx="388.13409234661606" cy="269.76597090449087" r="3" fill="hsl(334.13793103448273, 100%, 50%)"/></g><g id="crosshair__stack1__stack2" style="display: none"><line id="crosshair-h__stack1__stack2" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack2" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack2" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+top" data-x="5.676666666666667" data-y="5.533333333333333" cx="445.5829643685431" cy="213.7676576006747" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="5.343333333333333" data-y="5.866666666666667" cx="442.2095720008433" cy="210.39426523297493" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="5.01" data-y="6.2" cx="438.83617963314356" cy="207.02087286527518" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="4.56" data-y="6.2" cx="434.28209993674886" cy="207.02087286527518" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="4.109999999999999" data-y="6.2" cx="429.7280202403542" cy="207.02087286527518" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="3.66" data-y="6.2" cx="425.17394054395953" cy="207.02087286527518" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="3.21" data-y="6.2" cx="420.61986084756484" cy="207.02087286527518" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.99" data-y="3" cx="337.63440860215053" cy="239.40543959519295" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-5.259823256239847" data-y="3.269823256239847" cx="334.90374946246834" cy="236.67478045551076" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-5.529646512479694" data-y="3.5396465124796936" cx="332.17309032278615" cy="233.94412131582857" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-5.992323756239847" data-y="3.5396465124796936" cx="327.49071467435954" cy="233.94412131582857" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-6.455000999999999" data-y="3.5396465124796936" cx="322.8083390259329" cy="233.94412131582857" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-6.455000999999999" data-y="3.124717409983755" cx="322.8083390259329" cy="238.1432773183175" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-6.455000999999999" data-y="2.7097883074878157" cx="322.8083390259329" cy="242.34243332080646" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-6.455000999999999" data-y="2.294859204991877" cx="322.8083390259329" cy="246.5415893232954" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-6.455000999999999" data-y="1.8799301024959378" cx="322.8083390259329" cy="250.74074532578436" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-6.455000999999999" data-y="1.465000999999999" cx="322.8083390259329" cy="254.9399013282733" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-6.1620007999999995" data-y="1.1720007999999993" cx="325.7735529411765" cy="257.90511524351683" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-5.8690006" data-y="0.8790005999999995" cx="328.73876685642" cy="260.87032915876034" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-5.5760004" data-y="0.5860003999999996" cx="331.7039807716635" cy="263.83554307400385" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-5.2830002" data-y="0.2930001999999998" cx="334.669194686907" cy="266.80075698924736" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.99" data-y="0" cx="337.63440860215053" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.99" data-y="0" cx="337.63440860215053" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.99" data-y="-0.5" cx="337.63440860215053" cy="274.8260594560405" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.99" data-y="-1" cx="337.63440860215053" cy="279.8861480075902" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.99" data-y="-1.5" cx="337.63440860215053" cy="284.94623655913983" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.99" data-y="-2" cx="337.63440860215053" cy="290.0063251106895" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.99" data-y="-2.5" cx="337.63440860215053" cy="295.06641366223914" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.99" data-y="-3" cx="337.63440860215053" cy="300.1265022137888" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="-3" cx="448.95635673624287" cy="300.1265022137888" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="-2.5" cx="448.95635673624287" cy="295.06641366223914" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="-2" cx="448.95635673624287" cy="290.0063251106895" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="-1.5" cx="448.95635673624287" cy="284.94623655913983" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="-1" cx="448.95635673624287" cy="279.8861480075902" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="-0.5" cx="448.95635673624287" cy="274.8260594560405" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="0" cx="448.95635673624287" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="0" cx="448.95635673624287" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="0.5" cx="448.95635673624287" cy="264.7058823529412" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="1" cx="448.95635673624287" cy="259.64579380139156" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="1.5" cx="448.95635673624287" cy="254.5857052498419" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="2" cx="448.95635673624287" cy="249.52561669829225" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="2.5" cx="448.95635673624287" cy="244.4655281467426" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="3" cx="448.95635673624287" cy="239.40543959519295" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.99" data-y="-3" cx="337.63440860215053" cy="300.1265022137888" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-5.21250318732684" data-y="-3.22250318732684" cx="335.3826369403988" cy="302.37827387554046" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-5.43500637465368" data-y="-3.44500637465368" cx="333.1308652786471" cy="304.6300455372922" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-5.43500637465368" data-y="-3.7464222387898327" cx="333.1308652786471" cy="307.68042746403376" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-5.43500637465368" data-y="-4.047838102925986" cx="333.1308652786471" cy="310.73080939077533" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-5.43500637465368" data-y="-4.047838102925986" cx="333.1308652786471" cy="310.73080939077533" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-5.4245847631116435" data-y="-4.058259714468022" cx="333.23633383315223" cy="310.8362779452805" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-5.112004667934317" data-y="-4.370839809645348" cx="336.3996997552504" cy="313.99964386737867" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-4.799424572756991" data-y="-4.683419904822674" cx="339.5630656773486" cy="317.1630097894768" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-4.486844477579665" data-y="-4.996" cx="342.72643159944676" cy="320.326375711575" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-3.9921524093539986" data-y="-4.996" cx="347.73280294138897" cy="320.326375711575" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-3.4974603411283325" data-y="-4.996" cx="352.73917428333124" cy="320.326375711575" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-3.002768272902666" data-y="-4.996" cx="357.74554562527345" cy="320.326375711575" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-2.5080762046769998" data-y="-4.996" cx="362.75191696721566" cy="320.326375711575" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-2.0133841364513327" data-y="-4.996" cx="367.75828830915793" cy="320.326375711575" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-1.5186920682256666" data-y="-4.996" cx="372.76465965110015" cy="320.326375711575" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-1.024" data-y="-4.996" cx="377.77103099304236" cy="320.326375711575" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-1.024" data-y="-4.996" cx="377.77103099304236" cy="320.326375711575" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-1.0565206313402955" data-y="-5.028520631340296" cx="377.441916444374" cy="320.65549026024337" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-1.218231781216708" data-y="-5.028520631340296" cx="375.8053709680788" cy="320.65549026024337" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-1.5539714655465602" data-y="-5.364260315670148" cx="372.4076259021221" cy="324.05323532620014" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-1.8897111498764123" data-y="-5.7" cx="369.00988083616534" cy="327.4509803921569" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-2.1900000000000004" data-y="-5.7" cx="365.97090449082856" cy="327.4509803921569" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="6.01" data-y="-3" cx="448.95635673624287" cy="300.1265022137888" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="5.672499999999999" data-y="-3.3375" cx="445.54079696394683" cy="303.54206198608483" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="5.335" data-y="-3.675" cx="442.12523719165085" cy="306.9576217583808" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="4.9975" data-y="-4.0125" cx="438.7096774193548" cy="310.37318153067685" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="4.66" data-y="-4.35" cx="435.29411764705884" cy="313.7887413029728" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="4.3225" data-y="-4.6875" cx="431.8785578747628" cy="317.20430107526886" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="3.9849999999999994" data-y="-5.025" cx="428.46299810246677" cy="320.6198608475649" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="3.6474999999999995" data-y="-5.362500000000001" cx="425.0474383301708" cy="324.03542061986093" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="3.3099999999999996" data-y="-5.7" cx="421.63187855787476" cy="327.4509803921569" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="3.21" data-y="-5.7" cx="420.61986084756484" cy="327.4509803921569" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.99" data-y="0" cx="337.63440860215053" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.893" data-y="0.097" cx="338.6160657811512" cy="268.7843137254902" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.5975" data-y="0.097" cx="341.60657811511703" cy="268.7843137254902" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-4.302" data-y="0.097" cx="344.5970904490828" cy="268.7843137254902" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-4.302" data-y="0.097" cx="344.5970904490828" cy="268.7843137254902" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-4.288943945821694" data-y="0.11005605417830638" cx="344.729220029635" cy="268.65218414493813" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-4.286" data-y="0.113" cx="344.75901328273244" cy="268.62239089184067" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-3.8837999999999995" data-y="0.113" cx="348.829348513599" cy="268.62239089184067" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-3.4816" data-y="0.113" cx="352.8996837444655" cy="268.62239089184067" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-3.0793999999999997" data-y="0.113" cx="356.97001897533204" cy="268.62239089184067" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-2.6772" data-y="0.113" cx="361.0403542061986" cy="268.62239089184067" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+bottom" data-x="-2.275" data-y="0.113" cx="365.11068943706516" cy="268.62239089184067" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-2.275" data-y="0.113" cx="365.11068943706516" cy="268.62239089184067" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-2.244249772519263" data-y="0.08224977251926317" cx="365.4218871851308" cy="268.9335886399063" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-2.2158546998677835" data-y="0.08224977251926317" cx="365.70925034921913" cy="268.9335886399063" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-2.1336049273485203" data-y="0" cx="366.5416326138037" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-1.7068839418788162" data-y="0" cx="370.86012456036616" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-1.2801629564091122" data-y="0" cx="375.1786165069286" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-0.8534419709394081" data-y="0" cx="379.49710845349114" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-0.42672098546970405" data-y="0" cx="383.8156004000536" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="0" data-y="0" cx="388.13409234661606" cy="269.76597090449087" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-2.1900000000000004" data-y="-5.7" cx="365.97090449082856" cy="327.4509803921569" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-1.9424995000000003" data-y="-5.9475005" cx="368.47565338393423" cy="329.9557292852625" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-1.6949990000000001" data-y="-6.195001" cx="370.98040227703984" cy="332.4604781783682" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-1.204938948057622" data-y="-6.195001" cx="375.9398967938507" cy="332.4604781783682" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-0.7148788961152439" data-y="-6.195001" cx="380.89939131066166" cy="332.4604781783682" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="-0.2248188441728658" data-y="-6.195001" cx="385.8588858274726" cy="332.4604781783682" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="0.2652412077695123" data-y="-6.195001" cx="390.81838034428347" cy="332.4604781783682" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="0.7553012597118904" data-y="-6.195001" cx="395.7778748610944" cy="332.4604781783682" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="1.2453613116542686" data-y="-6.195001" cx="400.7373693779053" cy="332.4604781783682" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="1.7354213635966467" data-y="-6.195001" cx="405.6968638947162" cy="332.4604781783682" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="2.225481415539025" data-y="-6.195001" cx="410.65635841152715" cy="332.4604781783682" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="2.715541467481403" data-y="-6.195001" cx="415.61585292833803" cy="332.4604781783682" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="3.205601519423781" data-y="-6.195001" cx="420.57534744514896" cy="332.4604781783682" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="3.205601519423781" data-y="-5.704398480576219" cx="420.57534744514896" cy="327.4954937945728" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_net_0
+source_net_0
+top" data-x="3.21" data-y="-5.7" cx="420.61986084756484" cy="327.4509803921569" r="3" fill="hsl(333.0612244897959, 100%, 50%)"/></g><g id="crosshair__stack1__stack2" style="display: none"><line id="crosshair-h__stack1__stack2" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack2" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack2" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
               document.currentScript.parentElement.addEventListener('mousemove', (e) => {
                 const svg = e.currentTarget;
                 const rect = svg.getBoundingClientRect();

--- a/tests/repros/repro-rp2040-subcircuit-autorouting-slowdown.test.tsx
+++ b/tests/repros/repro-rp2040-subcircuit-autorouting-slowdown.test.tsx
@@ -280,6 +280,11 @@ test("RP2040 subcircuit exposes slow parent autorouter input construction", asyn
           />
         </Fragment>
       ))}
+      <trace
+        name="FLASH_VCC"
+        from=".U_FLASH > .VCC"
+        to={`${rp2040Selector} > .IOVDD1`}
+      />
 
       <chip
         name="U_DEBUG_USB"
@@ -364,7 +369,7 @@ test("RP2040 subcircuit exposes slow parent autorouter input construction", asyn
     expect(autoroutingPhaseIoStack).toHaveLength(1)
     expect(
       autoroutingPhaseIoStack[0]?.startSimpleRouteJson?.connections,
-    ).toHaveLength(58)
+    ).toHaveLength(59)
     console.log(`Flat RP2040 autorouting took ${renderDurationMs.toFixed(0)}ms`)
     return
   }
@@ -373,7 +378,7 @@ test("RP2040 subcircuit exposes slow parent autorouter input construction", asyn
   const [subcircuitPhase, boardPhase] = autoroutingPhaseIoStack
   expect(subcircuitPhase?.startSimpleRouteJson?.connections).toHaveLength(11)
   expect(subcircuitPhase?.endSimpleRouteJson?.traces).toHaveLength(20)
-  expect(boardPhase?.startSimpleRouteJson?.connections).toHaveLength(47)
+  expect(boardPhase?.startSimpleRouteJson?.connections).toHaveLength(48)
   expect(boardPhase?.startSimpleRouteJson?.traces?.length).toBe(
     subcircuitPhase?.endSimpleRouteJson?.traces?.length,
   )
@@ -404,8 +409,8 @@ test("RP2040 subcircuit exposes slow parent autorouter input construction", asyn
   const rp2040ConnectionPoints = boardConnectionPoints.filter(
     (point) => point.pcb_port_id && rp2040PcbPortIds.has(point.pcb_port_id),
   )
-  expect(boardConnectionPoints).toHaveLength(94)
-  expect(rp2040ConnectionPoints).toHaveLength(45)
+  expect(boardConnectionPoints.length).toBeGreaterThan(96)
+  expect(rp2040ConnectionPoints).toHaveLength(46)
   expect(
     rp2040ConnectionPoints.every(
       (point) =>
@@ -435,11 +440,31 @@ test("RP2040 subcircuit exposes slow parent autorouter input construction", asyn
     ),
   ).toBe(true)
   expect(new Set(boardInputSrj.connections.map(({ name }) => name)).size).toBe(
-    47,
+    48,
   )
   expect(
     new Set(boardInputSrj.traces?.map(({ pcb_trace_id }) => pcb_trace_id)).size,
   ).toBe(20)
+
+  const childTraceConnectionPoints = boardConnectionPoints.filter((point) =>
+    point.pointId?.startsWith("pcb_trace_route_point_"),
+  )
+  expect(childTraceConnectionPoints.length).toBeGreaterThan(2)
+  const preservedTraceConnectedIds = new Set(
+    boardInputSrj.traces?.flatMap((trace) => trace.connectsTo ?? []),
+  )
+  expect(
+    childTraceConnectionPoints.every(
+      (point) => point.pointId && preservedTraceConnectedIds.has(point.pointId),
+    ),
+  ).toBe(true)
+  expect(
+    boardInputSrj.connections.filter((connection) =>
+      connection.pointsToConnect.some((point) =>
+        point.pointId?.startsWith("pcb_trace_route_point_"),
+      ),
+    ),
+  ).toHaveLength(1)
 
   console.log(
     `RP2040 subcircuit ${

--- a/tests/utils/autorouting/preserved-trace-connection-points.test.ts
+++ b/tests/utils/autorouting/preserved-trace-connection-points.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { TscircuitAutorouter } from "lib/utils/autorouting/CapacityMeshAutorouter"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+import { getPreservedTraceConnectionPoints } from "lib/utils/autorouting/getPreservedRoutedSubcircuitTraces"
+
+test("parent autorouting can attach to the closest point along child copper", () => {
+  const preservedTrace: NonNullable<SimpleRouteJson["traces"]>[number] = {
+    type: "pcb_trace",
+    pcb_trace_id: "pcb_trace_child",
+    connection_name: "source_trace_child",
+    connectsTo: [],
+    route: [
+      { route_type: "wire", x: 0, y: 0, width: 0.1, layer: "top" },
+      { route_type: "wire", x: 10, y: 0, width: 0.1, layer: "top" },
+    ],
+  }
+  const childTracePoints = getPreservedTraceConnectionPoints(preservedTrace)
+  preservedTrace.connectsTo = childTracePoints.map((point) => point.pointId)
+
+  const simpleRouteJson: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -1, maxX: 11, minY: -1, maxY: 6 },
+    obstacles: [],
+    traces: [preservedTrace],
+    connections: [
+      {
+        name: "source_trace_parent",
+        pointsToConnect: [
+          { x: 5, y: 5, layer: "top", pointId: "pcb_port_parent" },
+          ...childTracePoints,
+        ],
+      },
+    ],
+  }
+
+  const routedTraces = new TscircuitAutorouter(simpleRouteJson).solveSync()
+
+  expect(routedTraces).toHaveLength(1)
+  expect(routedTraces[0]?.connectsTo).toEqual([
+    "pcb_port_parent",
+    "pcb_trace_route_point_pcb_trace_child_10",
+  ])
+  expect(routedTraces[0]?.route).toEqual([
+    { route_type: "wire", x: 5, y: 0, width: 0.1, layer: "top" },
+    { route_type: "wire", x: 5, y: 5, width: 0.1, layer: "top" },
+  ])
+})

--- a/tests/utils/autorouting/simple-route-json-ignores-existing-top-level-pcb-traces.test.ts
+++ b/tests/utils/autorouting/simple-route-json-ignores-existing-top-level-pcb-traces.test.ts
@@ -206,7 +206,13 @@ test("simple route json keeps existing pcb traces as routing state inside subcir
       (connection) => connection.source_trace_id === "source_trace_ab",
     ),
   ).toBe(false)
-  expect(netConnection!.externallyConnectedPointIds).toEqual([
-    ["pcb_port_a", "pcb_port_b"],
+  expect(netConnection!.externallyConnectedPointIds).toBeUndefined()
+  expect(netConnection!.pointsToConnect.map((point) => point.pointId)).toEqual([
+    "pcb_port_a",
+    "pcb_port_b",
+  ])
+  expect(simpleRouteJson.traces?.[0]?.connectsTo).toEqual([
+    "pcb_port_a",
+    "pcb_port_b",
   ])
 })

--- a/tests/utils/autorouting/simple-route-json-preserves-child-net-routing-state.test.ts
+++ b/tests/utils/autorouting/simple-route-json-preserves-child-net-routing-state.test.ts
@@ -96,15 +96,27 @@ test("board simple route json preserves child trace physical connectivity", () =
     (connection) => connection.name === "source_net_shared",
   )
 
+  const childTracePointIds = [0, 1, 2, 3, 4].map(
+    (pointIndex) =>
+      `pcb_trace_route_point_pcb_trace_child_routed_${pointIndex}`,
+  )
   expect(netConnection?.pointsToConnect.map((point) => point.pointId)).toEqual([
     "opaque-child-a",
     "opaque-child-b",
     "opaque-board-port",
+    ...childTracePointIds,
+  ])
+  expect(netConnection?.pointsToConnect.slice(3)).toEqual([
+    { x: -2, y: 0, layer: "top", pointId: childTracePointIds[0] },
+    { x: -1.5, y: 0, layer: "top", pointId: childTracePointIds[1] },
+    { x: -1, y: 0, layer: "top", pointId: childTracePointIds[2] },
+    { x: -0.5, y: 0, layer: "top", pointId: childTracePointIds[3] },
+    { x: 0, y: 0, layer: "top", pointId: childTracePointIds[4] },
   ])
   expect(simpleRouteJson.traces).toEqual([
     expect.objectContaining({
       pcb_trace_id: "pcb_trace_child_routed",
-      connectsTo: ["opaque-child-a", "opaque-child-b"],
+      connectsTo: ["opaque-child-a", "opaque-child-b", ...childTracePointIds],
     }),
   ])
 


### PR DESCRIPTION
## Summary

- preserve child-first subcircuit autorouting instead of co-routing transparent subcircuits with their parent
- keep each cross-boundary child port as a normal attachment point in the parent connection's `pointsToConnect`
- where electrically matching child copper already exists, sample attachment points every 0.5 mm along that source-backed trace and add them to the parent connection's `pointsToConnect`
- add sampled point IDs to the preserved trace's `connectsTo`, so the capacity router treats them as already-connected alternatives in its MST rather than new terminals that all require routing
- restrict enrichment to descendant-subcircuit traces so same-scope routes and manual copper such as solder-jumper bridges remain unchanged
- preserve explicit `<breakoutpoint>` boundaries as the sole child/parent handoff instead of adding interior trace candidates behind them
- extend the RP2040 reproduction with a board-level VCC connection that shares the child-routed IOVDD1 decoupling copper

## SRJ findings

The phase split remains hierarchical: the RP2040 child starts with 11 connections and ends with 20 traces; the board then starts with 48 connections and those same 20 preserved traces.

The board input already contains 46 RP2040 physical-pad attachment points for the cross-boundary signals. Those connections do not need fanout: the RP2040 pad is their subcircuit attachment point.

The matching `FLASH_VCC` connection additionally contains stable attachment points along the already-routed IOVDD1 trace, and every candidate ID is present in that trace's `connectsTo`. Unrelated GPIO/USB/QSPI connections correctly receive no trace-interior candidates because they have no existing child copper, while retaining their physical-pad attachment point.

A focused capacity-router test confirms that a parent endpoint at `(5, 5)` chooses the interior `(5, 0)` point of a preserved child trace instead of routing back to an endpoint.

The full RP2040 real-router experiment still reaches the existing 120-second test ceiling. This is not evidence that the remaining cross-boundary signals need fanout: their attachment points are present in the parent SRJ. The remaining performance issue should be investigated in how the parent router handles the dense QFN endpoints together with preserved child geometry, separately from this missing existing-copper attachment representation.

## Validation

- `bun run build`
- `bunx tsc --noEmit`
- `bun test tests/utils/autorouting` (36 pass)
- `bun test tests/subcircuits` (50 pass, 1 existing skip)
- `bun test tests/components/primitive-components` (223 pass, 1 existing skip)
- remote autorouting fixture suite (11 pass, 3 existing skips)
- explicit-breakout regression and original snapshots
- solder-jumper regression snapshot
- RP2040 SRJ phase-stack snapshot visually inspected
- real RP2040 mode measured to the 120-second ceiling as described above

Stacked on #3298.
