### PR TITLE
Reproduce bus trace identity collision

### DIFF
--- a/tests/features/bus-exact-trace-selector-connectivity-key-collision.test.tsx
+++ b/tests/features/bus-exact-trace-selector-connectivity-key-collision.test.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("bus trace names sharing one connectivity key resolve ambiguously", async () => {
+  const { circuit } = getTestFixture()
+  let asyncEffectError: string | undefined
+
+  circuit.on("asyncEffect:end", (event) => {
+    if (event.error) asyncEffectError = event.error
+  })
+
+  circuit.add(
+    <board width="20mm" height="10mm">
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-6} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={0} />
+      <resistor name="R3" resistance="1k" footprint="0402" pcbX={6} />
+      <trace name="LEFT_DATA" from=".R1 > .pin1" to=".R2 > .pin1" />
+      <trace name="RIGHT_DATA" from=".R2 > .pin1" to=".R3 > .pin1" />
+      <bus name="DATA" connections={["LEFT_DATA", "RIGHT_DATA"]} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(asyncEffectError).toContain(
+    'Bus "DATA" resolves multiple entries to one trace',
+  )
+})


### PR DESCRIPTION
## Reproduction

This adds a real board where two explicitly named bus traces meet at the same terminal. They therefore share a subcircuit connectivity-map key while retaining distinct source-trace identities.

The test records the current failure: resolving `LEFT_DATA` scans every source trace with the shared connectivity key, then resolving `RIGHT_DATA` does the same, so the bus reports `resolves multiple entries to one trace` before the autorouter can run.

## Expected behavior

An exact trace-name selector should first select that named source trace. Connectivity-map fallback should only be used when the selector does not uniquely identify a source trace.

## Test

- `bun test tests/features/bus-exact-trace-selector-connectivity-key-collision.test.tsx`
- `bunx biome check tests/features/bus-exact-trace-selector-connectivity-key-collision.test.tsx`

This is the reproduction PR. The fix is intentionally kept in the next PR in the stack.
