### PR TITLE
Preserve fanout source-trace identity on published solver

### DIFF
--- a/lib/utils/autorouting/FanoutAutorouter.ts
+++ b/lib/utils/autorouting/FanoutAutorouter.ts
@@ -20,6 +20,7 @@ import type {
 import type {
   SimpleRouteBounds,
   SimpleRouteBus,
+  SimpleRouteConnection,
   SimpleRouteJson,
   SimpleRoutePoint,
   SimplifiedPcbTrace,
@@ -28,6 +29,10 @@ import { getFanoutSharedBoundary } from "./get-fanout-shared-boundary"
 import { getFanoutSpaceErrorMessage } from "./get-fanout-space-error-message"
 
 export type FanoutAutorouterMode = "single_layer_fanout" | "fanout"
+
+type FanoutTraceWithSourceTraceId = SimplifiedPcbTrace & {
+  source_trace_id?: string
+}
 
 export interface FanoutAutorouterOptions {
   mode: FanoutAutorouterMode
@@ -82,6 +87,32 @@ const expandBoundsToIncludePoints = (
       ...points.map((p) => p.y),
     ),
   }
+}
+
+const addSourceTraceIdentityFromInputConnections = ({
+  fanoutTraces,
+  inputConnections,
+}: {
+  fanoutTraces: readonly SimplifiedPcbTrace[]
+  inputConnections: readonly SimpleRouteConnection[]
+}): SimplifiedPcbTrace[] => {
+  const sourceTraceIdByConnectionName = new Map(
+    inputConnections.flatMap((connection) =>
+      connection.source_trace_id
+        ? [[connection.name, connection.source_trace_id] as const]
+        : [],
+    ),
+  )
+  const fanoutTracesWithOptionalSourceTraceId =
+    fanoutTraces as readonly FanoutTraceWithSourceTraceId[]
+  return fanoutTracesWithOptionalSourceTraceId.map((trace) => {
+    const sourceTraceId =
+      trace.source_trace_id ??
+      (trace.connection_name === undefined
+        ? undefined
+        : sourceTraceIdByConnectionName.get(trace.connection_name))
+    return sourceTraceId ? { ...trace, source_trace_id: sourceTraceId } : trace
+  })
 }
 
 export const getFanoutSolverBuses = (
@@ -478,9 +509,19 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
       )
     }
     const output = fanoutSolver.getOutput()
-    const fanoutSimpleRouteJson =
+    const rawFanoutSimpleRouteJson =
       output.simpleRouteJson as unknown as SimpleRouteJson
-    const fanoutTraces = output.fanoutTraces as unknown as SimplifiedPcbTrace[]
+    const fanoutSimpleRouteJson = {
+      ...rawFanoutSimpleRouteJson,
+      traces: addSourceTraceIdentityFromInputConnections({
+        fanoutTraces: rawFanoutSimpleRouteJson.traces ?? [],
+        inputConnections: this.input.connections,
+      }),
+    }
+    const fanoutTraces = addSourceTraceIdentityFromInputConnections({
+      fanoutTraces: output.fanoutTraces as unknown as SimplifiedPcbTrace[],
+      inputConnections: this.input.connections,
+    })
     return {
       downstreamSimpleRouteJson: createDownstreamSimpleRouteJson({
         fanoutSimpleRouteJson,

--- a/tests/features/fanout-stage-source-trace-id.test.tsx
+++ b/tests/features/fanout-stage-source-trace-id.test.tsx
@@ -3,7 +3,7 @@ import { Fragment } from "react"
 import { createAutoroutingPhaseIoStack } from "tests/fixtures/create-autorouting-phase-io-stack"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test("fanout stage output drops source trace identity", async () => {
+test("fanout stage output preserves source trace identity", async () => {
   const { circuit } = getTestFixture()
   const autoroutingPhaseIoStack = createAutoroutingPhaseIoStack(circuit)
   const pads = Array.from({ length: 16 }, (_, padIndex) => {
@@ -64,7 +64,7 @@ test("fanout stage output drops source trace identity", async () => {
     | undefined
   expect(
     fanoutTracesWithOptionalSourceTraceId?.every(
-      (trace) => trace.source_trace_id === undefined,
+      (trace) => trace.source_trace_id !== undefined,
     ),
   ).toBe(true)
   expect(circuit).toMatchPcbSnapshot(import.meta.path)


### PR DESCRIPTION
## Stack

- Reproduction: #3336
- Fix: this PR

## Summary

- run the exact reproduction on the latest published `@tscircuit/fanout-solver` version, `0.0.35`
- restore persistent source-trace identity from Core's typed input connections at the solver adapter boundary
- apply the identity to both newly emitted `fanoutTraces` and the downstream Simple Route JSON trace state
- preserve an identity already supplied by a future solver release

## Why this is needed

The current published solver release routes the copper correctly but does not expose `source_trace_id` on its trace type or emitted objects. Pinning the unmerged Git commit from fanout-solver#85 made this Core PR depend on an unpublished source snapshot and was not reproducible for package consumers.

Core already owns the mapping between phase-local connection names and persistent source-trace IDs. Restoring that boundary metadata keeps current `0.0.35` consumers correct now, while preserving the solver-provided field automatically after fanout-solver#85 is released.

Without the mapping, later phases may treat a fanout trace as unrelated copper, reroute it, or lose it when trace IDs are normalized.

## Verification

- `bun test tests/features/fanout-stage-source-trace-id.test.tsx`
- `bunx biome check lib/utils/autorouting/FanoutAutorouter.ts tests/features/fanout-stage-source-trace-id.test.tsx`
- `git diff --check`
