### PR TITLE
Reproduce winding QFP breakout routes in core

### DIFF
--- a/tests/breakout/breakout-qfp16-with-header-and-passives.test.tsx
+++ b/tests/breakout/breakout-qfp16-with-header-and-passives.test.tsx
@@ -2,7 +2,9 @@ import { expect, test } from "bun:test"
 import { createAutoroutingPhaseIoStack } from "tests/fixtures/create-autorouting-phase-io-stack"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
-test("breakout routes qfp16 controller pins to header and passives with auto breakout points", async () => {
+const failingTest = test.failing
+
+failingTest("QFP breakout points avoid winding routes", async () => {
   const { circuit } = getTestFixture()
   const autoroutingPhaseIoStack = createAutoroutingPhaseIoStack(circuit)
 
@@ -161,10 +163,10 @@ test("breakout routes qfp16 controller pins to header and passives with auto bre
   })
 
   expect(breakoutPcbGroup).toBeDefined()
-  expect(circuit.db.pcb_breakout_point.list().length).toBe(5)
+  expect(circuit.db.pcb_breakout_point.list()).toHaveLength(4)
   expect(autoroutingPhaseIoStack.length).toBeGreaterThanOrEqual(2)
   expect(circuit.db.pcb_trace.list().length).toBeGreaterThanOrEqual(6)
-  expect(circuit.db.pcb_via.list().length).toBeLessThanOrEqual(6)
+  expect(circuit.db.pcb_via.list()).toHaveLength(0)
   await expect(circuit).toMatchPcbSnapshot(import.meta.path)
   await expect(autoroutingPhaseIoStack).toMatchAutoroutingPhaseIoStackSnapshot(
     import.meta.path,


### PR DESCRIPTION
## Reproduction

The existing real QFP16 + header + passives board is now an explicit expected-failure test for the winding-aware result. On `main` it creates five automatic breakout points and uses vias to untangle the escape; the intended topology needs only the four boundary handoffs that actually cross the breakout and routes them with zero vias.

The fixture retains its full source-trace identity checks, PCB snapshot, autorouting phase snapshot, and zero-DRC assertions. Only the intended breakout-point count and via count are tightened, so the failure is isolated to the winding topology rather than a synthetic solver input.

This is intentionally a reproduction-only PR. The child PR remains #3280 and will be rebased onto this branch.

## Validation

- focused expected-failure real-board test
- TypeScript check
- formatter check
- diff check