### PR TITLE
Warn when fine-pitch land arrays need process review

### DIFF
--- a/lib/components/normal-components/Board_doInitialPcbPlacementDesignRuleChecks.ts
+++ b/lib/components/normal-components/Board_doInitialPcbPlacementDesignRuleChecks.ts
@@ -1,5 +1,6 @@
 import { runAllPlacementChecks } from "@tscircuit/checks"
 import type { AnyCircuitElement } from "circuit-json"
+import { insertFinePitchFabricationWarnings } from "lib/utils/insert-fine-pitch-fabrication-warnings"
 import type { Renderable } from "../base-components/Renderable"
 import type { Board } from "./Board"
 
@@ -55,6 +56,12 @@ export const Board_doInitialPcbPlacementDesignRuleChecks = (board: Board) => {
       )
 
       db.insertAll(newPlacementDiagnostics as AnyCircuitElement[])
+      if (board.pcb_board_id) {
+        insertFinePitchFabricationWarnings({
+          db,
+          pcbBoardId: board.pcb_board_id,
+        })
+      }
       board._pcbPlacementDrcErrorCount = placementCheckResults.filter(
         (result) => result.type.endsWith("_error"),
       ).length

--- a/lib/utils/insert-fine-pitch-fabrication-warnings.ts
+++ b/lib/utils/insert-fine-pitch-fabrication-warnings.ts
@@ -1,0 +1,147 @@
+import type { CircuitJsonUtilObjects } from "@tscircuit/circuit-json-util"
+import type { PcbSmtPad } from "circuit-json"
+
+const CONVENTIONAL_MECHANICAL_VIA_LAND_PITCH_MM = 0.8
+const MIN_GRID_AXIS_POSITION_COUNT = 4
+const MIN_GRID_OCCUPANCY_RATIO = 0.75
+const POSITION_TOLERANCE_MM = 1e-6
+const JLCPCB_FINE_PITCH_REFERENCE_URL =
+  "https://jlcpcb.com/blog/effective-escape-routing-strategies"
+
+interface PcbFabricationProcessWarningInsert {
+  warning_type: "pcb_fabrication_process_warning"
+  message: string
+  pcb_component_id: string
+  source_component_id?: string
+  pcb_board_id?: string
+  land_pitch: number
+  required_process: string
+  manufacturer: string
+  reference_url?: string
+  subcircuit_id?: string
+}
+
+type CircuitJsonUtilWithFabricationProcessWarning = CircuitJsonUtilObjects & {
+  pcb_fabrication_process_warning: {
+    insert: (warning: PcbFabricationProcessWarningInsert) => void
+  }
+}
+
+const getDistinctSortedPositions = (positions: number[]): number[] => {
+  const sortedPositions = [...positions].sort((a, b) => a - b)
+  const distinctPositions: number[] = []
+
+  for (const position of sortedPositions) {
+    const previousPosition = distinctPositions.at(-1)
+    if (
+      previousPosition === undefined ||
+      Math.abs(position - previousPosition) > POSITION_TOLERANCE_MM
+    ) {
+      distinctPositions.push(position)
+    }
+  }
+
+  return distinctPositions
+}
+
+const getMinimumPositionSpacing = (positions: number[]): number | null => {
+  const distinctPositions = getDistinctSortedPositions(positions)
+  if (distinctPositions.length < MIN_GRID_AXIS_POSITION_COUNT) return null
+
+  let minimumSpacing = Number.POSITIVE_INFINITY
+  for (let index = 1; index < distinctPositions.length; index++) {
+    minimumSpacing = Math.min(
+      minimumSpacing,
+      distinctPositions[index]! - distinctPositions[index - 1]!,
+    )
+  }
+
+  return minimumSpacing
+}
+
+export const getFinePitchLandArrayPitch = ({
+  pads,
+}: {
+  pads: PcbSmtPad[]
+}): number | null => {
+  const centeredPads = pads.filter(
+    (pad): pad is Exclude<PcbSmtPad, { shape: "polygon" }> =>
+      pad.shape !== "polygon",
+  )
+  const distinctXPositions = getDistinctSortedPositions(
+    centeredPads.map((pad) => pad.x),
+  )
+  const distinctYPositions = getDistinctSortedPositions(
+    centeredPads.map((pad) => pad.y),
+  )
+  const gridPositionCount =
+    distinctXPositions.length * distinctYPositions.length
+  const gridOccupancyRatio = centeredPads.length / gridPositionCount
+  if (gridOccupancyRatio < MIN_GRID_OCCUPANCY_RATIO) return null
+
+  const xPitch = getMinimumPositionSpacing(distinctXPositions)
+  const yPitch = getMinimumPositionSpacing(distinctYPositions)
+  if (xPitch === null || yPitch === null) return null
+
+  const landPitch = Math.max(xPitch, yPitch)
+  if (
+    landPitch + POSITION_TOLERANCE_MM >=
+    CONVENTIONAL_MECHANICAL_VIA_LAND_PITCH_MM
+  ) {
+    return null
+  }
+
+  return Math.round(landPitch / POSITION_TOLERANCE_MM) * POSITION_TOLERANCE_MM
+}
+
+export const insertFinePitchFabricationWarnings = ({
+  db,
+  pcbBoardId,
+}: {
+  db: CircuitJsonUtilObjects
+  pcbBoardId: string
+}): void => {
+  for (const pcbComponent of db.pcb_component.list()) {
+    const alreadyHasFabricationWarning = db
+      .toArray()
+      .some(
+        (element) =>
+          element.type.includes("pcb_fabrication_process_warning") &&
+          "pcb_component_id" in element &&
+          element.pcb_component_id === pcbComponent.pcb_component_id,
+      )
+    if (alreadyHasFabricationWarning) continue
+
+    const componentPads = db.pcb_smtpad
+      .list()
+      .filter((pad) => pad.pcb_component_id === pcbComponent.pcb_component_id)
+    const landPitch = getFinePitchLandArrayPitch({ pads: componentPads })
+    if (landPitch === null) continue
+
+    const sourceComponent = db.source_component.get(
+      pcbComponent.source_component_id,
+    )
+    const componentName = sourceComponent?.name ?? pcbComponent.pcb_component_id
+
+    const fabricationProcessWarning: PcbFabricationProcessWarningInsert = {
+      warning_type: "pcb_fabrication_process_warning",
+      message: `${componentName} uses a ${landPitch} mm two-dimensional land array. Generic geometry DRC does not qualify its fabrication process; JLCPCB documents laser microvias or via-in-pad for pitches below 0.8 mm.`,
+      pcb_component_id: pcbComponent.pcb_component_id,
+      source_component_id: pcbComponent.source_component_id,
+      pcb_board_id: pcbBoardId,
+      land_pitch: landPitch,
+      required_process: "laser_microvia_or_via_in_pad",
+      manufacturer: "jlcpcb",
+      reference_url: JLCPCB_FINE_PITCH_REFERENCE_URL,
+      subcircuit_id: pcbComponent.subcircuit_id,
+    }
+
+    // circuit-json #715 defines this collection. Keep the pinned consumer
+    // usable before its generated package declarations are released.
+    const fabricationWarningDb =
+      db as CircuitJsonUtilWithFabricationProcessWarning
+    fabricationWarningDb.pcb_fabrication_process_warning.insert(
+      fabricationProcessWarning,
+    )
+  }
+}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "bun-match-svg": "0.0.12",
     "calculate-elbow": "^0.0.12",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.469",
