### PR TITLE
Deduplicate fanout output against input traces

### DIFF
--- a/lib/utils/autorouting/FanoutAutorouter.ts
+++ b/lib/utils/autorouting/FanoutAutorouter.ts
@@ -480,7 +480,12 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
     const output = fanoutSolver.getOutput()
     const fanoutSimpleRouteJson =
       output.simpleRouteJson as unknown as SimpleRouteJson
-    const fanoutTraces = output.fanoutTraces as unknown as SimplifiedPcbTrace[]
+    const inputTraceIds = new Set(
+      (this.input.traces ?? []).map((trace) => trace.pcb_trace_id),
+    )
+    const fanoutTraces = (
+      output.fanoutTraces as unknown as SimplifiedPcbTrace[]
+    ).filter((trace) => !inputTraceIds.has(trace.pcb_trace_id))
     return {
       downstreamSimpleRouteJson: createDownstreamSimpleRouteJson({
         fanoutSimpleRouteJson,

--- a/tests/utils/autorouting/fanout-autorouter-reemits-input-trace-id.test.ts
+++ b/tests/utils/autorouting/fanout-autorouter-reemits-input-trace-id.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import { FanoutAutorouter } from "lib/utils/autorouting/FanoutAutorouter"
 import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
 
-test("fanout autorouter re-emits a trace already present in its input", () => {
+test("fanout autorouter does not re-emit a trace already present in its input", () => {
   const input: SimpleRouteJson = {
     layerCount: 2,
     minTraceWidth: 0.1,
@@ -58,8 +58,8 @@ test("fanout autorouter re-emits a trace already present in its input", () => {
   )
   const secondFanoutTraces = secondAutorouter.solveSync()
 
-  expect(secondFanoutTraces).toHaveLength(1)
-  expect(secondFanoutTraces[0]!.pcb_trace_id).toBe(
-    firstFanoutTraces[0]!.pcb_trace_id,
+  expect(secondFanoutTraces).toEqual([])
+  expect(secondAutorouter.getOutputSimpleRouteJson()?.traces).toContainEqual(
+    firstFanoutTraces[0],
   )
 })


### PR DESCRIPTION
## Summary

- collect `pcb_trace_id`s already present in the fanout adapter's input traces
- filter only duplicate IDs from the newly returned fanout-trace list
- keep the existing routed copper in downstream `SimpleRouteJson.traces`; no trace is converted into an obstacle
- turn the reproduction into a regression that requires no duplicate emitted trace while confirming the input trace remains in downstream SRJ

## Stack

- Reproduction: #3338
- Fix: this PR

This branch is based directly on the reproduction branch so GitHub can show the stack.

## Tests

- `bun test tests/utils/autorouting/fanout-autorouter-reemits-input-trace-id.test.ts tests/features/breakout-fanout-props.test.tsx`
- `bunx biome check lib/utils/autorouting/FanoutAutorouter.ts tests/utils/autorouting/fanout-autorouter-reemits-input-trace-id.test.ts`
