### PR TITLE
Use autorouting phase region as routing bounds

### DIFF
--- a/lib/components/primitive-components/Group/Group_getRoutingPhasePlans.ts
+++ b/lib/components/primitive-components/Group/Group_getRoutingPhasePlans.ts
@@ -343,6 +343,14 @@ export function Group_getRoutingPhasePlans(
     plan.phaseName = phaseProps?.name
     plan.reroute = phaseProps?.reroute
     plan.region = phaseProps?.region
+    if (phaseProps?.region) {
+      plan.routingBounds = {
+        minX: phaseProps.region.minX,
+        maxX: phaseProps.region.maxX,
+        minY: phaseProps.region.minY,
+        maxY: phaseProps.region.maxY,
+      }
+    }
     plan.connectionSelectors = phaseProps
       ? getConnectionSelectorsFromAutoroutingPhaseProps(phaseProps)
       : undefined

--- a/tests/features/autoroutingphase-region-routing-bounds.test.tsx
+++ b/tests/features/autoroutingphase-region-routing-bounds.test.tsx
@@ -6,7 +6,7 @@ import type {
 import { createBasicAutorouter } from "tests/fixtures/createBasicAutorouter"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test("non-reroute autorouting phase region does not constrain routing bounds", async () => {
+test("non-reroute autorouting phase region constrains routing bounds", async () => {
   const { circuit } = getTestFixture()
   let phaseInput: SimpleRouteJson | undefined
   const autorouter = createBasicAutorouter(
@@ -56,10 +56,10 @@ test("non-reroute autorouting phase region does not constrain routing bounds", a
 
   expect(phaseInput).toBeDefined()
   expect(phaseInput!.bounds).toEqual({
-    minX: -20,
-    maxX: 20,
-    minY: -10,
-    maxY: 10,
+    minX: -5,
+    maxX: 5,
+    minY: -3,
+    maxY: 3,
   })
   expect(circuit).toMatchPcbSnapshot(import.meta.path)
 })


### PR DESCRIPTION
## Summary

- copy a declared autorouting phase rectangle into that phase's `routingBounds`
- pass only the numeric bounds fields, without leaking the region shape discriminator into Simple Route JSON
- turn the real-board reproduction into a regression that requires the local autorouter to receive the 10 mm × 6 mm phase bounds

## Stack

- Reproduction: #3330
- Fix: this PR

This branch is based directly on the reproduction branch so GitHub can show the stack.

## Tests

- `bun test tests/features/autoroutingphase-region-routing-bounds.test.tsx tests/features/autoroutingphase-region-reroute.test.tsx`
- `bunx biome check lib/components/primitive-components/Group/Group_getRoutingPhasePlans.ts tests/features/autoroutingphase-region-routing-bounds.test.tsx`
