### PR TITLE
Reproduce unqualified OSM fine-pitch fabrication

### DIFF
--- a/tests/repros/repro-osm-land-array-needs-fabrication-review.test.tsx
+++ b/tests/repros/repro-osm-land-array-needs-fabrication-review.test.tsx
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test.failing(
+  "a 0.5 mm OSM-style land array warns that generic DRC is not fabrication qualification",
+  async () => {
+    const { circuit } = getTestFixture()
+
+    circuit.add(
+      <board width="20mm" height="20mm" routingDisabled>
+        <chip
+          name="U1"
+          manufacturerPartNumber="OSM-S-AM62L"
+          footprint="bga100_grid10x10_p0.5mm_pad0.25mm_circularpads"
+        />
+      </board>,
+    )
+
+    await circuit.renderUntilSettled()
+
+    expect(circuit.db.pcb_pad_pad_clearance_error.list()).toEqual([])
+
+    const fabricationProcessWarnings = circuit
+      .getCircuitJson()
+      .filter((element) =>
+        element.type.includes("pcb_fabrication_process_warning"),
+      )
+
+    expect(fabricationProcessWarnings).toHaveLength(1)
+  },
+)


### PR DESCRIPTION
## Reproduction

This is a real tscircuit board with an OSM-S-AM62L-style 10×10, 0.5 mm land array and 0.25 mm pads. The board has zero generic pad-clearance errors, but core emits no diagnostic that the escape process still needs fabrication-specific review.

The test expects one fabrication-process warning and is marked as an expected failure on `main`. This separates geometric DRC from JLCPCB process qualification.

This is intentionally a reproduction-only PR. The child PR pins the warning schema from circuit-json #715 and implements detection.

## Validation

- focused expected-failure board test
- TypeScript check
- formatter check
- diff check

## Reference

JLCPCB states that conventional mechanical-via escape reaches about 0.8 mm pitch and that denser arrays require laser microvias and/or via-in-pad: https://jlcpcb.com/blog/effective-escape-routing-strategies