### PR TITLE
test: reproduce silent impedance target

### DIFF
--- a/tests/components/primitive-components/differential-pair/unverified-impedance-warning.test.tsx
+++ b/tests/components/primitive-components/differential-pair/unverified-impedance-warning.test.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test.failing("warns that a USB impedance target is not signal-integrity verification", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="10mm">
+      <differentialpair
+        name="USB2"
+        positiveConnection="USB_DP"
+        negativeConnection="USB_DM"
+        targetDifferentialImpedance="90ohm"
+        pcbTraceGap="0.15mm"
+      />
+      <resistor name="R1" resistance="22" footprint="0402" />
+      <resistor name="R2" resistance="22" footprint="0402" />
+      <chip name="U1" footprint="soic8" />
+      <trace name="USB_DP" from=".U1 > .pin1" to=".R1 > .pin1" />
+      <trace name="USB_DM" from=".U1 > .pin2" to=".R2 > .pin1" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  const warnings = circuit.db.source_property_ignored_warning
+    .list()
+    .filter(
+      (warning) => warning.property_name === "targetDifferentialImpedance",
+    )
+  expect(warnings).toHaveLength(1)
+  expect(warnings[0]?.message).toContain(
+    "does not verify controlled impedance or signal integrity",
+  )
+})

--- a/tests/components/primitive-components/differential-pair/unverified-impedance-warning.test.tsx
+++ b/tests/components/primitive-components/differential-pair/unverified-impedance-warning.test.tsx
@@ -1,34 +1,37 @@
 import { expect, test } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test.failing("warns that a USB impedance target is not signal-integrity verification", async () => {
-  const { circuit } = getTestFixture()
+test.failing(
+  "warns that a USB impedance target is not signal-integrity verification",
+  async () => {
+    const { circuit } = getTestFixture()
 
-  circuit.add(
-    <board width="20mm" height="10mm">
-      <differentialpair
-        name="USB2"
-        positiveConnection="USB_DP"
-        negativeConnection="USB_DM"
-        targetDifferentialImpedance="90ohm"
-        pcbTraceGap="0.15mm"
-      />
-      <resistor name="R1" resistance="22" footprint="0402" />
-      <resistor name="R2" resistance="22" footprint="0402" />
-      <chip name="U1" footprint="soic8" />
-      <trace name="USB_DP" from=".U1 > .pin1" to=".R1 > .pin1" />
-      <trace name="USB_DM" from=".U1 > .pin2" to=".R2 > .pin1" />
-    </board>,
-  )
-  await circuit.renderUntilSettled()
-
-  const warnings = circuit.db.source_property_ignored_warning
-    .list()
-    .filter(
-      (warning) => warning.property_name === "targetDifferentialImpedance",
+    circuit.add(
+      <board width="20mm" height="10mm">
+        <differentialpair
+          name="USB2"
+          positiveConnection="USB_DP"
+          negativeConnection="USB_DM"
+          targetDifferentialImpedance="90ohm"
+          pcbTraceGap="0.15mm"
+        />
+        <resistor name="R1" resistance="22" footprint="0402" />
+        <resistor name="R2" resistance="22" footprint="0402" />
+        <chip name="U1" footprint="soic8" />
+        <trace name="USB_DP" from=".U1 > .pin1" to=".R1 > .pin1" />
+        <trace name="USB_DM" from=".U1 > .pin2" to=".R2 > .pin1" />
+      </board>,
     )
-  expect(warnings).toHaveLength(1)
-  expect(warnings[0]?.message).toContain(
-    "does not verify controlled impedance or signal integrity",
-  )
-})
+    await circuit.renderUntilSettled()
+
+    const warnings = circuit.db.source_property_ignored_warning
+      .list()
+      .filter(
+        (warning) => warning.property_name === "targetDifferentialImpedance",
+      )
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]?.message).toContain(
+      "does not verify controlled impedance or signal integrity",
+    )
+  },
+)


### PR DESCRIPTION
## Summary

- add a real USB 2.0-style differential pair with a 90 ohm target and explicit trace gap
- record the missing diagnostic with `test.failing`
- leave routing and DRC behavior unchanged

## Current behavior

`targetDifferentialImpedance="90ohm"` parses successfully, but core does not pass a board stackup to a field solver and does not verify the routed pair's impedance or broader signal integrity. The rendered circuit currently contains no warning, so a design can report zero geometric DRC errors while the impedance target remains electrically unverified.

The reproduction expects one explicit warning. It does not claim that geometry-only DRC can replace stackup selection, impedance calculation, or SI validation.

## Validation

- `bun test ./tests/components/primitive-components/differential-pair/unverified-impedance-warning.test.tsx --timeout 30000`
- current behavior reproduces zero matching warnings; Bun reports the `test.failing` case as passing
