### PR TITLE
chore(deps): bump @tscircuit/footprinter to ^0.0.424

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@tscircuit/copper-pour-solver": "^0.0.49",
     "@tscircuit/create-fdm-enclosure": "0.0.4",
     "@tscircuit/fanout-solver": "0.0.33",
-    "@tscircuit/footprinter": "^0.0.418",
+    "@tscircuit/footprinter": "^0.0.424",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/infer-cable-insertion-point": "^0.0.4",
     "@tscircuit/infgrid-ijump-astar": "^0.0.35",


### PR DESCRIPTION
#### MOTIVATION !!
I want to use jst2.5mm xh footprint for my jscad model
Bumps `@tscircuit/footprinter` to `^0.0.424` 