### PR TITLE
Normalize fanout handoff to source-trace identity

### DIFF
--- a/lib/components/primitive-components/Group/Group_syncFanoutExitsWithGlobalConnections.ts
+++ b/lib/components/primitive-components/Group/Group_syncFanoutExitsWithGlobalConnections.ts
@@ -57,6 +57,23 @@ const removeCompletedFanoutConnections = (
   }
 }
 
+const useSourceTraceIdentityForDownstreamHandoff = (
+  simpleRouteJson: SimpleRouteJson,
+): SimpleRouteJson => ({
+  ...simpleRouteJson,
+  traces: simpleRouteJson.traces?.map((trace) =>
+    trace.source_trace_id
+      ? {
+          ...trace,
+          connection_name: trace.source_trace_id,
+          connectsTo: Array.from(
+            new Set([...(trace.connectsTo ?? []), trace.source_trace_id]),
+          ),
+        }
+      : trace,
+  ),
+})
+
 export interface SynchronizedBreakoutPoint {
   sourceTraceId: string
   routingPcbGroupId: string
@@ -171,11 +188,15 @@ export function Group_syncFanoutExitsWithGlobalConnections({
     })
   }
 
-  return {
-    downstreamSimpleRouteJson: removeCompletedFanoutConnections(
+  const downstreamSimpleRouteJson = useSourceTraceIdentityForDownstreamHandoff(
+    removeCompletedFanoutConnections(
       fanoutOutputSimpleRouteJson,
       routingPcbGroupId,
     ),
+  )
+
+  return {
+    downstreamSimpleRouteJson,
     baseSimpleRouteJson: {
       ...baseSimpleRouteJson,
       connections: baseConnections,

--- a/tests/utils/autorouting/fanout-handoff-trace-identity.test.ts
+++ b/tests/utils/autorouting/fanout-handoff-trace-identity.test.ts
@@ -21,7 +21,7 @@ const createSimpleRouteJson = (
   bounds: { minX: -1, maxX: 10, minY: -1, maxY: 1 },
 })
 
-test("fanout handoff trace keeps its phase-local routing identity", () => {
+test("fanout handoff trace uses its source trace identity downstream", () => {
   const padPoint = { x: 0, y: 0, layer: "top", pointId: "soc:A1" }
   const remotePoint = { x: 10, y: 0, layer: "top", pointId: "memory:D1" }
   const fanoutExitPoint = {
@@ -82,8 +82,12 @@ test("fanout handoff trace keeps its phase-local routing identity", () => {
   })
 
   const handoffTrace = result.downstreamSimpleRouteJson.traces?.[0]
-  expect(handoffTrace?.connection_name).toBe(localConnectionName)
-  expect(handoffTrace?.connectsTo).not.toContain(sourceTraceId)
+  expect(handoffTrace?.connection_name).toBe(sourceTraceId)
+  expect(handoffTrace?.connectsTo).toEqual([
+    "soc:A1",
+    "breakout:DDR_D0",
+    sourceTraceId,
+  ])
   expect(
     result.baseSimpleRouteJson.connections[0]?.pointsToConnect[0],
   ).toMatchObject({ x: 3, y: 0, layer: "top", pointId: "soc:A1" })


### PR DESCRIPTION
## Stack

- Reproduction: #3341
- Fix: this PR

## Summary

- normalize fanout traces carrying `source_trace_id` at the fanout-to-global handoff
- set downstream `connection_name` to the persistent source-trace identity
- add that identity to `connectsTo` with set-based deduplication
- leave traces without persistent identity unchanged
- preserve the synchronized global endpoint behavior

## Why this is needed

This synchronization function is the point where Core changes from phase-local routing names to global persistent identities. Normalizing anywhere earlier would break the fanout solver's local connection lookup; normalizing later would allow the global phase to ingest copper under the wrong name. Performing the translation here makes the preloaded fanout prefix electrically owned by the same connection the global autorouter is completing.

On the AM62L design, the mismatch caused fanout copper to be treated as unrelated routing state and contributed to duplicate traces and incorrect obstacle ownership across phases.

## Verification

- `bun test tests/utils/autorouting/fanout-handoff-trace-identity.test.ts`
- `bunx biome check lib/components/primitive-components/Group/Group_syncFanoutExitsWithGlobalConnections.ts tests/utils/autorouting/fanout-handoff-trace-identity.test.ts`
