### PR TITLE
Fix internally connected custom-symbol ports

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -671,9 +671,14 @@ export class NormalComponent<
       {},
       {
         get: (target, prop): Port => {
-          const port = this._getAllPortsFromChildren().find((port) =>
-            port.isMatchingNameOrAlias(prop as string),
+          const symbol = this.children.find(
+            (child) => child.componentName === "Symbol",
           )
+          const port = [...this.children, ...(symbol?.children ?? [])].find(
+            (child) =>
+              child.componentName === "Port" &&
+              (child as Port).isMatchingNameOrAlias(prop as string),
+          ) as Port | undefined
           if (!port) {
             throw new Error(
               `There was an issue finding the port "${prop.toString()}" inside of a ${

--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -671,10 +671,8 @@ export class NormalComponent<
       {},
       {
         get: (target, prop): Port => {
-          const port = this.children.find(
-            (c) =>
-              c.componentName === "Port" &&
-              (c as Port).isMatchingNameOrAlias(prop as string),
+          const port = this._getAllPortsFromChildren().find((port) =>
+            port.isMatchingNameOrAlias(prop as string),
           )
           if (!port) {
             throw new Error(
@@ -773,24 +771,11 @@ export class NormalComponent<
   _getInternallyConnectedPins(): Port[][] {
     if (this.internallyConnectedPinNames.length === 0) return []
 
-    const childPorts = this._getAllPortsFromChildren()
     const internallyConnectedPorts: Port[][] = []
     for (const netPortNames of this.internallyConnectedPinNames) {
       const ports: Port[] = []
       for (const portName of netPortNames) {
-        const port = childPorts.find((port) =>
-          port.isMatchingNameOrAlias(portName),
-        )
-        if (!port) {
-          throw new Error(
-            `There was an issue finding the port "${portName}" inside of a ${
-              this.componentName
-            } component with name: "${
-              this.props.name
-            }". This is a bug in @tscircuit/core`,
-          )
-        }
-        ports.push(port)
+        ports.push(this.portMap[portName as PortNames] as Port)
       }
       internallyConnectedPorts.push(ports)
     }

--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -773,11 +773,24 @@ export class NormalComponent<
   _getInternallyConnectedPins(): Port[][] {
     if (this.internallyConnectedPinNames.length === 0) return []
 
+    const childPorts = this._getAllPortsFromChildren()
     const internallyConnectedPorts: Port[][] = []
     for (const netPortNames of this.internallyConnectedPinNames) {
       const ports: Port[] = []
       for (const portName of netPortNames) {
-        ports.push(this.portMap[portName as PortNames] as Port)
+        const port = childPorts.find((port) =>
+          port.isMatchingNameOrAlias(portName),
+        )
+        if (!port) {
+          throw new Error(
+            `There was an issue finding the port "${portName}" inside of a ${
+              this.componentName
+            } component with name: "${
+              this.props.name
+            }". This is a bug in @tscircuit/core`,
+          )
+        }
+        ports.push(port)
       }
       internallyConnectedPorts.push(ports)
     }

--- a/tests/repros/repro-custom-symbol-internally-connected-pins-without-traces.test.tsx
+++ b/tests/repros/repro-custom-symbol-internally-connected-pins-without-traces.test.tsx
@@ -280,38 +280,35 @@ export const DMT6007LFG_7 = (props: ChipProps<typeof pinLabels>) => {
     />
   )
 }
-test.failing(
-  "imported DMT6007LFG_7 custom symbol supports internallyConnectedPins without traces or netlabels",
-  async () => {
-    const { circuit } = getTestFixture()
+test("imported DMT6007LFG_7 custom symbol supports internallyConnectedPins without traces or netlabels", async () => {
+  const { circuit } = getTestFixture()
 
-    circuit.add(
-      <board width="16mm" height="12mm">
-        <DMT6007LFG_7 name="Q1" internallyConnectedPins={[[1, 2, 3]]} />
-      </board>,
-    )
+  circuit.add(
+    <board width="16mm" height="12mm">
+      <DMT6007LFG_7 name="Q1" internallyConnectedPins={[[1, 2, 3]]} />
+    </board>,
+  )
 
-    await circuit.renderUntilSettled()
+  await circuit.renderUntilSettled()
 
-    const sourcePortsById = new Map(
-      circuit.db.source_port
-        .list()
-        .map((sourcePort) => [sourcePort.source_port_id, sourcePort]),
-    )
-    const internalConnections =
-      circuit.db.source_component_internal_connection.list()
+  const sourcePortsById = new Map(
+    circuit.db.source_port
+      .list()
+      .map((sourcePort) => [sourcePort.source_port_id, sourcePort]),
+  )
+  const internalConnections =
+    circuit.db.source_component_internal_connection.list()
 
-    expect(circuit.db.source_trace.list()).toHaveLength(0)
-    expect(internalConnections).toHaveLength(1)
-    expect(
-      internalConnections[0].source_port_ids
-        .map((sourcePortId) => sourcePortsById.get(sourcePortId)?.pin_number)
-        .sort((pinNumberA, pinNumberB) =>
-          pinNumberA !== undefined && pinNumberB !== undefined
-            ? pinNumberA - pinNumberB
-            : 0,
-        ),
-    ).toEqual([1, 2, 3])
-    expect(circuit).toMatchSchematicSnapshot(import.meta.path)
-  },
-)
+  expect(circuit.db.source_trace.list()).toHaveLength(0)
+  expect(internalConnections).toHaveLength(1)
+  expect(
+    internalConnections[0].source_port_ids
+      .map((sourcePortId) => sourcePortsById.get(sourcePortId)?.pin_number)
+      .sort((pinNumberA, pinNumberB) =>
+        pinNumberA !== undefined && pinNumberB !== undefined
+          ? pinNumberA - pinNumberB
+          : 0,
+      ),
+  ).toEqual([1, 2, 3])
+  expect(circuit).toMatchSchematicSnapshot(import.meta.path)
+})

