### PR TITLE
test: reproduce repeated supplier lookup failures

### DIFF
--- a/tests/components/normal-components/parts-engine-shared-request.test.tsx
+++ b/tests/components/normal-components/parts-engine-shared-request.test.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import type { PartsEngine } from "@tscircuit/props"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test.failing("identical parts share one failed supplier lookup and warning", async () => {
+  let findPartCallCount = 0
+  const partsEngine: PartsEngine = {
+    findPart: async () => {
+      findPartCallCount++
+      throw new Error("supplier service unavailable")
+    },
+  }
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="12mm" partsEngine={partsEngine}>
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <capacitor name="C2" capacitance="100nF" footprint="0402" />
+      <capacitor name="C3" capacitance="100nF" footprint="0402" />
+      <capacitor name="C4" capacitance="100nF" footprint="0402" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  expect(findPartCallCount).toBe(1)
+  expect(circuit.db.source_part_not_found_warning.list()).toHaveLength(1)
+})

--- a/tests/components/normal-components/parts-engine-shared-request.test.tsx
+++ b/tests/components/normal-components/parts-engine-shared-request.test.tsx
@@ -2,26 +2,29 @@ import { expect, test } from "bun:test"
 import type { PartsEngine } from "@tscircuit/props"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test.failing("identical parts share one failed supplier lookup and warning", async () => {
-  let findPartCallCount = 0
-  const partsEngine: PartsEngine = {
-    findPart: async () => {
-      findPartCallCount++
-      throw new Error("supplier service unavailable")
-    },
-  }
-  const { circuit } = getTestFixture()
+test.failing(
+  "identical parts share one failed supplier lookup and warning",
+  async () => {
+    let findPartCallCount = 0
+    const partsEngine: PartsEngine = {
+      findPart: async () => {
+        findPartCallCount++
+        throw new Error("supplier service unavailable")
+      },
+    }
+    const { circuit } = getTestFixture()
 
-  circuit.add(
-    <board width="20mm" height="12mm" partsEngine={partsEngine}>
-      <capacitor name="C1" capacitance="100nF" footprint="0402" />
-      <capacitor name="C2" capacitance="100nF" footprint="0402" />
-      <capacitor name="C3" capacitance="100nF" footprint="0402" />
-      <capacitor name="C4" capacitance="100nF" footprint="0402" />
-    </board>,
-  )
-  await circuit.renderUntilSettled()
+    circuit.add(
+      <board width="20mm" height="12mm" partsEngine={partsEngine}>
+        <capacitor name="C1" capacitance="100nF" footprint="0402" />
+        <capacitor name="C2" capacitance="100nF" footprint="0402" />
+        <capacitor name="C3" capacitance="100nF" footprint="0402" />
+        <capacitor name="C4" capacitance="100nF" footprint="0402" />
+      </board>,
+    )
+    await circuit.renderUntilSettled()
 
-  expect(findPartCallCount).toBe(1)
-  expect(circuit.db.source_part_not_found_warning.list()).toHaveLength(1)
-})
+    expect(findPartCallCount).toBe(1)
+    expect(circuit.db.source_part_not_found_warning.list()).toHaveLength(1)
+  },
+)


### PR DESCRIPTION
## Summary

- add a four-capacitor board whose identical supplier lookups all reject with the same network error
- record the intended boundary: one supplier request and one actionable warning per unique part query
- use `test.failing` so this PR contains no behavior change

## Current behavior

The board performs four identical `findPart` calls. Each component then emits its own copy of the same `source_part_not_found_warning`. The reproduction currently observes the first failed assertion as `Received: 4`.

The component reference (`C1` through `C4`) is not a part-selection input, so it should not split otherwise identical requests.

## Validation

- `bun test ./tests/components/normal-components/parts-engine-shared-request.test.tsx --timeout 30000`
- current implementation: expected failure is reproduced and Bun reports the `test.failing` case as passing
