### PR TITLE
Pass trace maximum via counts to autorouter input

### DIFF
--- a/lib/utils/autorouting/SimpleRouteJson.ts
+++ b/lib/utils/autorouting/SimpleRouteJson.ts
@@ -86,6 +86,8 @@ export type SimpleRouteConnection = {
   isOffBoard?: boolean
   netConnectionName?: string
   nominalTraceWidth?: number
+  /** Maximum number of vias permitted across the routed connection. */
+  maxViaCount?: number
   /** @deprecated Use `nominalTraceWidth` instead. */
   width?: number
   pointsToConnect: SimpleRoutePoint[]

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -484,6 +484,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
           "",
         source_trace_id: trace.source_trace_id,
         nominalTraceWidth: trace.min_trace_thickness,
+        maxViaCount: trace.max_via_count,
         width: trace.min_trace_thickness,
         // Simple Route JSON connections are multi-terminal, so retain every
         // source trace endpoint in the autorouter input.

--- a/tests/components/primitive-components/trace-max-via-count.test.tsx
+++ b/tests/components/primitive-components/trace-max-via-count.test.tsx
@@ -1,13 +1,14 @@
 import { expect, test } from "bun:test"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test("trace maxViaCount is emitted on the source trace", () => {
+test("trace maxViaCount is emitted on the source trace and autorouter input", () => {
   const { circuit } = getTestFixture()
 
   circuit.add(
     <board routingDisabled>
-      <resistor name="R1" resistance="1k" />
-      <resistor name="R2" resistance="1k" />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-2} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={2} />
       <trace from=".R1 > .pin1" to=".R2 > .pin1" maxViaCount={2} />
     </board>,
   )
@@ -16,4 +17,10 @@ test("trace maxViaCount is emitted on the source trace", () => {
 
   expect(circuit.db.source_trace.list()).toHaveLength(1)
   expect(circuit.db.source_trace.list()[0].max_via_count).toBe(2)
+
+  const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
+    circuitJson: circuit.getCircuitJson(),
+  })
+  expect(simpleRouteJson.connections).toHaveLength(1)
+  expect(simpleRouteJson.connections[0].maxViaCount).toBe(2)
 })


### PR DESCRIPTION
## Summary

- add `maxViaCount` to Simple Route JSON connections
- propagate source trace `max_via_count` into autorouter input
- extend the source-trace regression test through the SRJ boundary

## Tests

- `bun test tests/components/primitive-components/trace-max-via-count.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`