### PR TITLE
Warn when differential impedance is unverified

### DIFF
--- a/lib/components/primitive-components/DifferentialPair_doInitialSourceDesignRuleChecks.ts
+++ b/lib/components/primitive-components/DifferentialPair_doInitialSourceDesignRuleChecks.ts
@@ -119,6 +119,28 @@ export const DifferentialPair_doInitialSourceDesignRuleChecks = (
     })
   }
 
+  const targetDifferentialImpedance =
+    differentialPair._parsedProps.targetDifferentialImpedance
+  if (targetDifferentialImpedance !== undefined) {
+    const positiveConnection = resolvePointToPointConnection(
+      differentialPair,
+      differentialPair._parsedProps.positiveConnection,
+    )
+    const warningSourceComponentId = positiveConnection?.sourcePorts.find(
+      (sourcePort) => sourcePort.source_component_id !== undefined,
+    )?.source_component_id
+    if (warningSourceComponentId) {
+      db.source_property_ignored_warning.insert({
+        source_component_id: warningSourceComponentId,
+        property_name: "targetDifferentialImpedance",
+        error_type: "source_property_ignored_warning",
+        message: `Differential pair "${differentialPair.name}" requests ${targetDifferentialImpedance} ohm differential impedance. This routing target does not verify controlled impedance or signal integrity; qualification still requires the fabricated stackup and field-solver or SI analysis.`,
+        subcircuit_id:
+          differentialPair.getSubcircuit().subcircuit_id ?? undefined,
+      })
+    }
+  }
+
   for (const connectionPolarity of ["positive", "negative"] as const) {
     let connectionSelector = differentialPair._parsedProps.negativeConnection
     if (connectionPolarity === "positive") {

--- a/tests/components/primitive-components/differential-pair/unverified-impedance-warning.test.tsx
+++ b/tests/components/primitive-components/differential-pair/unverified-impedance-warning.test.tsx
@@ -1,37 +1,34 @@
 import { expect, test } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test.failing(
-  "warns that a USB impedance target is not signal-integrity verification",
-  async () => {
-    const { circuit } = getTestFixture()
+test("warns that a USB impedance target is not signal-integrity verification", async () => {
+  const { circuit } = getTestFixture()
 
-    circuit.add(
-      <board width="20mm" height="10mm">
-        <differentialpair
-          name="USB2"
-          positiveConnection="USB_DP"
-          negativeConnection="USB_DM"
-          targetDifferentialImpedance="90ohm"
-          pcbTraceGap="0.15mm"
-        />
-        <resistor name="R1" resistance="22" footprint="0402" />
-        <resistor name="R2" resistance="22" footprint="0402" />
-        <chip name="U1" footprint="soic8" />
-        <trace name="USB_DP" from=".U1 > .pin1" to=".R1 > .pin1" />
-        <trace name="USB_DM" from=".U1 > .pin2" to=".R2 > .pin1" />
-      </board>,
-    )
-    await circuit.renderUntilSettled()
+  circuit.add(
+    <board width="20mm" height="10mm">
+      <differentialpair
+        name="USB2"
+        positiveConnection="USB_DP"
+        negativeConnection="USB_DM"
+        targetDifferentialImpedance="90ohm"
+        pcbTraceGap="0.15mm"
+      />
+      <resistor name="R1" resistance="22" footprint="0402" />
+      <resistor name="R2" resistance="22" footprint="0402" />
+      <chip name="U1" footprint="soic8" />
+      <trace name="USB_DP" from=".U1 > .pin1" to=".R1 > .pin1" />
+      <trace name="USB_DM" from=".U1 > .pin2" to=".R2 > .pin1" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
 
-    const warnings = circuit.db.source_property_ignored_warning
-      .list()
-      .filter(
-        (warning) => warning.property_name === "targetDifferentialImpedance",
-      )
-    expect(warnings).toHaveLength(1)
-    expect(warnings[0]?.message).toContain(
-      "does not verify controlled impedance or signal integrity",
+  const warnings = circuit.db.source_property_ignored_warning
+    .list()
+    .filter(
+      (warning) => warning.property_name === "targetDifferentialImpedance",
     )
-  },
-)
+  expect(warnings).toHaveLength(1)
+  expect(warnings[0]?.message).toContain(
+    "does not verify controlled impedance or signal integrity",
+  )
+})


### PR DESCRIPTION
## Summary

- emit an explicit `source_property_ignored_warning` when `targetDifferentialImpedance` is set
- identify the exact differential pair and requested impedance
- explain that geometry-only DRC cannot qualify controlled impedance or signal integrity without a fabrication stackup and field solver
- convert the real USB differential-pair reproduction from an expected failure into a regression test

## Stack

Depends on #3345.

## Validation

- focused differential-pair tests
- trace-name regression test
- DDR constraint regression tests
- TypeScript check
- formatting check