--- a/tests/repros/repro-custom-symbol-internally-connected-pins.test.tsx
+++ b/tests/repros/repro-custom-symbol-internally-connected-pins.test.tsx
@@ -281,40 +281,37 @@ export const DMT6007LFG_7 = (props: ChipProps<typeof pinLabels>) => {
   )
 }
 
-test.failing(
-  "imported DMT6007LFG_7 custom symbol ports support internallyConnectedPins",
-  async () => {
-    const { circuit } = getTestFixture()
+test("imported DMT6007LFG_7 custom symbol ports support internallyConnectedPins", async () => {
+  const { circuit } = getTestFixture()
 
-    circuit.add(
-      <board width="16mm" height="12mm">
-        <DMT6007LFG_7 name="Q1" internallyConnectedPins={[[1, 2, 3]]} />
-        <trace from=".Q1 > .S3" to="net.SOURCE" />
-        <trace from=".Q1 > .G" to="net.GATE" />
-        <trace from=".Q1 > .D" to="net.DRAIN" />
-      </board>,
-    )
+  circuit.add(
+    <board width="16mm" height="12mm">
+      <DMT6007LFG_7 name="Q1" internallyConnectedPins={[[1, 2, 3]]} />
+      <trace from=".Q1 > .S3" to="net.SOURCE" />
+      <trace from=".Q1 > .G" to="net.GATE" />
+      <trace from=".Q1 > .D" to="net.DRAIN" />
+    </board>,
+  )
 
-    await circuit.renderUntilSettled()
+  await circuit.renderUntilSettled()
 
-    const sourcePortsById = new Map(
-      circuit.db.source_port
-        .list()
-        .map((sourcePort) => [sourcePort.source_port_id, sourcePort]),
-    )
-    const internalConnections =
-      circuit.db.source_component_internal_connection.list()
+  const sourcePortsById = new Map(
+    circuit.db.source_port
+      .list()
+      .map((sourcePort) => [sourcePort.source_port_id, sourcePort]),
+  )
+  const internalConnections =
+    circuit.db.source_component_internal_connection.list()
 
-    expect(internalConnections).toHaveLength(1)
-    expect(
-      internalConnections[0].source_port_ids
-        .map((sourcePortId) => sourcePortsById.get(sourcePortId)?.pin_number)
-        .sort((pinNumberA, pinNumberB) =>
-          pinNumberA !== undefined && pinNumberB !== undefined
-            ? pinNumberA - pinNumberB
-            : 0,
-        ),
-    ).toEqual([1, 2, 3])
-    expect(circuit).toMatchSchematicSnapshot(import.meta.path)
-  },
-)
+  expect(internalConnections).toHaveLength(1)
+  expect(
+    internalConnections[0].source_port_ids
+      .map((sourcePortId) => sourcePortsById.get(sourcePortId)?.pin_number)
+      .sort((pinNumberA, pinNumberB) =>
+        pinNumberA !== undefined && pinNumberB !== undefined
+          ? pinNumberA - pinNumberB
+          : 0,
+      ),
+  ).toEqual([1, 2, 3])
+  expect(circuit).toMatchSchematicSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## What changed

- Resolve internally connected pin groups from all ports owned by a component, including ports nested inside a custom React symbol.
- Preserve alias-based pin resolution and the existing missing-port error.
- Convert both exact DMT6007LFG-7 repros from expected failures into passing regression tests.

## Root cause

NormalComponent._getInternallyConnectedPins used portMap, which only searches direct child ports. Imported custom symbols place their ports beneath a Symbol primitive container, so valid pins such as pin1 could not be found.

The fix uses the existing _getAllPortsFromChildren path that core already relies on while initializing custom-symbol ports. It does not special-case the MOSFET, supplier part, or pin numbers.

## Validation

- Both merged custom-symbol repros pass as regular tests.
- Nine internal-connectivity tests pass across chips, interconnects, jumpers, and solder jumpers.
- bunx tsc --noEmit passes.
- Existing schematic snapshots remain unchanged.
