### PR TITLE
fix: report connected source ports missing PCB mappings

### DIFF
--- a/lib/components/normal-components/Board_doInitialPcbPlacementDesignRuleChecks.ts
+++ b/lib/components/normal-components/Board_doInitialPcbPlacementDesignRuleChecks.ts
@@ -2,6 +2,7 @@ import { runAllPlacementChecks } from "@tscircuit/checks"
 import type { AnyCircuitElement } from "circuit-json"
 import type { Renderable } from "../base-components/Renderable"
 import type { Board } from "./Board"
+import { getPcbPortNotMatchedErrors } from "./board-get-pcb-port-not-matched-errors"
 
 const resetPcbTraceRenderInSubtree = (renderable: Renderable) => {
   if (renderable._pcbTraceRenderWaitingForPlacementChecks) {
@@ -41,9 +42,10 @@ export const Board_doInitialPcbPlacementDesignRuleChecks = (board: Board) => {
   board._pcbPlacementDrcChecksPending = true
   board._queueAsyncEffect("board:pre-route-placement-checks", async () => {
     try {
-      const placementCheckResults = await runAllPlacementChecks(
-        subcircuitCircuitJson,
-      )
+      const placementCheckResults = [
+        ...getPcbPortNotMatchedErrors(subcircuitCircuitJson),
+        ...(await runAllPlacementChecks(subcircuitCircuitJson)),
+      ]
       const newPlacementDiagnostics = placementCheckResults.filter(
         (result) =>
           !existingPlacementDiagnostics.some(

--- a/lib/components/normal-components/board-get-pcb-port-not-matched-errors.ts
+++ b/lib/components/normal-components/board-get-pcb-port-not-matched-errors.ts
@@ -1,0 +1,119 @@
+import type {
+  AnyCircuitElement,
+  PcbComponent,
+  PcbPort,
+  PcbPortNotMatchedError,
+  SourcePort,
+} from "circuit-json"
+
+type SourceComponent = Extract<AnyCircuitElement, { type: "source_component" }>
+type SourceComponentId = SourceComponent["source_component_id"]
+type SourcePortId = SourcePort["source_port_id"]
+
+export const getPcbPortNotMatchedErrors = (
+  circuitJson: AnyCircuitElement[],
+): PcbPortNotMatchedError[] => {
+  const connectedSourcePortIds = new Set<SourcePortId>()
+  const internalConnectionGroups: SourcePortId[][] = []
+  const sourceComponentsById = new Map<SourceComponentId, SourceComponent>()
+  const pcbComponentsBySourceComponentId = new Map<
+    SourceComponentId,
+    PcbComponent[]
+  >()
+  const pcbPorts: PcbPort[] = []
+  const sourceComponentIdsWithFootprintErrors = new Set<SourceComponentId>()
+
+  for (const element of circuitJson) {
+    if (element.type === "source_trace") {
+      for (const sourcePortId of element.connected_source_port_ids ?? []) {
+        connectedSourcePortIds.add(sourcePortId)
+      }
+    } else if (element.type === "source_component_internal_connection") {
+      internalConnectionGroups.push(element.source_port_ids)
+    } else if (element.type === "source_component") {
+      sourceComponentsById.set(element.source_component_id, element)
+      internalConnectionGroups.push(
+        ...(element.internally_connected_source_port_ids ?? []),
+      )
+    } else if (element.type === "pcb_component") {
+      if (!element.source_component_id) continue
+      const pcbComponents =
+        pcbComponentsBySourceComponentId.get(element.source_component_id) ?? []
+      pcbComponents.push(element)
+      pcbComponentsBySourceComponentId.set(
+        element.source_component_id,
+        pcbComponents,
+      )
+    } else if (element.type === "pcb_port") {
+      pcbPorts.push(element)
+    } else if (
+      element.type === "pcb_missing_footprint_error" ||
+      element.type === "external_footprint_load_error" ||
+      element.type === "circuit_json_footprint_load_error"
+    ) {
+      sourceComponentIdsWithFootprintErrors.add(element.source_component_id)
+    }
+  }
+
+  let foundNewConnectedPort = true
+  while (foundNewConnectedPort) {
+    foundNewConnectedPort = false
+    for (const group of internalConnectionGroups) {
+      if (
+        !group.some((sourcePortId) => connectedSourcePortIds.has(sourcePortId))
+      ) {
+        continue
+      }
+      for (const sourcePortId of group) {
+        if (connectedSourcePortIds.has(sourcePortId)) continue
+        connectedSourcePortIds.add(sourcePortId)
+        foundNewConnectedPort = true
+      }
+    }
+  }
+
+  const errors: PcbPortNotMatchedError[] = []
+  for (const element of circuitJson) {
+    if (
+      element.type !== "source_port" ||
+      !connectedSourcePortIds.has(element.source_port_id) ||
+      !element.source_component_id ||
+      sourceComponentIdsWithFootprintErrors.has(element.source_component_id)
+    ) {
+      continue
+    }
+
+    const pcbComponents = pcbComponentsBySourceComponentId.get(
+      element.source_component_id,
+    )
+    if (!pcbComponents?.length) continue
+
+    const ownerPcbComponentIds = new Set(
+      pcbComponents.map((component) => component.pcb_component_id),
+    )
+    const hasMatchingPcbPort = pcbPorts.some(
+      (pcbPort) =>
+        pcbPort.source_port_id === element.source_port_id &&
+        pcbPort.pcb_component_id !== undefined &&
+        ownerPcbComponentIds.has(pcbPort.pcb_component_id),
+    )
+    if (hasMatchingPcbPort) continue
+
+    const sourceComponent = sourceComponentsById.get(
+      element.source_component_id,
+    )
+    errors.push({
+      type: "pcb_port_not_matched_error",
+      pcb_error_id: `pcb_port_not_matched_${element.source_port_id}`,
+      error_type: "pcb_port_not_matched_error",
+      message: `Source port ${sourceComponent?.name ?? "unnamed component"}.${element.name} is connected but does not have a matching PCB port.`,
+      pcb_component_ids: pcbComponents.map(
+        (component) => component.pcb_component_id,
+      ),
+      subcircuit_id:
+        element.subcircuit_id ?? pcbComponents[0]?.subcircuit_id ?? undefined,
+    })
+  }
+
+  return errors
+}

--- a/tests/components/normal-components/board-pcb-port-not-matched-errors.test.ts
+++ b/tests/components/normal-components/board-pcb-port-not-matched-errors.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getPcbPortNotMatchedErrors } from "lib/components/normal-components/board-get-pcb-port-not-matched-errors"
+
+const createCircuitJson = (): AnyCircuitElement[] => [
+  {
+    type: "source_component",
+    source_component_id: "source_component_1",
+    ftype: "simple_chip",
+    name: "U1",
+    supplier_part_numbers: {},
+  },
+  {
+    type: "source_port",
+    source_port_id: "source_port_1",
+    source_component_id: "source_component_1",
+    name: "EP",
+    pin_number: 9,
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: "pcb_component_1",
+    source_component_id: "source_component_1",
+    center: { x: 0, y: 0 },
+    width: 2,
+    height: 2,
+    layer: "top",
+    rotation: 0,
+    obstructs_within_bounds: false,
+  },
+]
+
+test("missing PCB ports are reported only for connected, successfully footprinted source ports", () => {
+  const unconnectedCircuitJson = createCircuitJson()
+  expect(getPcbPortNotMatchedErrors(unconnectedCircuitJson)).toEqual([])
+
+  const connectedCircuitJson = createCircuitJson()
+  connectedCircuitJson.push({
+    type: "source_trace",
+    source_trace_id: "source_trace_1",
+    connected_source_port_ids: ["source_port_1"],
+    connected_source_net_ids: ["source_net_1"],
+  })
+  expect(getPcbPortNotMatchedErrors(connectedCircuitJson)).toHaveLength(1)
+
+  connectedCircuitJson.push({
+    type: "pcb_missing_footprint_error",
+    pcb_missing_footprint_error_id: "pcb_missing_footprint_error_1",
+    error_type: "pcb_missing_footprint_error",
+    message: "No footprint specified for U1.",
+    source_component_id: "source_component_1",
+  })
+  expect(getPcbPortNotMatchedErrors(connectedCircuitJson)).toEqual([])
+})

--- a/tests/repros/repro-mangopi-imported-thermal-pad-alias-overridden.test.tsx
+++ b/tests/repros/repro-mangopi-imported-thermal-pad-alias-overridden.test.tsx
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test"
+import type { ChipProps } from "@tscircuit/props"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const createImportedPinLabels = (pinCount: number) =>
+  Object.fromEntries(
+    Array.from({ length: pinCount }, (_, index) => {
+      const pinNumber = index + 1
+      return [`pin${pinNumber}`, [`pin${pinNumber}`]]
+    }),
+  )
+
+const createBoardPinLabels = (pinCount: number) =>
+  Object.fromEntries(
+    Array.from({ length: pinCount }, (_, index) => {
+      const pinNumber = index + 1
+      return [`pin${pinNumber}`, [`P${pinNumber}`, `pin${pinNumber}`]]
+    }),
+  )
+
+const f1c200sPinLabels = {
+  ...createImportedPinLabels(89),
+  pin89: ["pin89", "thermalpad"],
+}
+
+const gd5f1gq5ueyigrPinLabels = {
+  ...createImportedPinLabels(9),
+  pin9: ["EP", "thermalpad"],
+}
+
+const F1C200S = (props: ChipProps) => (
+  <chip
+    pinLabels={f1c200sPinLabels}
+    footprint="qfn88_thermalpad6.75mmx6.75mm_p0.4mm_h11mm_pw0.2mm_pl0.8mm_pin1location(bottomside,left)"
+    {...props}
+  />
+)
+
+const GD5F1GQ5UEYIGR = (props: ChipProps) => (
+  <chip
+    pinLabels={gd5f1gq5ueyigrPinLabels}
+    footprint="dfn8_thermalpad3.4mmx4.3mm_w8.7998mm"
+    {...props}
+  />
+)
+
+test("MangoPi-style imported thermal pads overridden by board labels are diagnosed before autorouting", async () => {
+  const { circuit } = getTestFixture()
+  let autoroutingStartCount = 0
+
+  circuit.on("autorouting:start", () => {
+    autoroutingStartCount++
+  })
+
+  circuit.add(
+    <board
+      width="30mm"
+      height="20mm"
+      autorouter={{ local: true, groupMode: "subcircuit" }}
+    >
+      <F1C200S name="U1" pcbX={-7} pinLabels={createBoardPinLabels(89)} />
+      <GD5F1GQ5UEYIGR name="U3" pcbX={7} pinLabels={createBoardPinLabels(9)} />
+      <trace from=".U1 > .pin89" to=".U3 > .pin9" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_port.list()).toHaveLength(98)
+  expect(circuit.db.pcb_port.list()).toHaveLength(96)
+  expect(
+    circuit.db.pcb_port_not_matched_error
+      .list()
+      .map((error) => error.message)
+      .sort(),
+  ).toEqual([
+    "Source port U1.P89 is connected but does not have a matching PCB port.",
+    "Source port U3.P9 is connected but does not have a matching PCB port.",
+  ])
+  expect(autoroutingStartCount).toBe(0)
+  expect(circuit.db.pcb_trace.list()).toHaveLength(0)
+  expect(circuit.db.pcb_autorouting_error.list()).toHaveLength(1)
+})


### PR DESCRIPTION
## Summary

- validate that every connected, PCB-backed source port has an owner-matched PCB port after footprints and port matching have settled
- emit the canonical `pcb_port_not_matched_error` and feed it into Core's existing pre-routing placement-error gate
- follow internal pin connectivity while excluding unconnected/source-only ports and components with known footprint-load failures
- add a MangoPi-shaped regression for F1C200S pin 89 and GD5F1GQ5UEYIGR pin 9, plus a false-positive guard

## Root cause

The MangoPi imports provide `thermalpad` as a required physical alias, but their wrapper spreads caller props after the imported `pinLabels`. A board-level `pinLabels` override therefore erases that alias before Core receives the `<chip>`. The footprint exposes only `thermalpad`, so Core cannot authoritatively reconstruct pin 89 or pin 9 without guessing from footprint order.

Core's bug was that this final malformed state passed placement validation: `Port.doInitialPcbPortRender` produced no PCB port, and routing was allowed to continue. This change checks the completed Circuit JSON at `PcbPlacementDesignRuleChecks`, reports the exact source ports, and prevents autorouting. It deliberately does not re-enable implicit named-pad numbering, which would regress mechanical footprint hints.

The importer generator should separately merge caller labels with required imported physical aliases while both mappings are still available.

## Testing

- `bun test` focused/high-risk suite: 11 passed, 0 failed
- `bunx tsc --noEmit`
- `bunx biome format .`
- `bun run build`
- `bun run smoke-test:dist`
- `bunx @tscircuit/dependency-check`

Supersedes the Core-generated-Circuit-JSON portion of https://github.com/tscircuit/checks/pull/216.