+    "circuit-json": "0.0.469",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-gltf": "^0.0.118",
     "circuit-json-to-connectivity-map": "^0.0.27",
@@ -131,6 +131,6 @@
   "overrides": {
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/props": "^0.0.624",
-    "circuit-json": "^0.0.469"
+    "circuit-json": "0.0.469"
   }
 }

--- a/tests/repros/repro-osm-land-array-needs-fabrication-review.test.tsx
+++ b/tests/repros/repro-osm-land-array-needs-fabrication-review.test.tsx
@@ -1,31 +1,43 @@
 import { expect, test } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test.failing(
-  "a 0.5 mm OSM-style land array warns that generic DRC is not fabrication qualification",
-  async () => {
-    const { circuit } = getTestFixture()
+test("a 0.5 mm OSM-style land array warns that generic DRC is not fabrication qualification", async () => {
+  const { circuit } = getTestFixture()
 
-    circuit.add(
-      <board width="20mm" height="20mm" routingDisabled>
-        <chip
-          name="U1"
-          manufacturerPartNumber="OSM-S-AM62L"
-          footprint="bga100_grid10x10_p0.5mm_pad0.25mm_circularpads"
-        />
-      </board>,
+  circuit.add(
+    <board width="32mm" height="20mm" routingDisabled>
+      <chip
+        name="U1"
+        manufacturerPartNumber="OSM-S-AM62L"
+        footprint="bga100_grid10x10_p0.5mm_pad0.25mm_circularpads"
+      />
+      <chip
+        name="U2"
+        pcbX={9}
+        footprint="bga36_grid6x6_p0.8mm_pad0.35mm_circularpads"
+      />
+      <chip
+        name="U3"
+        pcbX={-9}
+        footprint="qfn56_w7.8_h7.8_p0.4mm_pw0.23mm_pl0.8mm_thermalpad3.2x3.2"
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.pcb_pad_pad_clearance_error.list()).toEqual([])
+
+  const fabricationProcessWarnings = circuit
+    .getCircuitJson()
+    .filter((element) =>
+      element.type.includes("pcb_fabrication_process_warning"),
     )
 
-    await circuit.renderUntilSettled()
-
-    expect(circuit.db.pcb_pad_pad_clearance_error.list()).toEqual([])
-
-    const fabricationProcessWarnings = circuit
-      .getCircuitJson()
-      .filter((element) =>
-        element.type.includes("pcb_fabrication_process_warning"),
-      )
-
-    expect(fabricationProcessWarnings).toHaveLength(1)
-  },
-)
+  expect(fabricationProcessWarnings).toHaveLength(1)
+  expect(fabricationProcessWarnings[0]).toMatchObject({
+    land_pitch: 0.5,
+    required_process: "laser_microvia_or_via_in_pad",
+    manufacturer: "jlcpcb",
+  })
+})


### PR DESCRIPTION
## Summary

- pin the currently released `circuit-json` version exactly while circuit-json #715 adds the canonical schema
- detect dense two-dimensional land arrays below the documented conventional 0.8 mm mechanical-via escape pitch
- emit a fabrication-process warning with measured pitch, required JLCPCB process, and reference URL
- keep generic pad-clearance DRC distinct from fabrication qualification
- verify the real OSM-style board warns, while a 0.8 mm BGA and fine-pitch QFN do not

The structural collection adapter keeps this consumer buildable against the exact current release. Circuit-json #715 is additive schema typing and must merge before the adapter can be replaced by released generated declarations.

## Stack

Depends on core #3347 and circuit-json #715 (which depends on #714).

## Validation

- real-board OSM/BGA/QFN regression test
- adjacent placement-warning tests
- package build
- TypeScript check
- formatter check
- diff check

## Manufacturing reference

JLCPCB documents conventional 0.2 mm mechanical-via escape down to about 0.8 mm pitch; denser land arrays require laser microvias and/or via-in-pad: https://jlcpcb.com/blog/effective-escape-routing-strategies
