### PR TITLE
Deduplicate identical supplier lookup failures

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -1,5 +1,6 @@
 import { fp } from "@tscircuit/footprinter"
 import { normalizeDegrees } from "@tscircuit/math-utils"
+import { supplierProps } from "@tscircuit/props"
 import type {
   CadModelGlb,
   CadModelGltf,
@@ -10,12 +11,14 @@ import type {
   CadModelStl,
   CadModelWrl,
   FootprintInsertionDirection,
+  PartsEngine,
   SchematicPortArrangement,
   SpiceModelElement,
   SupplierPartNumbers,
 } from "@tscircuit/props"
 import {
   type AnyCircuitElement,
+  type AnySourceComponent,
   type LayerRef,
   type PcbComponent,
   distance,
@@ -102,6 +105,49 @@ import { isStaticAssetPath } from "./utils/isStaticAssetPath"
 import { parseLibraryFootprintRef } from "./utils/parseLibraryFootprintRef"
 
 const debug = Debug("tscircuit:core")
+
+const supplierPartRequestsByCircuit = new WeakMap<
+  object,
+  WeakMap<PartsEngine, Map<string, Promise<SupplierPartNumbers>>>
+>()
+const reportedSupplierPartFailuresByCircuit = new WeakMap<object, Set<string>>()
+const sourceComponentIdentityFields = new Set([
+  "source_component_id",
+  "source_group_id",
+  "subcircuit_id",
+  "name",
+])
+
+function getSupplierPartRequestCache(
+  circuit: object,
+  partsEngine: PartsEngine,
+): Map<string, Promise<SupplierPartNumbers>> {
+  let requestsByPartsEngine = supplierPartRequestsByCircuit.get(circuit)
+  if (!requestsByPartsEngine) {
+    requestsByPartsEngine = new WeakMap()
+    supplierPartRequestsByCircuit.set(circuit, requestsByPartsEngine)
+  }
+  let requestsByCacheKey = requestsByPartsEngine.get(partsEngine)
+  if (!requestsByCacheKey) {
+    requestsByCacheKey = new Map()
+    requestsByPartsEngine.set(partsEngine, requestsByCacheKey)
+  }
+  return requestsByCacheKey
+}
+
+function hasReportedSupplierPartFailure(
+  circuit: object,
+  cacheKey: string,
+): boolean {
+  let reportedCacheKeys = reportedSupplierPartFailuresByCircuit.get(circuit)
+  if (!reportedCacheKeys) {
+    reportedCacheKeys = new Set()
+    reportedSupplierPartFailuresByCircuit.set(circuit, reportedCacheKeys)
+  }
+  if (reportedCacheKeys.has(cacheKey)) return true
+  reportedCacheKeys.add(cacheKey)
+  return false
+}
 
 const rotation3 = z.object({
   x: rotation,
@@ -1998,28 +2044,29 @@ export class NormalComponent<
   }
 
   private _getPartsEngineCacheKey(
-    source_component: any,
+    sourceComponent: AnySourceComponent,
     footprinterString?: string,
   ): string {
+    const partSelectionProperties = Object.fromEntries(
+      Object.entries(sourceComponent).filter(
+        ([propertyName]) => !sourceComponentIdentityFields.has(propertyName),
+      ),
+    )
     return JSON.stringify({
-      ftype: source_component.ftype,
-      name: source_component.name,
-      manufacturer_part_number: source_component.manufacturer_part_number,
-      standard: source_component.standard,
-      pin_count: source_component.pin_count,
+      partSelectionProperties,
       footprinterString,
     })
   }
 
   protected async _getSupplierPartNumbers(
-    partsEngine: any,
-    source_component: any,
+    partsEngine: PartsEngine,
+    sourceComponent: AnySourceComponent,
     footprinterString: string | undefined,
-  ) {
+  ): Promise<SupplierPartNumbers> {
     if (this.props.doNotPlace) return {}
     const cacheEngine = this.root?.platform?.localCacheEngine
     const cacheKey = this._getPartsEngineCacheKey(
-      source_component,
+      sourceComponent,
       footprinterString,
     )
     if (cacheEngine) {
@@ -2030,52 +2077,64 @@ export class NormalComponent<
         } catch {}
       }
     }
-    const result = await Promise.resolve(
-      partsEngine.findPart({
-        sourceComponent: source_component,
-        footprinterString,
-      }),
-    )
+    const root = this.root
+    if (!root) return {}
+    const requestsByCacheKey = getSupplierPartRequestCache(root, partsEngine)
+    const existingRequest = requestsByCacheKey.get(cacheKey)
+    if (existingRequest) return existingRequest
 
-    // Validate the result format
-    if (typeof result === "string") {
-      // Check if it's an HTML error page or "Not found"
-      if (result.includes("<!DOCTYPE") || result.includes("<html")) {
-        throw new Error(
-          `Failed to fetch supplier part numbers: Received HTML response instead of JSON. Response starts with: ${result.substring(0, 100)}`,
-        )
-      }
-      if (result === "Not found") {
-        throw new Error(
-          `Part not found for ${this.getString()}${footprinterString ? ` with footprint "${footprinterString}"` : ""}`,
-        )
-      }
-      throw new Error(
-        `Invalid supplier part numbers format: Expected object but got string: "${result}"`,
+    const request = Promise.resolve()
+      .then(() =>
+        partsEngine.findPart({
+          sourceComponent,
+          footprinterString,
+        }),
       )
-    }
+      .then(async (partsEngineResult) => {
+        const result: unknown = partsEngineResult
+        if (typeof result === "string") {
+          if (result.includes("<!DOCTYPE") || result.includes("<html")) {
+            throw new Error(
+              `Failed to fetch supplier part numbers: Received HTML response instead of JSON. Response starts with: ${result.substring(0, 100)}`,
+            )
+          }
+          if (result === "Not found") {
+            throw new Error(
+              `Part not found for ${this.getString()}${footprinterString ? ` with footprint "${footprinterString}"` : ""}`,
+            )
+          }
+          throw new Error(
+            `Invalid supplier part numbers format: Expected object but got string: "${result}"`,
+          )
+        }
 
-    // Validate that result is an object (not array, null, etc.)
-    if (!result || Array.isArray(result) || typeof result !== "object") {
-      const actualType =
-        result === null
-          ? "null"
-          : Array.isArray(result)
-            ? "array"
-            : typeof result
-      throw new Error(
-        `Invalid supplier part numbers format: Expected object but got ${actualType}`,
-      )
-    }
+        if (!result || Array.isArray(result) || typeof result !== "object") {
+          const actualType =
+            result === null
+              ? "null"
+              : Array.isArray(result)
+                ? "array"
+                : typeof result
+          throw new Error(
+            `Invalid supplier part numbers format: Expected object but got ${actualType}`,
+          )
+        }
 
-    const supplierPartNumbers = result
-
-    if (cacheEngine) {
-      try {
-        await cacheEngine.setItem(cacheKey, JSON.stringify(supplierPartNumbers))
-      } catch {}
-    }
-    return supplierPartNumbers
+        const supplierPartNumbers = supplierProps.shape.supplierPartNumbers
+          .unwrap()
+          .parse(result)
+        if (cacheEngine) {
+          try {
+            await cacheEngine.setItem(
+              cacheKey,
+              JSON.stringify(supplierPartNumbers),
+            )
+          } catch {}
+        }
+        return supplierPartNumbers
+      })
+    requestsByCacheKey.set(cacheKey, request)
+    return request
   }
 
   doInitialPartsEngineRender(): void {
@@ -2114,6 +2173,14 @@ export class NormalComponent<
         })
         .catch((error: Error) => {
           this._asyncSupplierPartNumbers = {}
+          const cacheKey = this._getPartsEngineCacheKey(
+            source_component,
+            footprinterString,
+          )
+          if (hasReportedSupplierPartFailure(this.root!, cacheKey)) {
+            this._markDirty("PartsEngineRender")
+            return
+          }
           const warning = source_part_not_found_warning.parse({
             type: "source_part_not_found_warning",
             message: `Failed to fetch supplier part numbers for ${this.getString()}: ${error.message}`,

--- a/lib/components/normal-components/Connector.ts
+++ b/lib/components/normal-components/Connector.ts
@@ -1,28 +1,28 @@
 import { guessCableInsertCenter } from "@tscircuit/infer-cable-insertion-point"
 import {
-  connectorProps,
-  type ConnectorStandard,
   type ConnectorProps,
+  type ConnectorStandard,
   type PartsEngine,
   type SchematicPinStyle,
   type SchematicPortArrangement,
+  connectorProps,
 } from "@tscircuit/props"
 import type { AnyCircuitElement, SourceSimpleConnector } from "circuit-json"
 import { source_part_not_found_warning } from "circuit-json"
-import { createComponentsFromCircuitJson } from "lib/utils/createComponentsFromCircuitJson"
-import { convertCircuitJsonToUsbCStandardCircuitJson } from "lib/utils/connectors/convertCircuitJsonToUsbCStandardCircuitJson"
 import { convertCircuitJsonToJstStandardCircuitJson } from "lib/utils/connectors/convertCircuitJsonToJstStandardCircuitJson"
+import { convertCircuitJsonToUsbCStandardCircuitJson } from "lib/utils/connectors/convertCircuitJsonToUsbCStandardCircuitJson"
+import { extractCadModelFromCircuitJson } from "lib/utils/connectors/extractCadModelFromCircuitJson"
 import { STANDARD_USB_C_PIN_LABELS } from "lib/utils/connectors/usb-c-canonical-pin-definitions"
+import { createComponentsFromCircuitJson } from "lib/utils/createComponentsFromCircuitJson"
 import {
-  getAllDimensionsForSchematicBox,
   type SchematicBoxDimensions,
+  getAllDimensionsForSchematicBox,
 } from "lib/utils/schematic/getAllDimensionsForSchematicBox"
 import { getNumericSchPinStyle } from "lib/utils/schematic/getNumericSchPinStyle"
-import { extractCadModelFromCircuitJson } from "lib/utils/connectors/extractCadModelFromCircuitJson"
 import { symbols } from "schematic-symbols"
+import { Port } from "../primitive-components/Port"
 import { Chip } from "./Chip"
 import { insertInnerSymbolInSchematicBox } from "./Connector_insertInnerSymbolInSchematicBox"
-import { Port } from "../primitive-components/Port"
 
 const USB_C_SIGNAL_LABELS_IN_ORDER = [
   "VBUS1",
@@ -419,8 +419,9 @@ export class Connector<
     // the first await in this async effect synchronous phases complete and
     // source_component_id will be available for db updates.
     const sourceComponentForQuery = {
-      type: "source_component",
-      ftype: "simple_connector",
+      type: "source_component" as const,
+      source_component_id: `pending_source_component_${this.name}`,
+      ftype: "simple_connector" as const,
       name: this.name,
       manufacturer_part_number: props.manufacturerPartNumber ?? props.mfn,
       standard,

--- a/tests/components/normal-components/parts-engine-shared-request.test.tsx
+++ b/tests/components/normal-components/parts-engine-shared-request.test.tsx
@@ -2,29 +2,48 @@ import { expect, test } from "bun:test"
 import type { PartsEngine } from "@tscircuit/props"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test.failing(
-  "identical parts share one failed supplier lookup and warning",
-  async () => {
-    let findPartCallCount = 0
-    const partsEngine: PartsEngine = {
-      findPart: async () => {
-        findPartCallCount++
-        throw new Error("supplier service unavailable")
-      },
-    }
-    const { circuit } = getTestFixture()
+test("identical parts share one failed supplier lookup and warning", async () => {
+  let findPartCallCount = 0
+  const partsEngine: PartsEngine = {
+    findPart: async () => {
+      findPartCallCount++
+      throw new Error("supplier service unavailable")
+    },
+  }
+  const { circuit } = getTestFixture()
 
-    circuit.add(
-      <board width="20mm" height="12mm" partsEngine={partsEngine}>
-        <capacitor name="C1" capacitance="100nF" footprint="0402" />
-        <capacitor name="C2" capacitance="100nF" footprint="0402" />
-        <capacitor name="C3" capacitance="100nF" footprint="0402" />
-        <capacitor name="C4" capacitance="100nF" footprint="0402" />
-      </board>,
-    )
-    await circuit.renderUntilSettled()
+  circuit.add(
+    <board width="20mm" height="12mm" partsEngine={partsEngine}>
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <capacitor name="C2" capacitance="100nF" footprint="0402" />
+      <capacitor name="C3" capacitance="100nF" footprint="0402" />
+      <capacitor name="C4" capacitance="100nF" footprint="0402" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
 
-    expect(findPartCallCount).toBe(1)
-    expect(circuit.db.source_part_not_found_warning.list()).toHaveLength(1)
-  },
-)
+  expect(findPartCallCount).toBe(1)
+  expect(circuit.db.source_part_not_found_warning.list()).toHaveLength(1)
+})
+
+test("different component values keep separate supplier lookups", async () => {
+  let findPartCallCount = 0
+  const partsEngine: PartsEngine = {
+    findPart: async () => {
+      findPartCallCount++
+      throw new Error("supplier service unavailable")
+    },
+  }
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="12mm" partsEngine={partsEngine}>
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <capacitor name="C2" capacitance="1uF" footprint="0402" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  expect(findPartCallCount).toBe(2)
+  expect(circuit.db.source_part_not_found_warning.list()).toHaveLength(2)
+})


### PR DESCRIPTION
## Summary

- share one in-flight `findPart` request for components with the same part-selection properties
- exclude generated source IDs and reference designators from the request key while retaining electrical values, package, standard, and manufacturer data
- emit one network-failure warning per unique request within a circuit render
- keep different values, such as 100 nF and 1 µF capacitors, as separate supplier queries

## Stack

Depends on #3343, which records the real four-component failure without changing behavior.

## Behavior

Before this PR, four identical 100 nF 0402 capacitors caused four concurrent supplier requests and four copies of the same warning. They now share one promise and produce one warning. The cache is scoped to a circuit and parts-engine instance, so a later circuit can retry and unrelated engines do not share results.

The persistent `localCacheEngine` path remains intact for successful lookups across circuit renders.

## Validation

- focused shared-request regression: 2 passed
- existing parts-engine cache and error-handling regressions: 4 passed
- USB-C supplier Circuit JSON regression: passed
- `bunx tsc --noEmit`
- `bun run format`
- `git diff --check`
