### PR TITLE
add RV1106G2 circuit json benchmark

### DIFF
--- a/benchmarking/all-benchmarks.tsx
+++ b/benchmarking/all-benchmarks.tsx
@@ -1,8 +1,10 @@
 import { Benchmark1LedMatrix } from "./benchmarks/benchmark1-led-matrix.tsx"
 import { Benchmark2Rp2040DecouplingCapacitors } from "./benchmarks/benchmark2-rp2040-decoupling-capacitors.tsx"
+import { Benchmark3Rv1106g2CircuitJson } from "./benchmarks/benchmark3-rv1106g2-circuit-json.tsx"
 
 export const BENCHMARKS = {
   "benchmark1-led-matrix": Benchmark1LedMatrix,
   "benchmark2-rp2040-decoupling-capacitors":
     Benchmark2Rp2040DecouplingCapacitors,
+  "benchmark3-rv1106g2-circuit-json": Benchmark3Rv1106g2CircuitJson,
 }

--- a/benchmarking/benchmarks/benchmark3-rv1106g2-circuit-json.test.tsx
+++ b/benchmarking/benchmarks/benchmark3-rv1106g2-circuit-json.test.tsx
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import { orderedRenderPhases } from "lib"
+import { runBenchmark } from "../benchmark-lib/run-benchmark"
+import { Benchmark3Rv1106g2CircuitJson } from "./benchmark3-rv1106g2-circuit-json"
+
+test("RV1106G2 Circuit JSON benchmark records render phase timings", async () => {
+  const phaseTimings = await runBenchmark({
+    Component: Benchmark3Rv1106g2CircuitJson,
+  })
+
+  expect(Object.keys(phaseTimings)).toHaveLength(orderedRenderPhases.length)
+  expect(phaseTimings.SchematicPortRender).toBeGreaterThan(0)
+})

--- a/benchmarking/benchmarks/benchmark3-rv1106g2-circuit-json.tsx
+++ b/benchmarking/benchmarks/benchmark3-rv1106g2-circuit-json.tsx
@@ -1,0 +1,18 @@
+import type { CircuitJson } from "circuit-json"
+import rv1106g2CircuitJson from "./benchmark3-rv1106g2-circuit.json"
+
+const compatibleCircuitJson = rv1106g2CircuitJson.map((element) => {
+  if (element.type !== "source_component") return element
+  if (
+    element.ftype !== "simple_crystal" &&
+    element.ftype !== "simple_pin_header"
+  ) {
+    return element
+  }
+
+  return { ...element, ftype: "simple_chip" as const }
+}) as CircuitJson
+
+export const Benchmark3Rv1106g2CircuitJson = () => (
+  <board circuitJson={compatibleCircuitJson} />
+)

--- a/benchmarking/benchmarks/benchmark3-rv1106g2-circuit.json
+++ b/benchmarking/benchmarks/benchmark3-rv1106g2-circuit.json
@@ -1,0 +1,37309 @@
+[
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_0",
+    "is_subcircuit": true,
+    "was_automatically_named": true,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_0",
+    "name": "EH2",
+    "pin_number": 1,
+    "port_hints": [
+      "EH2",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_1",
+    "name": "EH1",
+    "pin_number": 2,
+    "port_hints": [
+      "EH1",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_2",
+    "name": "EH4",
+    "pin_number": 3,
+    "port_hints": [
+      "EH4",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_3",
+    "name": "EH3",
+    "pin_number": 4,
+    "port_hints": [
+      "EH3",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_4",
+    "name": "B8",
+    "pin_number": 5,
+    "port_hints": [
+      "B8",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_connect": true
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_5",
+    "name": "A5",
+    "pin_number": 6,
+    "port_hints": [
+      "A5",
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_6",
+    "name": "B7",
+    "pin_number": 7,
+    "port_hints": [
+      "B7",
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_7",
+    "name": "A6",
+    "pin_number": 8,
+    "port_hints": [
+      "A6",
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_8",
+    "name": "A7",
+    "pin_number": 9,
+    "port_hints": [
+      "A7",
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_9",
+    "name": "B6",
+    "pin_number": 10,
+    "port_hints": [
+      "B6",
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_10",
+    "name": "A8",
+    "pin_number": 11,
+    "port_hints": [
+      "A8",
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_connect": true
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_11",
+    "name": "B5",
+    "pin_number": 12,
+    "port_hints": [
+      "B5",
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_12",
+    "name": "A1B12",
+    "pin_number": 13,
+    "port_hints": [
+      "A1B12",
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_13",
+    "name": "B1A12",
+    "pin_number": 14,
+    "port_hints": [
+      "B1A12",
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_14",
+    "name": "B4A9",
+    "pin_number": 15,
+    "port_hints": [
+      "B4A9",
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_15",
+    "name": "A4B9",
+    "pin_number": 16,
+    "port_hints": [
+      "A4B9",
+      "pin16",
+      "16"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_0",
+    "ftype": "simple_chip",
+    "name": "J1",
+    "manufacturer_part_number": "TYPE-C-31-M-12",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C165948"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_16",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_17",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_1",
+    "ftype": "simple_resistor",
+    "name": "R1",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C23186",
+        "C2907044",
+        "C105580"
+      ]
+    },
+    "resistance": 5100,
+    "display_resistance": "5.1kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_18",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_19",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_2",
+    "ftype": "simple_resistor",
+    "name": "R2",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C23186",
+        "C2907044",
+        "C105580"
+      ]
+    },
+    "resistance": 5100,
+    "display_resistance": "5.1kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_20",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_21",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_22",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_23",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_24",
+    "name": "pin5",
+    "pin_number": 5,
+    "port_hints": [
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_25",
+    "name": "pin6",
+    "pin_number": 6,
+    "port_hints": [
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_3",
+    "ftype": "simple_chip",
+    "name": "D1",
+    "manufacturer_part_number": "USBLC6_2SC6",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C7519"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_26",
+    "name": "VIN",
+    "pin_number": 1,
+    "port_hints": [
+      "VIN",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_27",
+    "name": "GND",
+    "pin_number": 2,
+    "port_hints": [
+      "GND",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_28",
+    "name": "EN",
+    "pin_number": 3,
+    "port_hints": [
+      "EN",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_29",
+    "name": "NC",
+    "pin_number": 4,
+    "port_hints": [
+      "NC",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_30",
+    "name": "VOUT",
+    "pin_number": 5,
+    "port_hints": [
+      "VOUT",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_4",
+    "ftype": "simple_chip",
+    "name": "U2",
+    "manufacturer_part_number": "AP2112K-3.3TRG1",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C51118"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_31",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_32",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_5",
+    "ftype": "simple_capacitor",
+    "name": "C1",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C19702",
+        "C96446",
+        "C1691"
+      ]
+    },
+    "capacitance": 0.00001,
+    "display_capacitance": "10uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_33",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_34",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_6",
+    "ftype": "simple_capacitor",
+    "name": "C2",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C19702",
+        "C96446",
+        "C1691"
+      ]
+    },
+    "capacitance": 0.00001,
+    "display_capacitance": "10uF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_35",
+    "name": "VIN",
+    "pin_number": 1,
+    "port_hints": [
+      "VIN",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_36",
+    "name": "GND",
+    "pin_number": 2,
+    "port_hints": [
+      "GND",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_37",
+    "name": "EN",
+    "pin_number": 3,
+    "port_hints": [
+      "EN",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_38",
+    "name": "VOUT_1V8",
+    "pin_number": 4,
+    "port_hints": [
+      "VOUT_1V8",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_39",
+    "name": "VOUT_0V9",
+    "pin_number": 5,
+    "port_hints": [
+      "VOUT_0V9",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_40",
+    "name": "VOUT_1V1",
+    "pin_number": 6,
+    "port_hints": [
+      "VOUT_1V1",
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_41",
+    "name": "FB",
+    "pin_number": 7,
+    "port_hints": [
+      "FB",
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_42",
+    "name": "PG",
+    "pin_number": 8,
+    "port_hints": [
+      "PG",
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_7",
+    "ftype": "simple_chip",
+    "name": "U3",
+    "supplier_part_numbers": {
+      "jlcpcb": []
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_43",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_44",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_45",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_46",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_47",
+    "name": "pin5",
+    "pin_number": 5,
+    "port_hints": [
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_48",
+    "name": "pin6",
+    "pin_number": 6,
+    "port_hints": [
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_49",
+    "name": "pin7",
+    "pin_number": 7,
+    "port_hints": [
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_50",
+    "name": "pin8",
+    "pin_number": 8,
+    "port_hints": [
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_51",
+    "name": "pin9",
+    "pin_number": 9,
+    "port_hints": [
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_52",
+    "name": "DVDD_1",
+    "pin_number": 10,
+    "port_hints": [
+      "DVDD_1",
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_53",
+    "name": "pin11",
+    "pin_number": 11,
+    "port_hints": [
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_54",
+    "name": "pin12",
+    "pin_number": 12,
+    "port_hints": [
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_55",
+    "name": "GPIO4_VCC",
+    "pin_number": 13,
+    "port_hints": [
+      "GPIO4_VCC",
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_56",
+    "name": "pin14",
+    "pin_number": 14,
+    "port_hints": [
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_57",
+    "name": "pin15",
+    "pin_number": 15,
+    "port_hints": [
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_58",
+    "name": "pin16",
+    "pin_number": 16,
+    "port_hints": [
+      "pin16",
+      "16"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_59",
+    "name": "pin17",
+    "pin_number": 17,
+    "port_hints": [
+      "pin17",
+      "17"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_60",
+    "name": "pin18",
+    "pin_number": 18,
+    "port_hints": [
+      "pin18",
+      "18"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_61",
+    "name": "RTC_AVDD3V3",
+    "pin_number": 19,
+    "port_hints": [
+      "RTC_AVDD3V3",
+      "pin19",
+      "19"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_62",
+    "name": "RTC_XOUT",
+    "pin_number": 20,
+    "port_hints": [
+      "RTC_XOUT",
+      "pin20",
+      "20"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_63",
+    "name": "RTC_XIN",
+    "pin_number": 21,
+    "port_hints": [
+      "RTC_XIN",
+      "pin21",
+      "21"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_64",
+    "name": "pin22",
+    "pin_number": 22,
+    "port_hints": [
+      "pin22",
+      "22"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_65",
+    "name": "pin23",
+    "pin_number": 23,
+    "port_hints": [
+      "pin23",
+      "23"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_66",
+    "name": "SARADC_USB_AVDD1V8",
+    "pin_number": 24,
+    "port_hints": [
+      "SARADC_USB_AVDD1V8",
+      "pin24",
+      "24"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_67",
+    "name": "USB_VBUSDET",
+    "pin_number": 25,
+    "port_hints": [
+      "USB_VBUSDET",
+      "pin25",
+      "25"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_68",
+    "name": "USB_DM",
+    "pin_number": 26,
+    "port_hints": [
+      "USB_DM",
+      "pin26",
+      "26"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_69",
+    "name": "USB_DP",
+    "pin_number": 27,
+    "port_hints": [
+      "USB_DP",
+      "pin27",
+      "27"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_70",
+    "name": "USB_AVDD3V3",
+    "pin_number": 28,
+    "port_hints": [
+      "USB_AVDD3V3",
+      "pin28",
+      "28"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_71",
+    "name": "CODEC_LINEOUT",
+    "pin_number": 29,
+    "port_hints": [
+      "CODEC_LINEOUT",
+      "pin29",
+      "29"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_72",
+    "name": "CODEC_VCM",
+    "pin_number": 30,
+    "port_hints": [
+      "CODEC_VCM",
+      "pin30",
+      "30"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_73",
+    "name": "CODEC_AVDD1V8",
+    "pin_number": 31,
+    "port_hints": [
+      "CODEC_AVDD1V8",
+      "pin31",
+      "31"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_74",
+    "name": "CODEC_MICBIAS",
+    "pin_number": 32,
+    "port_hints": [
+      "CODEC_MICBIAS",
+      "pin32",
+      "32"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_75",
+    "name": "CODEC_MIC0N",
+    "pin_number": 33,
+    "port_hints": [
+      "CODEC_MIC0N",
+      "pin33",
+      "33"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_76",
+    "name": "CODEC_MIC0P",
+    "pin_number": 34,
+    "port_hints": [
+      "CODEC_MIC0P",
+      "pin34",
+      "34"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_77",
+    "name": "CODEC_MIC1N",
+    "pin_number": 35,
+    "port_hints": [
+      "CODEC_MIC1N",
+      "pin35",
+      "35"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_78",
+    "name": "CODEC_MIC1P",
+    "pin_number": 36,
+    "port_hints": [
+      "CODEC_MIC1P",
+      "pin36",
+      "36"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_79",
+    "name": "CODEC_AVSS",
+    "pin_number": 37,
+    "port_hints": [
+      "CODEC_AVSS",
+      "pin37",
+      "37"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_80",
+    "name": "pin38",
+    "pin_number": 38,
+    "port_hints": [
+      "pin38",
+      "38"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_81",
+    "name": "pin39",
+    "pin_number": 39,
+    "port_hints": [
+      "pin39",
+      "39"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_82",
+    "name": "pin40",
+    "pin_number": 40,
+    "port_hints": [
+      "pin40",
+      "40"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_83",
+    "name": "pin41",
+    "pin_number": 41,
+    "port_hints": [
+      "pin41",
+      "41"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_84",
+    "name": "pin42",
+    "pin_number": 42,
+    "port_hints": [
+      "pin42",
+      "42"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_85",
+    "name": "GPIO3_VCC",
+    "pin_number": 43,
+    "port_hints": [
+      "GPIO3_VCC",
+      "pin43",
+      "43"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_86",
+    "name": "pin44",
+    "pin_number": 44,
+    "port_hints": [
+      "pin44",
+      "44"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_87",
+    "name": "pin45",
+    "pin_number": 45,
+    "port_hints": [
+      "pin45",
+      "45"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_88",
+    "name": "pin46",
+    "pin_number": 46,
+    "port_hints": [
+      "pin46",
+      "46"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_89",
+    "name": "pin47",
+    "pin_number": 47,
+    "port_hints": [
+      "pin47",
+      "47"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_90",
+    "name": "pin48",
+    "pin_number": 48,
+    "port_hints": [
+      "pin48",
+      "48"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_91",
+    "name": "DDR_VDDQ_1",
+    "pin_number": 49,
+    "port_hints": [
+      "DDR_VDDQ_1",
+      "pin49",
+      "49"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_92",
+    "name": "DDR_VDDQ_2",
+    "pin_number": 50,
+    "port_hints": [
+      "DDR_VDDQ_2",
+      "pin50",
+      "50"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_93",
+    "name": "DVDD_2D",
+    "pin_number": 51,
+    "port_hints": [
+      "DVDD_2D",
+      "pin51",
+      "51"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_94",
+    "name": "RAM_ZQ",
+    "pin_number": 52,
+    "port_hints": [
+      "RAM_ZQ",
+      "pin52",
+      "52"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_95",
+    "name": "DDR_PLL_AVDD1V8",
+    "pin_number": 53,
+    "port_hints": [
+      "DDR_PLL_AVDD1V8",
+      "pin53",
+      "53"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_96",
+    "name": "DVDD_3",
+    "pin_number": 54,
+    "port_hints": [
+      "DVDD_3",
+      "pin54",
+      "54"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_97",
+    "name": "DVDD_4",
+    "pin_number": 55,
+    "port_hints": [
+      "DVDD_4",
+      "pin55",
+      "55"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_98",
+    "name": "DDR_VDDQ_3",
+    "pin_number": 56,
+    "port_hints": [
+      "DDR_VDDQ_3",
+      "pin56",
+      "56"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_99",
+    "name": "TVSS",
+    "pin_number": 57,
+    "port_hints": [
+      "TVSS",
+      "pin57",
+      "57"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_100",
+    "name": "pin58",
+    "pin_number": 58,
+    "port_hints": [
+      "pin58",
+      "58"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_101",
+    "name": "pin59",
+    "pin_number": 59,
+    "port_hints": [
+      "pin59",
+      "59"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_102",
+    "name": "pin60",
+    "pin_number": 60,
+    "port_hints": [
+      "pin60",
+      "60"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_103",
+    "name": "PMU_VCC3V3",
+    "pin_number": 61,
+    "port_hints": [
+      "PMU_VCC3V3",
+      "pin61",
+      "61"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_104",
+    "name": "pin62",
+    "pin_number": 62,
+    "port_hints": [
+      "pin62",
+      "62"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_105",
+    "name": "pin63",
+    "pin_number": 63,
+    "port_hints": [
+      "pin63",
+      "63"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_106",
+    "name": "pin64",
+    "pin_number": 64,
+    "port_hints": [
+      "pin64",
+      "64"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_107",
+    "name": "pin65",
+    "pin_number": 65,
+    "port_hints": [
+      "pin65",
+      "65"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_108",
+    "name": "POR",
+    "pin_number": 66,
+    "port_hints": [
+      "POR",
+      "pin66",
+      "66"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_109",
+    "name": "PMU_DVDD0V9",
+    "pin_number": 67,
+    "port_hints": [
+      "PMU_DVDD0V9",
+      "pin67",
+      "67"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_110",
+    "name": "OSC_XIN",
+    "pin_number": 68,
+    "port_hints": [
+      "OSC_XIN",
+      "pin68",
+      "68"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net14"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_111",
+    "name": "OSC_XOUT",
+    "pin_number": 69,
+    "port_hints": [
+      "OSC_XOUT",
+      "pin69",
+      "69"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_112",
+    "name": "pin70",
+    "pin_number": 70,
+    "port_hints": [
+      "pin70",
+      "70"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_113",
+    "name": "OSC_PLL_DVDD",
+    "pin_number": 71,
+    "port_hints": [
+      "OSC_PLL_DVDD",
+      "pin71",
+      "71"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_114",
+    "name": "pin72",
+    "pin_number": 72,
+    "port_hints": [
+      "pin72",
+      "72"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_115",
+    "name": "pin73",
+    "pin_number": 73,
+    "port_hints": [
+      "pin73",
+      "73"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_116",
+    "name": "pin74",
+    "pin_number": 74,
+    "port_hints": [
+      "pin74",
+      "74"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_117",
+    "name": "pin75",
+    "pin_number": 75,
+    "port_hints": [
+      "pin75",
+      "75"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_118",
+    "name": "pin76",
+    "pin_number": 76,
+    "port_hints": [
+      "pin76",
+      "76"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_119",
+    "name": "pin77",
+    "pin_number": 77,
+    "port_hints": [
+      "pin77",
+      "77"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_120",
+    "name": "pin78",
+    "pin_number": 78,
+    "port_hints": [
+      "pin78",
+      "78"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_121",
+    "name": "pin79",
+    "pin_number": 79,
+    "port_hints": [
+      "pin79",
+      "79"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_122",
+    "name": "pin80",
+    "pin_number": 80,
+    "port_hints": [
+      "pin80",
+      "80"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_123",
+    "name": "GPIO1_VCC3V3",
+    "pin_number": 81,
+    "port_hints": [
+      "GPIO1_VCC3V3",
+      "pin81",
+      "81"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_124",
+    "name": "DVDD_5",
+    "pin_number": 82,
+    "port_hints": [
+      "DVDD_5",
+      "pin82",
+      "82"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_125",
+    "name": "pin83",
+    "pin_number": 83,
+    "port_hints": [
+      "pin83",
+      "83"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_126",
+    "name": "pin84",
+    "pin_number": 84,
+    "port_hints": [
+      "pin84",
+      "84"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_127",
+    "name": "pin85",
+    "pin_number": 85,
+    "port_hints": [
+      "pin85",
+      "85"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_128",
+    "name": "pin86",
+    "pin_number": 86,
+    "port_hints": [
+      "pin86",
+      "86"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_129",
+    "name": "pin87",
+    "pin_number": 87,
+    "port_hints": [
+      "pin87",
+      "87"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_130",
+    "name": "GPIO6_VCC",
+    "pin_number": 88,
+    "port_hints": [
+      "GPIO6_VCC",
+      "pin88",
+      "88"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_131",
+    "name": "pin89",
+    "pin_number": 89,
+    "port_hints": [
+      "pin89",
+      "89"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_132",
+    "name": "pin90",
+    "pin_number": 90,
+    "port_hints": [
+      "pin90",
+      "90"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_133",
+    "name": "pin91",
+    "pin_number": 91,
+    "port_hints": [
+      "pin91",
+      "91"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_134",
+    "name": "pin92",
+    "pin_number": 92,
+    "port_hints": [
+      "pin92",
+      "92"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_135",
+    "name": "pin93",
+    "pin_number": 93,
+    "port_hints": [
+      "pin93",
+      "93"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_136",
+    "name": "pin94",
+    "pin_number": 94,
+    "port_hints": [
+      "pin94",
+      "94"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_137",
+    "name": "pin95",
+    "pin_number": 95,
+    "port_hints": [
+      "pin95",
+      "95"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_138",
+    "name": "pin96",
+    "pin_number": 96,
+    "port_hints": [
+      "pin96",
+      "96"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_139",
+    "name": "ETH_PHY_RXN",
+    "pin_number": 97,
+    "port_hints": [
+      "ETH_PHY_RXN",
+      "pin97",
+      "97"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_140",
+    "name": "ETH_PHY_RXP",
+    "pin_number": 98,
+    "port_hints": [
+      "ETH_PHY_RXP",
+      "pin98",
+      "98"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_141",
+    "name": "ETH_PHY_TXN",
+    "pin_number": 99,
+    "port_hints": [
+      "ETH_PHY_TXN",
+      "pin99",
+      "99"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_142",
+    "name": "ETH_PHY_TXP",
+    "pin_number": 100,
+    "port_hints": [
+      "ETH_PHY_TXP",
+      "pin100",
+      "100"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_143",
+    "name": "ETH_AVDD3V3",
+    "pin_number": 101,
+    "port_hints": [
+      "ETH_AVDD3V3",
+      "pin101",
+      "101"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_144",
+    "name": "ETH_EXTR",
+    "pin_number": 102,
+    "port_hints": [
+      "ETH_EXTR",
+      "pin102",
+      "102"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_145",
+    "name": "DVDD_6",
+    "pin_number": 103,
+    "port_hints": [
+      "DVDD_6",
+      "pin103",
+      "103"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_146",
+    "name": "pin104",
+    "pin_number": 104,
+    "port_hints": [
+      "pin104",
+      "104"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_147",
+    "name": "pin105",
+    "pin_number": 105,
+    "port_hints": [
+      "pin105",
+      "105"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_148",
+    "name": "pin106",
+    "pin_number": 106,
+    "port_hints": [
+      "pin106",
+      "106"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_149",
+    "name": "pin107",
+    "pin_number": 107,
+    "port_hints": [
+      "pin107",
+      "107"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_150",
+    "name": "GPIO5_VCC",
+    "pin_number": 108,
+    "port_hints": [
+      "GPIO5_VCC",
+      "pin108",
+      "108"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_151",
+    "name": "pin109",
+    "pin_number": 109,
+    "port_hints": [
+      "pin109",
+      "109"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_152",
+    "name": "pin110",
+    "pin_number": 110,
+    "port_hints": [
+      "pin110",
+      "110"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_153",
+    "name": "pin111",
+    "pin_number": 111,
+    "port_hints": [
+      "pin111",
+      "111"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_154",
+    "name": "pin112",
+    "pin_number": 112,
+    "port_hints": [
+      "pin112",
+      "112"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_155",
+    "name": "pin113",
+    "pin_number": 113,
+    "port_hints": [
+      "pin113",
+      "113"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_156",
+    "name": "pin114",
+    "pin_number": 114,
+    "port_hints": [
+      "pin114",
+      "114"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_157",
+    "name": "CPU_DVDD",
+    "pin_number": 115,
+    "port_hints": [
+      "CPU_DVDD",
+      "pin115",
+      "115"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_158",
+    "name": "DVDD_7",
+    "pin_number": 116,
+    "port_hints": [
+      "DVDD_7",
+      "pin116",
+      "116"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_159",
+    "name": "pin117",
+    "pin_number": 117,
+    "port_hints": [
+      "pin117",
+      "117"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_160",
+    "name": "pin118",
+    "pin_number": 118,
+    "port_hints": [
+      "pin118",
+      "118"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_161",
+    "name": "pin119",
+    "pin_number": 119,
+    "port_hints": [
+      "pin119",
+      "119"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_162",
+    "name": "pin120",
+    "pin_number": 120,
+    "port_hints": [
+      "pin120",
+      "120"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_163",
+    "name": "pin121",
+    "pin_number": 121,
+    "port_hints": [
+      "pin121",
+      "121"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net22"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_164",
+    "name": "pin122",
+    "pin_number": 122,
+    "port_hints": [
+      "pin122",
+      "122"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_165",
+    "name": "pin123",
+    "pin_number": 123,
+    "port_hints": [
+      "pin123",
+      "123"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_166",
+    "name": "pin124",
+    "pin_number": 124,
+    "port_hints": [
+      "pin124",
+      "124"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_167",
+    "name": "pin125",
+    "pin_number": 125,
+    "port_hints": [
+      "pin125",
+      "125"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net24"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_168",
+    "name": "pin126",
+    "pin_number": 126,
+    "port_hints": [
+      "pin126",
+      "126"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_169",
+    "name": "pin127",
+    "pin_number": 127,
+    "port_hints": [
+      "pin127",
+      "127"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_170",
+    "name": "pin128",
+    "pin_number": 128,
+    "port_hints": [
+      "pin128",
+      "128"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_171",
+    "name": "VSS",
+    "pin_number": 129,
+    "port_hints": [
+      "VSS",
+      "pin129",
+      "129"
+    ],
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_8",
+    "ftype": "simple_chip",
+    "name": "U1",
+    "manufacturer_part_number": "RV1106G2",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C5272606"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_172",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "left",
+      "X1",
+      "1"
+    ],
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net14"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_173",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "right",
+      "X2",
+      "2"
+    ],
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_9",
+    "name": "Y1",
+    "ftype": "simple_crystal",
+    "supplier_part_numbers": {
+      "jlcpcb": []
+    },
+    "frequency": 24000000,
+    "load_capacitance": 1.2e-11,
+    "pin_variant": "two_pin",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_174",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net14"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_175",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_10",
+    "ftype": "simple_capacitor",
+    "name": "C3",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C1547",
+        "C76948",
+        "C696888"
+      ]
+    },
+    "capacitance": 1.2e-11,
+    "display_capacitance": "12pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_176",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_177",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_11",
+    "ftype": "simple_capacitor",
+    "name": "C4",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C1547",
+        "C76948",
+        "C696888"
+      ]
+    },
+    "capacitance": 1.2e-11,
+    "display_capacitance": "12pF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_178",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_179",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_12",
+    "ftype": "simple_resistor",
+    "name": "R3",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25804",
+        "C2906982",
+        "C98220"
+      ]
+    },
+    "resistance": 10000,
+    "display_resistance": "10kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_180",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_181",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_182",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_183",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_13",
+    "ftype": "simple_chip",
+    "name": "SW1",
+    "manufacturer_part_number": "HX_3x4x2_5_PA_4N_push_button_switch",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C55200589"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_184",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_185",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_186",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_187",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_14",
+    "ftype": "simple_chip",
+    "name": "SW2",
+    "manufacturer_part_number": "HX_3x4x2_5_PA_4N_push_button_switch",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C55200589"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_188",
+    "name": "CS",
+    "pin_number": 1,
+    "port_hints": [
+      "CS",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "supports_spi_cs": true,
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_189",
+    "name": "DO",
+    "pin_number": 2,
+    "port_hints": [
+      "DO",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "supports_spi_miso": true,
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net18"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_190",
+    "name": "IO2",
+    "pin_number": 3,
+    "port_hints": [
+      "IO2",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_191",
+    "name": "GND",
+    "pin_number": 4,
+    "port_hints": [
+      "GND",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "must_be_connected": true,
+    "requires_ground": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_192",
+    "name": "DI",
+    "pin_number": 5,
+    "port_hints": [
+      "DI",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "supports_spi_mosi": true,
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_193",
+    "name": "CLK",
+    "pin_number": 6,
+    "port_hints": [
+      "CLK",
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "supports_spi_sck": true,
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_194",
+    "name": "IO3",
+    "pin_number": 7,
+    "port_hints": [
+      "IO3",
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "must_be_connected": true,
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_195",
+    "name": "VCC",
+    "pin_number": 8,
+    "port_hints": [
+      "VCC",
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "must_be_connected": true,
+    "requires_power": true,
+    "requires_voltage": "3.3V",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_15",
+    "ftype": "simple_chip",
+    "name": "U4",
+    "manufacturer_part_number": "W25Q128JVSIQ",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C97521"
+      ]
+    },
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_196",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "1",
+      "left"
+    ],
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_197",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "2",
+      "right"
+    ],
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_16",
+    "ftype": "simple_capacitor",
+    "name": "C5",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C1525",
+        "C307331",
+        "C60474"
+      ]
+    },
+    "capacitance": 1e-7,
+    "display_capacitance": "100nF",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_198",
+    "name": "GND",
+    "pin_number": 1,
+    "port_hints": [
+      "GND",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_199",
+    "name": "3V3",
+    "pin_number": 2,
+    "port_hints": [
+      "3V3",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_200",
+    "name": "GPIO0_P125",
+    "pin_number": 3,
+    "port_hints": [
+      "GPIO0_P125",
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net24"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_201",
+    "name": "GPIO1_P126",
+    "pin_number": 4,
+    "port_hints": [
+      "GPIO1_P126",
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_202",
+    "name": "I2C_SDA_P65",
+    "pin_number": 5,
+    "port_hints": [
+      "I2C_SDA_P65",
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_203",
+    "name": "I2C_SCL_P127",
+    "pin_number": 6,
+    "port_hints": [
+      "I2C_SCL_P127",
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_204",
+    "name": "UART_TX_P122",
+    "pin_number": 7,
+    "port_hints": [
+      "UART_TX_P122",
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_205",
+    "name": "UART_RX_P121",
+    "pin_number": 8,
+    "port_hints": [
+      "UART_RX_P121",
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net22"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_206",
+    "name": "VBUS",
+    "pin_number": 9,
+    "port_hints": [
+      "VBUS",
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_207",
+    "name": "GND_2",
+    "pin_number": 10,
+    "port_hints": [
+      "GND_2",
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_17",
+    "ftype": "simple_pin_header",
+    "name": "J_DEBUG",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C492422",
+        "C57369",
+        "C492409"
+      ]
+    },
+    "pin_count": 10,
+    "gender": "male",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_208",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_209",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net29"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_18",
+    "ftype": "simple_led",
+    "name": "D2",
+    "color": "green",
+    "symbol_display_value": "green",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C965799",
+        "C84263",
+        "C965804"
+      ]
+    },
+    "are_pins_interchangeable": false,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_210",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net29"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_211",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_19",
+    "ftype": "simple_resistor",
+    "name": "R6",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C21190",
+        "C2907002",
+        "C2907113"
+      ]
+    },
+    "resistance": 1000,
+    "display_resistance": "1kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_0",
+    "name": "USB_CC1",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_1",
+    "name": "USB_CC2",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_2",
+    "name": "USB_DM",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_3",
+    "name": "USB_DP",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_4",
+    "name": "GND",
+    "member_source_group_ids": [],
+    "is_ground": true,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_5",
+    "name": "VBUS_5V",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_6",
+    "name": "USB_DM_SOC",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_7",
+    "name": "USB_DP_SOC",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_8",
+    "name": "VCC_3V3",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_9",
+    "name": "VCC_1V8",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_10",
+    "name": "VDD_0V9",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_11",
+    "name": "VDD_CORE",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_12",
+    "name": "VBUS_DET",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_13",
+    "name": "RESET_N",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_14",
+    "name": "XIN",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net14"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_15",
+    "name": "XOUT",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_16",
+    "name": "FSPI_IO3",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_17",
+    "name": "FSPI_IO0",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_18",
+    "name": "FSPI_IO1",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net18"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_19",
+    "name": "FSPI_IO2",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_20",
+    "name": "FSPI_CS",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_21",
+    "name": "FSPI_CLK",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_22",
+    "name": "UART0_RX",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net22"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_23",
+    "name": "UART0_TX",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_24",
+    "name": "GPIO0",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net24"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_25",
+    "name": "GPIO1",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_26",
+    "name": "I2C1_SCL",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_27",
+    "name": "I2C1_SDA",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_28",
+    "name": "BOOT_STRAP",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_29",
+    "name": "POWER_LED",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net29"
+  },
+  {
+    "type": "source_board",
+    "source_board_id": "source_board_0",
+    "source_group_id": "source_group_0",
+    "title": "RV1106G2 Linux development board — review required"
+  },
+  {
+    "type": "source_refdes_convention_warning",
+    "warning_type": "source_refdes_convention_warning",
+    "message": "The \"J\" prefix is being used with a <chip />, try using it with a <connector /> or <jumper />",
+    "source_component_id": "source_component_0",
+    "refdes": "J1",
+    "source_component_ftype": "simple_chip",
+    "expected_prefixes": [
+      "U",
+      "IC"
+    ],
+    "actual_prefix": "J",
+    "source_refdes_convention_warning_id": "source_refdes_convention_warning_0"
+  },
+  {
+    "type": "source_refdes_convention_warning",
+    "warning_type": "source_refdes_convention_warning",
+    "message": "The \"S\" prefix is being used with a <chip />, try using it with a <switch /> or <pushbutton />",
+    "source_component_id": "source_component_13",
+    "refdes": "SW1",
+    "source_component_ftype": "simple_chip",
+    "expected_prefixes": [
+      "U",
+      "IC"
+    ],
+    "actual_prefix": "SW",
+    "source_refdes_convention_warning_id": "source_refdes_convention_warning_1"
+  },
+  {
+    "type": "source_refdes_convention_warning",
+    "warning_type": "source_refdes_convention_warning",
+    "message": "The \"S\" prefix is being used with a <chip />, try using it with a <switch /> or <pushbutton />",
+    "source_component_id": "source_component_14",
+    "refdes": "SW2",
+    "source_component_ftype": "simple_chip",
+    "expected_prefixes": [
+      "U",
+      "IC"
+    ],
+    "actual_prefix": "SW",
+    "source_refdes_convention_warning_id": "source_refdes_convention_warning_2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_0",
+    "connected_source_port_ids": [
+      "source_port_5"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .A5 to net.USB_CC1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_0",
+    "message": "<trace#1284(from:.J1 > .A5 to:net.USB_CC1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_1",
+    "connected_source_port_ids": [
+      "source_port_11"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .B5 to net.USB_CC2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_1",
+    "message": "<trace#1285(from:.J1 > .B5 to:net.USB_CC2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_2",
+    "connected_source_port_ids": [
+      "source_port_6"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .B7 to net.USB_DM",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_2",
+    "message": "<trace#1286(from:.J1 > .B7 to:net.USB_DM) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_3",
+    "connected_source_port_ids": [
+      "source_port_8"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .A7 to net.USB_DM",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_3",
+    "message": "<trace#1287(from:.J1 > .A7 to:net.USB_DM) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_4",
+    "connected_source_port_ids": [
+      "source_port_7"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .A6 to net.USB_DP",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_4",
+    "message": "<trace#1288(from:.J1 > .A6 to:net.USB_DP) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_5",
+    "connected_source_port_ids": [
+      "source_port_9"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .B6 to net.USB_DP",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_5",
+    "message": "<trace#1289(from:.J1 > .B6 to:net.USB_DP) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_6",
+    "connected_source_port_ids": [
+      "source_port_12"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .A1B12 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_6",
+    "message": "<trace#1290(from:.J1 > .A1B12 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_7",
+    "connected_source_port_ids": [
+      "source_port_13"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .B1A12 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_7",
+    "message": "<trace#1291(from:.J1 > .B1A12 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_8",
+    "connected_source_port_ids": [
+      "source_port_14"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .B4A9 to net.VBUS_5V",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_8",
+    "message": "<trace#1292(from:.J1 > .B4A9 to:net.VBUS_5V) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_9",
+    "connected_source_port_ids": [
+      "source_port_15"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .A4B9 to net.VBUS_5V",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_9",
+    "message": "<trace#1293(from:.J1 > .A4B9 to:net.VBUS_5V) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_9",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_10",
+    "connected_source_port_ids": [
+      "source_port_1"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .EH1 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_10",
+    "message": "<trace#1294(from:.J1 > .EH1 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_10",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_11",
+    "connected_source_port_ids": [
+      "source_port_0"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .EH2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_11",
+    "message": "<trace#1295(from:.J1 > .EH2 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_11",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_12",
+    "connected_source_port_ids": [
+      "source_port_3"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .EH3 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_12",
+    "message": "<trace#1296(from:.J1 > .EH3 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_12",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_13",
+    "connected_source_port_ids": [
+      "source_port_2"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J1 > .EH4 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_13",
+    "message": "<trace#1297(from:.J1 > .EH4 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_14",
+    "connected_source_port_ids": [
+      "source_port_16"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".R1 > .pin1 to net.USB_CC1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_14",
+    "message": "<trace#1298(from:.R1 > .pin1 to:net.USB_CC1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_15",
+    "connected_source_port_ids": [
+      "source_port_17"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".R1 > .pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_15",
+    "message": "<trace#1299(from:.R1 > .pin2 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_16",
+    "connected_source_port_ids": [
+      "source_port_18"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".R2 > .pin1 to net.USB_CC2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_16",
+    "message": "<trace#1300(from:.R2 > .pin1 to:net.USB_CC2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_16",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_17",
+    "connected_source_port_ids": [
+      "source_port_19"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".R2 > .pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_17",
+    "message": "<trace#1301(from:.R2 > .pin2 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_18",
+    "connected_source_port_ids": [
+      "source_port_20"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".D1 > .pin1 to net.USB_DM",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_18",
+    "message": "<trace#1302(from:.D1 > .pin1 to:net.USB_DM) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_18",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_19",
+    "connected_source_port_ids": [
+      "source_port_25"
+    ],
+    "connected_source_net_ids": [
+      "source_net_6"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".D1 > .pin6 to net.USB_DM_SOC",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_19",
+    "message": "<trace#1303(from:.D1 > .pin6 to:net.USB_DM_SOC) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_19",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_20",
+    "connected_source_port_ids": [
+      "source_port_22"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".D1 > .pin3 to net.USB_DP",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_20",
+    "message": "<trace#1304(from:.D1 > .pin3 to:net.USB_DP) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_20",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_21",
+    "connected_source_port_ids": [
+      "source_port_23"
+    ],
+    "connected_source_net_ids": [
+      "source_net_7"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".D1 > .pin4 to net.USB_DP_SOC",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_21",
+    "message": "<trace#1305(from:.D1 > .pin4 to:net.USB_DP_SOC) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_21",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_22",
+    "connected_source_port_ids": [
+      "source_port_21"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".D1 > .pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_22",
+    "message": "<trace#1306(from:.D1 > .pin2 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_22",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_23",
+    "connected_source_port_ids": [
+      "source_port_24"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".D1 > .pin5 to net.VBUS_5V",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_23",
+    "message": "<trace#1307(from:.D1 > .pin5 to:net.VBUS_5V) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_23",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_24",
+    "connected_source_port_ids": [
+      "source_port_26"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U2 > .VIN to net.VBUS_5V",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_24",
+    "message": "<trace#1308(from:.U2 > .VIN to:net.VBUS_5V) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_24",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_25",
+    "connected_source_port_ids": [
+      "source_port_28"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U2 > .EN to net.VBUS_5V",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_25",
+    "message": "<trace#1309(from:.U2 > .EN to:net.VBUS_5V) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_25",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_26",
+    "connected_source_port_ids": [
+      "source_port_27"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U2 > .GND to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_26",
+    "message": "<trace#1310(from:.U2 > .GND to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_26",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_27",
+    "connected_source_port_ids": [
+      "source_port_30"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U2 > .VOUT to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_27",
+    "message": "<trace#1311(from:.U2 > .VOUT to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_27",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_28",
+    "connected_source_port_ids": [
+      "source_port_31"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".C1 > .pin1 to net.VBUS_5V",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_28",
+    "message": "<trace#1312(from:.C1 > .pin1 to:net.VBUS_5V) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_28",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_29",
+    "connected_source_port_ids": [
+      "source_port_32"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".C1 > .pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_29",
+    "message": "<trace#1313(from:.C1 > .pin2 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_29",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_30",
+    "connected_source_port_ids": [
+      "source_port_33"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".C2 > .pin1 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_30",
+    "message": "<trace#1314(from:.C2 > .pin1 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_30",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_31",
+    "connected_source_port_ids": [
+      "source_port_34"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".C2 > .pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_31",
+    "message": "<trace#1315(from:.C2 > .pin2 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_31",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_32",
+    "connected_source_port_ids": [
+      "source_port_35"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U3 > .VIN to net.VBUS_5V",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_32",
+    "message": "<trace#1316(from:.U3 > .VIN to:net.VBUS_5V) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_32",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_33",
+    "connected_source_port_ids": [
+      "source_port_36"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U3 > .GND to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_33",
+    "message": "<trace#1317(from:.U3 > .GND to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_33",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_34",
+    "connected_source_port_ids": [
+      "source_port_37"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U3 > .EN to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_34",
+    "message": "<trace#1318(from:.U3 > .EN to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_34",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_35",
+    "connected_source_port_ids": [
+      "source_port_38"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U3 > .VOUT_1V8 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_35",
+    "message": "<trace#1319(from:.U3 > .VOUT_1V8 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_35",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_36",
+    "connected_source_port_ids": [
+      "source_port_39"
+    ],
+    "connected_source_net_ids": [
+      "source_net_10"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U3 > .VOUT_0V9 to net.VDD_0V9",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_36",
+    "message": "<trace#1320(from:.U3 > .VOUT_0V9 to:net.VDD_0V9) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_36",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_37",
+    "connected_source_port_ids": [
+      "source_port_40"
+    ],
+    "connected_source_net_ids": [
+      "source_net_11"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U3 > .VOUT_1V1 to net.VDD_CORE",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_37",
+    "message": "<trace#1321(from:.U3 > .VOUT_1V1 to:net.VDD_CORE) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_37",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_38",
+    "connected_source_port_ids": [
+      "source_port_52"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin10 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_38",
+    "message": "<trace#1322(from:.U1 > .pin10 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_38",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_39",
+    "connected_source_port_ids": [
+      "source_port_55"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin13 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_39",
+    "message": "<trace#1323(from:.U1 > .pin13 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_39",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_40",
+    "connected_source_port_ids": [
+      "source_port_61"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin19 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_40",
+    "message": "<trace#1324(from:.U1 > .pin19 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_40",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_41",
+    "connected_source_port_ids": [
+      "source_port_66"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin24 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_41",
+    "message": "<trace#1325(from:.U1 > .pin24 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_41",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_42",
+    "connected_source_port_ids": [
+      "source_port_67"
+    ],
+    "connected_source_net_ids": [
+      "source_net_12"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin25 to net.VBUS_DET",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_42",
+    "message": "<trace#1326(from:.U1 > .pin25 to:net.VBUS_DET) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_42",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_43",
+    "connected_source_port_ids": [
+      "source_port_68"
+    ],
+    "connected_source_net_ids": [
+      "source_net_6"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin26 to net.USB_DM_SOC",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_43",
+    "message": "<trace#1327(from:.U1 > .pin26 to:net.USB_DM_SOC) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_43",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_44",
+    "connected_source_port_ids": [
+      "source_port_69"
+    ],
+    "connected_source_net_ids": [
+      "source_net_7"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin27 to net.USB_DP_SOC",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_44",
+    "message": "<trace#1328(from:.U1 > .pin27 to:net.USB_DP_SOC) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_44",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_45",
+    "connected_source_port_ids": [
+      "source_port_70"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin28 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_45",
+    "message": "<trace#1329(from:.U1 > .pin28 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_45",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_46",
+    "connected_source_port_ids": [
+      "source_port_85"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin43 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_46",
+    "message": "<trace#1330(from:.U1 > .pin43 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_46",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_47",
+    "connected_source_port_ids": [
+      "source_port_91"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin49 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_47",
+    "message": "<trace#1331(from:.U1 > .pin49 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_47",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_48",
+    "connected_source_port_ids": [
+      "source_port_92"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin50 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_48",
+    "message": "<trace#1332(from:.U1 > .pin50 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_48",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_49",
+    "connected_source_port_ids": [
+      "source_port_95"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin53 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_49",
+    "message": "<trace#1333(from:.U1 > .pin53 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_49",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_50",
+    "connected_source_port_ids": [
+      "source_port_98"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin56 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_50",
+    "message": "<trace#1334(from:.U1 > .pin56 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_50",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_51",
+    "connected_source_port_ids": [
+      "source_port_103"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin61 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_51",
+    "message": "<trace#1335(from:.U1 > .pin61 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_51",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_52",
+    "connected_source_port_ids": [
+      "source_port_108"
+    ],
+    "connected_source_net_ids": [
+      "source_net_13"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin66 to net.RESET_N",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_52",
+    "message": "<trace#1336(from:.U1 > .pin66 to:net.RESET_N) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_52",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_53",
+    "connected_source_port_ids": [
+      "source_port_109"
+    ],
+    "connected_source_net_ids": [
+      "source_net_10"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin67 to net.VDD_0V9",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_53",
+    "message": "<trace#1337(from:.U1 > .pin67 to:net.VDD_0V9) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_53",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_54",
+    "connected_source_port_ids": [
+      "source_port_110"
+    ],
+    "connected_source_net_ids": [
+      "source_net_14"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 10,
+    "max_via_count": 0,
+    "display_name": ".U1 > .pin68 to net.XIN",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net14"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_54",
+    "message": "<trace#1338(from:.U1 > .pin68 to:net.XIN) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_54",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_55",
+    "connected_source_port_ids": [
+      "source_port_111"
+    ],
+    "connected_source_net_ids": [
+      "source_net_15"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 10,
+    "max_via_count": 0,
+    "display_name": ".U1 > .pin69 to net.XOUT",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_55",
+    "message": "<trace#1339(from:.U1 > .pin69 to:net.XOUT) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_55",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_56",
+    "connected_source_port_ids": [
+      "source_port_112"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin70 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_56",
+    "message": "<trace#1340(from:.U1 > .pin70 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_56",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_57",
+    "connected_source_port_ids": [
+      "source_port_113"
+    ],
+    "connected_source_net_ids": [
+      "source_net_10"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin71 to net.VDD_0V9",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_57",
+    "message": "<trace#1341(from:.U1 > .pin71 to:net.VDD_0V9) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_57",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_58",
+    "connected_source_port_ids": [
+      "source_port_123"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin81 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_58",
+    "message": "<trace#1342(from:.U1 > .pin81 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_58",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_59",
+    "connected_source_port_ids": [
+      "source_port_124"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin82 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_59",
+    "message": "<trace#1343(from:.U1 > .pin82 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_59",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_60",
+    "connected_source_port_ids": [
+      "source_port_130"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin88 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_60",
+    "message": "<trace#1344(from:.U1 > .pin88 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_60",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_61",
+    "connected_source_port_ids": [
+      "source_port_138"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin96 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_61",
+    "message": "<trace#1345(from:.U1 > .pin96 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_61",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_62",
+    "connected_source_port_ids": [
+      "source_port_143"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin101 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_62",
+    "message": "<trace#1346(from:.U1 > .pin101 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_62",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_63",
+    "connected_source_port_ids": [
+      "source_port_145"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin103 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_63",
+    "message": "<trace#1347(from:.U1 > .pin103 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_63",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_64",
+    "connected_source_port_ids": [
+      "source_port_150"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin108 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_64",
+    "message": "<trace#1348(from:.U1 > .pin108 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_64",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_65",
+    "connected_source_port_ids": [
+      "source_port_157"
+    ],
+    "connected_source_net_ids": [
+      "source_net_11"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin115 to net.VDD_CORE",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_65",
+    "message": "<trace#1349(from:.U1 > .pin115 to:net.VDD_CORE) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_65",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_66",
+    "connected_source_port_ids": [
+      "source_port_158"
+    ],
+    "connected_source_net_ids": [
+      "source_net_9"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin116 to net.VCC_1V8",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_66",
+    "message": "<trace#1350(from:.U1 > .pin116 to:net.VCC_1V8) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_66",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_67",
+    "connected_source_port_ids": [
+      "source_port_171"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin129 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_67",
+    "message": "<trace#1351(from:.U1 > .pin129 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_67",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_68",
+    "connected_source_port_ids": [
+      "source_port_81"
+    ],
+    "connected_source_net_ids": [
+      "source_net_16"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin39 to net.FSPI_IO3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_68",
+    "message": "<trace#1352(from:.U1 > .pin39 to:net.FSPI_IO3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_68",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_69",
+    "connected_source_port_ids": [
+      "source_port_83"
+    ],
+    "connected_source_net_ids": [
+      "source_net_17"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin41 to net.FSPI_IO0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_69",
+    "message": "<trace#1353(from:.U1 > .pin41 to:net.FSPI_IO0) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_69",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_70",
+    "connected_source_port_ids": [
+      "source_port_84"
+    ],
+    "connected_source_net_ids": [
+      "source_net_18"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin42 to net.FSPI_IO1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net18"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_70",
+    "message": "<trace#1354(from:.U1 > .pin42 to:net.FSPI_IO1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_70",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_71",
+    "connected_source_port_ids": [
+      "source_port_86"
+    ],
+    "connected_source_net_ids": [
+      "source_net_19"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin44 to net.FSPI_IO2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_71",
+    "message": "<trace#1355(from:.U1 > .pin44 to:net.FSPI_IO2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_71",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_72",
+    "connected_source_port_ids": [
+      "source_port_89"
+    ],
+    "connected_source_net_ids": [
+      "source_net_20"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin47 to net.FSPI_CS",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_72",
+    "message": "<trace#1356(from:.U1 > .pin47 to:net.FSPI_CS) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_72",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_73",
+    "connected_source_port_ids": [
+      "source_port_90"
+    ],
+    "connected_source_net_ids": [
+      "source_net_21"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin48 to net.FSPI_CLK",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_73",
+    "message": "<trace#1357(from:.U1 > .pin48 to:net.FSPI_CLK) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_73",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_74",
+    "connected_source_port_ids": [
+      "source_port_163"
+    ],
+    "connected_source_net_ids": [
+      "source_net_22"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin121 to net.UART0_RX",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net22"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_74",
+    "message": "<trace#1358(from:.U1 > .pin121 to:net.UART0_RX) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_74",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_75",
+    "connected_source_port_ids": [
+      "source_port_164"
+    ],
+    "connected_source_net_ids": [
+      "source_net_23"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin122 to net.UART0_TX",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_75",
+    "message": "<trace#1359(from:.U1 > .pin122 to:net.UART0_TX) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_75",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_76",
+    "connected_source_port_ids": [
+      "source_port_167"
+    ],
+    "connected_source_net_ids": [
+      "source_net_24"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin125 to net.GPIO0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net24"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_76",
+    "message": "<trace#1360(from:.U1 > .pin125 to:net.GPIO0) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_76",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_77",
+    "connected_source_port_ids": [
+      "source_port_168"
+    ],
+    "connected_source_net_ids": [
+      "source_net_25"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin126 to net.GPIO1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_77",
+    "message": "<trace#1361(from:.U1 > .pin126 to:net.GPIO1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_77",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_78",
+    "connected_source_port_ids": [
+      "source_port_169"
+    ],
+    "connected_source_net_ids": [
+      "source_net_26"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin127 to net.I2C1_SCL",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_78",
+    "message": "<trace#1362(from:.U1 > .pin127 to:net.I2C1_SCL) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_78",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_79",
+    "connected_source_port_ids": [
+      "source_port_107"
+    ],
+    "connected_source_net_ids": [
+      "source_net_27"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U1 > .pin65 to net.I2C1_SDA",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_79",
+    "message": "<trace#1363(from:.U1 > .pin65 to:net.I2C1_SDA) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_79",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_80",
+    "connected_source_port_ids": [
+      "source_port_172"
+    ],
+    "connected_source_net_ids": [
+      "source_net_14"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 10,
+    "max_via_count": 0,
+    "display_name": ".Y1 > .pin1 to net.XIN",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net14"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_80",
+    "message": "<trace#1364(from:.Y1 > .pin1 to:net.XIN) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_80",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_81",
+    "connected_source_port_ids": [
+      "source_port_173"
+    ],
+    "connected_source_net_ids": [
+      "source_net_15"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 10,
+    "max_via_count": 0,
+    "display_name": ".Y1 > .pin2 to net.XOUT",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_81",
+    "message": "<trace#1365(from:.Y1 > .pin2 to:net.XOUT) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_81",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_82",
+    "connected_source_port_ids": [
+      "source_port_174"
+    ],
+    "connected_source_net_ids": [
+      "source_net_14"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 10,
+    "max_via_count": 0,
+    "display_name": ".C3 > .pin1 to net.XIN",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net14"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_82",
+    "message": "<trace#1366(from:.C3 > .pin1 to:net.XIN) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_82",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_83",
+    "connected_source_port_ids": [
+      "source_port_175"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".C3 > .pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_83",
+    "message": "<trace#1367(from:.C3 > .pin2 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_83",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_84",
+    "connected_source_port_ids": [
+      "source_port_176"
+    ],
+    "connected_source_net_ids": [
+      "source_net_15"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "max_length": 10,
+    "max_via_count": 0,
+    "display_name": ".C4 > .pin1 to net.XOUT",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_84",
+    "message": "<trace#1368(from:.C4 > .pin1 to:net.XOUT) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_84",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_85",
+    "connected_source_port_ids": [
+      "source_port_177"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".C4 > .pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_85",
+    "message": "<trace#1369(from:.C4 > .pin2 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_85",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_86",
+    "connected_source_port_ids": [
+      "source_port_178"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".R3 > .pin1 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_86",
+    "message": "<trace#1370(from:.R3 > .pin1 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_86",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_87",
+    "connected_source_port_ids": [
+      "source_port_179"
+    ],
+    "connected_source_net_ids": [
+      "source_net_13"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".R3 > .pin2 to net.RESET_N",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_87",
+    "message": "<trace#1371(from:.R3 > .pin2 to:net.RESET_N) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_87",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_88",
+    "connected_source_port_ids": [
+      "source_port_180"
+    ],
+    "connected_source_net_ids": [
+      "source_net_13"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".SW1 > .pin1 to net.RESET_N",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_88",
+    "message": "<trace#1372(from:.SW1 > .pin1 to:net.RESET_N) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_88",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_89",
+    "connected_source_port_ids": [
+      "source_port_182"
+    ],
+    "connected_source_net_ids": [
+      "source_net_13"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".SW1 > .pin2 to net.RESET_N",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_89",
+    "message": "<trace#1373(from:.SW1 > .pin2 to:net.RESET_N) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_89",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_90",
+    "connected_source_port_ids": [
+      "source_port_181"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".SW1 > .pin3 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_90",
+    "message": "<trace#1374(from:.SW1 > .pin3 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_90",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_91",
+    "connected_source_port_ids": [
+      "source_port_183"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".SW1 > .pin4 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_91",
+    "message": "<trace#1375(from:.SW1 > .pin4 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_91",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_92",
+    "connected_source_port_ids": [
+      "source_port_184"
+    ],
+    "connected_source_net_ids": [
+      "source_net_28"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".SW2 > .pin1 to net.BOOT_STRAP",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_92",
+    "message": "<trace#1376(from:.SW2 > .pin1 to:net.BOOT_STRAP) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_92",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_93",
+    "connected_source_port_ids": [
+      "source_port_186"
+    ],
+    "connected_source_net_ids": [
+      "source_net_28"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".SW2 > .pin2 to net.BOOT_STRAP",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net28"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_93",
+    "message": "<trace#1377(from:.SW2 > .pin2 to:net.BOOT_STRAP) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_93",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_94",
+    "connected_source_port_ids": [
+      "source_port_185"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".SW2 > .pin3 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_94",
+    "message": "<trace#1378(from:.SW2 > .pin3 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_94",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_95",
+    "connected_source_port_ids": [
+      "source_port_187"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".SW2 > .pin4 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_95",
+    "message": "<trace#1379(from:.SW2 > .pin4 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_95",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_96",
+    "connected_source_port_ids": [
+      "source_port_188"
+    ],
+    "connected_source_net_ids": [
+      "source_net_20"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U4 > .CS to net.FSPI_CS",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_96",
+    "message": "<trace#1380(from:.U4 > .CS to:net.FSPI_CS) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_96",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_97",
+    "connected_source_port_ids": [
+      "source_port_192"
+    ],
+    "connected_source_net_ids": [
+      "source_net_17"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U4 > .DI to net.FSPI_IO0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_97",
+    "message": "<trace#1381(from:.U4 > .DI to:net.FSPI_IO0) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_97",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_98",
+    "connected_source_port_ids": [
+      "source_port_189"
+    ],
+    "connected_source_net_ids": [
+      "source_net_18"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U4 > .DO to net.FSPI_IO1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net18"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_98",
+    "message": "<trace#1382(from:.U4 > .DO to:net.FSPI_IO1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_98",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_99",
+    "connected_source_port_ids": [
+      "source_port_190"
+    ],
+    "connected_source_net_ids": [
+      "source_net_19"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U4 > .IO2 to net.FSPI_IO2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_99",
+    "message": "<trace#1383(from:.U4 > .IO2 to:net.FSPI_IO2) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_99",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_100",
+    "connected_source_port_ids": [
+      "source_port_194"
+    ],
+    "connected_source_net_ids": [
+      "source_net_16"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U4 > .IO3 to net.FSPI_IO3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_100",
+    "message": "<trace#1384(from:.U4 > .IO3 to:net.FSPI_IO3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_100",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_101",
+    "connected_source_port_ids": [
+      "source_port_193"
+    ],
+    "connected_source_net_ids": [
+      "source_net_21"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U4 > .CLK to net.FSPI_CLK",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_101",
+    "message": "<trace#1385(from:.U4 > .CLK to:net.FSPI_CLK) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_101",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_102",
+    "connected_source_port_ids": [
+      "source_port_195"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U4 > .VCC to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_102",
+    "message": "<trace#1386(from:.U4 > .VCC to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_102",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_103",
+    "connected_source_port_ids": [
+      "source_port_191"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".U4 > .GND to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_103",
+    "message": "<trace#1387(from:.U4 > .GND to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_103",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_104",
+    "connected_source_port_ids": [
+      "source_port_196"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".C5 > .pin1 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_104",
+    "message": "<trace#1388(from:.C5 > .pin1 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_104",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_105",
+    "connected_source_port_ids": [
+      "source_port_197"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".C5 > .pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_105",
+    "message": "<trace#1389(from:.C5 > .pin2 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_105",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_106",
+    "connected_source_port_ids": [
+      "source_port_198"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J_DEBUG > .pin1 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_106",
+    "message": "<trace#1390(from:.J_DEBUG > .pin1 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_106",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_107",
+    "connected_source_port_ids": [
+      "source_port_199"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J_DEBUG > .pin2 to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_107",
+    "message": "<trace#1391(from:.J_DEBUG > .pin2 to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_107",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_108",
+    "connected_source_port_ids": [
+      "source_port_200"
+    ],
+    "connected_source_net_ids": [
+      "source_net_24"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J_DEBUG > .pin3 to net.GPIO0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net24"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_108",
+    "message": "<trace#1392(from:.J_DEBUG > .pin3 to:net.GPIO0) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_108",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_109",
+    "connected_source_port_ids": [
+      "source_port_201"
+    ],
+    "connected_source_net_ids": [
+      "source_net_25"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J_DEBUG > .pin4 to net.GPIO1",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_109",
+    "message": "<trace#1393(from:.J_DEBUG > .pin4 to:net.GPIO1) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_109",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_110",
+    "connected_source_port_ids": [
+      "source_port_202"
+    ],
+    "connected_source_net_ids": [
+      "source_net_27"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J_DEBUG > .pin5 to net.I2C1_SDA",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_110",
+    "message": "<trace#1394(from:.J_DEBUG > .pin5 to:net.I2C1_SDA) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_110",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_111",
+    "connected_source_port_ids": [
+      "source_port_203"
+    ],
+    "connected_source_net_ids": [
+      "source_net_26"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J_DEBUG > .pin6 to net.I2C1_SCL",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_111",
+    "message": "<trace#1395(from:.J_DEBUG > .pin6 to:net.I2C1_SCL) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_111",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_112",
+    "connected_source_port_ids": [
+      "source_port_204"
+    ],
+    "connected_source_net_ids": [
+      "source_net_23"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J_DEBUG > .pin7 to net.UART0_TX",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net23"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_112",
+    "message": "<trace#1396(from:.J_DEBUG > .pin7 to:net.UART0_TX) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_112",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_113",
+    "connected_source_port_ids": [
+      "source_port_205"
+    ],
+    "connected_source_net_ids": [
+      "source_net_22"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J_DEBUG > .pin8 to net.UART0_RX",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net22"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_113",
+    "message": "<trace#1397(from:.J_DEBUG > .pin8 to:net.UART0_RX) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_113",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_114",
+    "connected_source_port_ids": [
+      "source_port_206"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J_DEBUG > .pin9 to net.VBUS_5V",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_114",
+    "message": "<trace#1398(from:.J_DEBUG > .pin9 to:net.VBUS_5V) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_114",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_115",
+    "connected_source_port_ids": [
+      "source_port_207"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".J_DEBUG > .pin10 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_115",
+    "message": "<trace#1399(from:.J_DEBUG > .pin10 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_115",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_116",
+    "connected_source_port_ids": [
+      "source_port_208"
+    ],
+    "connected_source_net_ids": [
+      "source_net_8"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".D2 > .anode to net.VCC_3V3",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_116",
+    "message": "<trace#1400(from:.D2 > .anode to:net.VCC_3V3) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_116",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_117",
+    "connected_source_port_ids": [
+      "source_port_209"
+    ],
+    "connected_source_net_ids": [
+      "source_net_29"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".D2 > .cathode to net.POWER_LED",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net29"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_117",
+    "message": "<trace#1401(from:.D2 > .cathode to:net.POWER_LED) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_117",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_118",
+    "connected_source_port_ids": [
+      "source_port_210"
+    ],
+    "connected_source_net_ids": [
+      "source_net_29"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".R6 > .pin1 to net.POWER_LED",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net29"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_118",
+    "message": "<trace#1402(from:.R6 > .pin1 to:net.POWER_LED) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_118",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_119",
+    "connected_source_port_ids": [
+      "source_port_211"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "display_name": ".R6 > .pin2 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "source_unnamed_trace_warning",
+    "source_unnamed_trace_warning_id": "source_unnamed_trace_warning_119",
+    "message": "<trace#1403(from:.R6 > .pin2 to:net.GND) /> is missing a name. Add a name prop to make the trace easier to identify.",
+    "source_trace_id": "source_trace_119",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "warning_type": "source_unnamed_trace_warning"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -18,
+      "y": -8
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 1.7999999999999998
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "EH2",
+      "pin2": "EH1",
+      "pin3": "EH4",
+      "pin4": "EH3",
+      "pin5": "B8",
+      "pin6": "A5",
+      "pin7": "B7",
+      "pin8": "A6",
+      "pin9": "A7",
+      "pin10": "B6",
+      "pin11": "A8",
+      "pin12": "B5",
+      "pin13": "A1B12",
+      "pin14": "B1A12",
+      "pin15": "B4A9",
+      "pin16": "A4B9"
+    },
+    "source_component_id": "source_component_0",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_0",
+    "text": "TYPE-C-31-M-12",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -18.6,
+      "y": -9.030000000000001
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_1",
+    "text": "J1",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -18.6,
+      "y": -6.97
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -20.36,
+      "y": -6.29
+    },
+    "size": {
+      "width": 0.65,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_1",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "5.1kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -18.48,
+      "y": -5.195
+    },
+    "size": {
+      "width": 0.65,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_2",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "5.1kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -22.5,
+      "y": -8
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.8
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "pin1",
+      "pin2": "pin2",
+      "pin3": "pin3",
+      "pin4": "pin4",
+      "pin5": "pin5",
+      "pin6": "pin6"
+    },
+    "source_component_id": "source_component_3",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_2",
+    "text": "USBLC6_2SC6",
+    "schematic_component_id": "schematic_component_3",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -23.1,
+      "y": -8.530000000000001
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_3",
+    "text": "D1",
+    "schematic_component_id": "schematic_component_3",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -23.1,
+      "y": -7.47
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -10,
+      "y": -8
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 0.6
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "VIN",
+      "pin2": "GND",
+      "pin3": "EN",
+      "pin4": "NC",
+      "pin5": "VOUT"
+    },
+    "source_component_id": "source_component_4",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_4",
+    "text": "AP2112K-3.3TRG1",
+    "schematic_component_id": "schematic_component_4",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -10.6,
+      "y": -8.430000000000001
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_5",
+    "text": "U2",
+    "schematic_component_id": "schematic_component_4",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -10.6,
+      "y": -7.57
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -12.37,
+      "y": -6.8475
+    },
+    "size": {
+      "width": 0.65,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_5",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "10uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -11.129999999999999,
+      "y": -6.8475
+    },
+    "size": {
+      "width": 0.65,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_6",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "10uF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 2.7025000000000015,
+      "y": -8
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.9000000000000001,
+      "height": 1
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "VIN",
+      "pin2": "GND",
+      "pin3": "EN",
+      "pin4": "VOUT_1V8",
+      "pin5": "VOUT_0V9",
+      "pin6": "VOUT_1V1",
+      "pin7": "FB",
+      "pin8": "PG"
+    },
+    "source_component_id": "source_component_7",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_6",
+    "text": "",
+    "schematic_component_id": "schematic_component_7",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 1.7525000000000013,
+      "y": -8.63
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_7",
+    "text": "U3",
+    "schematic_component_id": "schematic_component_7",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 1.7525000000000013,
+      "y": -7.37
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "rotation": 0,
+    "size": {
+      "width": 3.2,
+      "height": 13
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "pin1",
+      "pin2": "pin2",
+      "pin3": "pin3",
+      "pin4": "pin4",
+      "pin5": "pin5",
+      "pin6": "pin6",
+      "pin7": "pin7",
+      "pin8": "pin8",
+      "pin9": "pin9",
+      "pin10": "DVDD_1",
+      "pin11": "pin11",
+      "pin12": "pin12",
+      "pin13": "GPIO4_VCC",
+      "pin14": "pin14",
+      "pin15": "pin15",
+      "pin16": "pin16",
+      "pin17": "pin17",
+      "pin18": "pin18",
+      "pin19": "RTC_AVDD3V3",
+      "pin20": "RTC_XOUT",
+      "pin21": "RTC_XIN",
+      "pin22": "pin22",
+      "pin23": "pin23",
+      "pin24": "SARADC_USB_AVDD1V8",
+      "pin25": "USB_VBUSDET",
+      "pin26": "USB_DM",
+      "pin27": "USB_DP",
+      "pin28": "USB_AVDD3V3",
+      "pin29": "CODEC_LINEOUT",
+      "pin30": "CODEC_VCM",
+      "pin31": "CODEC_AVDD1V8",
+      "pin32": "CODEC_MICBIAS",
+      "pin33": "CODEC_MIC0N",
+      "pin34": "CODEC_MIC0P",
+      "pin35": "CODEC_MIC1N",
+      "pin36": "CODEC_MIC1P",
+      "pin37": "CODEC_AVSS",
+      "pin38": "pin38",
+      "pin39": "pin39",
+      "pin40": "pin40",
+      "pin41": "pin41",
+      "pin42": "pin42",
+      "pin43": "GPIO3_VCC",
+      "pin44": "pin44",
+      "pin45": "pin45",
+      "pin46": "pin46",
+      "pin47": "pin47",
+      "pin48": "pin48",
+      "pin49": "DDR_VDDQ_1",
+      "pin50": "DDR_VDDQ_2",
+      "pin51": "DVDD_2D",
+      "pin52": "RAM_ZQ",
+      "pin53": "DDR_PLL_AVDD1V8",
+      "pin54": "DVDD_3",
+      "pin55": "DVDD_4",
+      "pin56": "DDR_VDDQ_3",
+      "pin57": "TVSS",
+      "pin58": "pin58",
+      "pin59": "pin59",
+      "pin60": "pin60",
+      "pin61": "PMU_VCC3V3",
+      "pin62": "pin62",
+      "pin63": "pin63",
+      "pin64": "pin64",
+      "pin65": "pin65",
+      "pin66": "POR",
+      "pin67": "PMU_DVDD0V9",
+      "pin68": "OSC_XIN",
+      "pin69": "OSC_XOUT",
+      "pin70": "pin70",
+      "pin71": "OSC_PLL_DVDD",
+      "pin72": "pin72",
+      "pin73": "pin73",
+      "pin74": "pin74",
+      "pin75": "pin75",
+      "pin76": "pin76",
+      "pin77": "pin77",
+      "pin78": "pin78",
+      "pin79": "pin79",
+      "pin80": "pin80",
+      "pin81": "GPIO1_VCC3V3",
+      "pin82": "DVDD_5",
+      "pin83": "pin83",
+      "pin84": "pin84",
+      "pin85": "pin85",
+      "pin86": "pin86",
+      "pin87": "pin87",
+      "pin88": "GPIO6_VCC",
+      "pin89": "pin89",
+      "pin90": "pin90",
+      "pin91": "pin91",
+      "pin92": "pin92",
+      "pin93": "pin93",
+      "pin94": "pin94",
+      "pin95": "pin95",
+      "pin96": "pin96",
+      "pin97": "ETH_PHY_RXN",
+      "pin98": "ETH_PHY_RXP",
+      "pin99": "ETH_PHY_TXN",
+      "pin100": "ETH_PHY_TXP",
+      "pin101": "ETH_AVDD3V3",
+      "pin102": "ETH_EXTR",
+      "pin103": "DVDD_6",
+      "pin104": "pin104",
+      "pin105": "pin105",
+      "pin106": "pin106",
+      "pin107": "pin107",
+      "pin108": "GPIO5_VCC",
+      "pin109": "pin109",
+      "pin110": "pin110",
+      "pin111": "pin111",
+      "pin112": "pin112",
+      "pin113": "pin113",
+      "pin114": "pin114",
+      "pin115": "CPU_DVDD",
+      "pin116": "DVDD_7",
+      "pin117": "pin117",
+      "pin118": "pin118",
+      "pin119": "pin119",
+      "pin120": "pin120",
+      "pin121": "pin121",
+      "pin122": "pin122",
+      "pin123": "pin123",
+      "pin124": "pin124",
+      "pin125": "pin125",
+      "pin126": "pin126",
+      "pin127": "pin127",
+      "pin128": "pin128",
+      "pin129": "VSS"
+    },
+    "source_component_id": "source_component_8",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_8",
+    "text": "RV1106G2",
+    "schematic_component_id": "schematic_component_8",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -1.6,
+      "y": -6.63
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_9",
+    "text": "U1",
+    "schematic_component_id": "schematic_component_8",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -1.6,
+      "y": 6.63
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 4.645,
+      "y": -1.1599999999999997
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.85
+    },
+    "source_component_id": "source_component_9",
+    "is_box_with_pins": true,
+    "symbol_name": "crystal_right",
+    "symbol_display_value": "24MHz / 12pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": 3.6249999999999996,
+      "y": -2.6799999999999997
+    },
+    "size": {
+      "width": 0.65,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_10",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "12pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": 5.664999999999999,
+      "y": -2.6799999999999997
+    },
+    "size": {
+      "width": 0.65,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_11",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "12pF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": -16.3875,
+      "y": -18.8
+    },
+    "size": {
+      "width": 0.65,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_12",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "10kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": -10.0975,
+      "y": -23.240000000000002
+    },
+    "size": {
+      "width": 5.08,
+      "height": 5.08
+    },
+    "source_component_id": "source_component_13",
+    "is_box_with_pins": false,
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": -1.0174999999999992,
+      "y": -22.14
+    },
+    "size": {
+      "width": 5.08,
+      "height": 5.08
+    },
+    "source_component_id": "source_component_14",
+    "is_box_with_pins": false,
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 11.5,
+      "y": 4
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 1
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "CS",
+      "pin2": "DO",
+      "pin3": "IO2",
+      "pin4": "GND",
+      "pin5": "DI",
+      "pin6": "CLK",
+      "pin7": "IO3",
+      "pin8": "VCC"
+    },
+    "source_component_id": "source_component_15",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_10",
+    "text": "W25Q128JVSIQ",
+    "schematic_component_id": "schematic_component_15",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 10.9,
+      "y": 3.37
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_11",
+    "text": "U4",
+    "schematic_component_id": "schematic_component_15",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": 10.9,
+      "y": 4.63
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 11.5,
+      "y": 6.4799999999999995
+    },
+    "size": {
+      "width": 0.9,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_16",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_down",
+    "symbol_display_value": "100nF",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": -15,
+      "y": 3
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.34,
+      "height": 2.1999999999999997
+    },
+    "port_arrangement": {
+      "right_side": {
+        "direction": "top-to-bottom",
+        "pins": [
+          "pin1",
+          "pin2",
+          "pin3",
+          "pin4",
+          "pin5",
+          "pin6",
+          "pin7",
+          "pin8",
+          "pin9",
+          "pin10"
+        ]
+      }
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "GND",
+      "pin2": "3V3",
+      "pin3": "GPIO0_P125",
+      "pin4": "GPIO1_P126",
+      "pin5": "I2C_SDA_P65",
+      "pin6": "I2C_SCL_P127",
+      "pin7": "UART_TX_P122",
+      "pin8": "UART_RX_P121",
+      "pin9": "VBUS",
+      "pin10": "GND_2"
+    },
+    "source_component_id": "source_component_17",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_12",
+    "text": "",
+    "schematic_component_id": "schematic_component_17",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -15.67,
+      "y": 1.77
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_13",
+    "text": "J_DEBUG",
+    "schematic_component_id": "schematic_component_17",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -15.67,
+      "y": 4.2299999999999995
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 16.3875,
+      "y": -21.54
+    },
+    "size": {
+      "width": 0.65,
+      "height": 1.13
+    },
+    "source_component_id": "source_component_18",
+    "is_box_with_pins": true,
+    "symbol_name": "led_down",
+    "symbol_display_value": "green",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": 16.3875,
+      "y": -23.005000000000003
+    },
+    "size": {
+      "width": 0.65,
+      "height": 0.6
+    },
+    "source_component_id": "source_component_19",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_down",
+    "symbol_display_value": "1kΩ",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_0",
+    "is_subcircuit": true,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "name": "unnamed_board1",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_0",
+    "show_as_schematic_box": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_0",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -19,
+      "y": -7.3
+    },
+    "source_port_id": "source_port_0",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "EH2",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_1",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -19,
+      "y": -7.5
+    },
+    "source_port_id": "source_port_1",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "EH1",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_2",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -19,
+      "y": -7.7
+    },
+    "source_port_id": "source_port_2",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "EH4",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_3",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -19,
+      "y": -7.9
+    },
+    "source_port_id": "source_port_3",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "EH3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_4",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -19,
+      "y": -8.1
+    },
+    "source_port_id": "source_port_4",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "B8",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_5",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -19,
+      "y": -8.3
+    },
+    "source_port_id": "source_port_5",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "A5",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_6",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -19,
+      "y": -8.5
+    },
+    "source_port_id": "source_port_6",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "B7",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_7",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -19,
+      "y": -8.7
+    },
+    "source_port_id": "source_port_7",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "A6",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_8",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17,
+      "y": -8.7
+    },
+    "source_port_id": "source_port_8",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "display_pin_label": "A7",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_9",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17,
+      "y": -8.5
+    },
+    "source_port_id": "source_port_9",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "display_pin_label": "B6",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_10",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17,
+      "y": -8.3
+    },
+    "source_port_id": "source_port_10",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 11,
+    "true_ccw_index": 10,
+    "display_pin_label": "A8",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_11",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17,
+      "y": -8.1
+    },
+    "source_port_id": "source_port_11",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 12,
+    "true_ccw_index": 11,
+    "display_pin_label": "B5",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_12",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17,
+      "y": -7.9
+    },
+    "source_port_id": "source_port_12",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 13,
+    "true_ccw_index": 12,
+    "display_pin_label": "A1B12",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_13",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17,
+      "y": -7.7
+    },
+    "source_port_id": "source_port_13",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 14,
+    "true_ccw_index": 13,
+    "display_pin_label": "B1A12",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_14",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17,
+      "y": -7.5
+    },
+    "source_port_id": "source_port_14",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 15,
+    "true_ccw_index": 14,
+    "display_pin_label": "B4A9",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_15",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -17,
+      "y": -7.3
+    },
+    "source_port_id": "source_port_15",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 16,
+    "true_ccw_index": 15,
+    "display_pin_label": "A4B9",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_16",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -20.36,
+      "y": -5.989999999999999
+    },
+    "source_port_id": "source_port_16",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "top",
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_17",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -20.36,
+      "y": -6.590000000000001
+    },
+    "source_port_id": "source_port_17",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_18",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -18.48,
+      "y": -4.895
+    },
+    "source_port_id": "source_port_18",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "top",
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_19",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -18.48,
+      "y": -5.495000000000001
+    },
+    "source_port_id": "source_port_19",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_20",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -23.5,
+      "y": -7.8
+    },
+    "source_port_id": "source_port_20",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_21",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -23.5,
+      "y": -8
+    },
+    "source_port_id": "source_port_21",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_22",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -23.5,
+      "y": -8.2
+    },
+    "source_port_id": "source_port_22",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_23",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -21.5,
+      "y": -8.2
+    },
+    "source_port_id": "source_port_23",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_24",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -21.5,
+      "y": -8
+    },
+    "source_port_id": "source_port_24",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_25",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -21.5,
+      "y": -7.8
+    },
+    "source_port_id": "source_port_25",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_26",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -11,
+      "y": -7.8
+    },
+    "source_port_id": "source_port_26",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "VIN",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_27",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -11,
+      "y": -8
+    },
+    "source_port_id": "source_port_27",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "GND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_28",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -11,
+      "y": -8.2
+    },
+    "source_port_id": "source_port_28",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "EN",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_29",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -9,
+      "y": -8.1
+    },
+    "source_port_id": "source_port_29",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "NC",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_30",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -9,
+      "y": -7.9
+    },
+    "source_port_id": "source_port_30",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "VOUT",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_31",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -12.37,
+      "y": -6.547499999999999
+    },
+    "source_port_id": "source_port_31",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "top",
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_32",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -12.37,
+      "y": -7.147500000000001
+    },
+    "source_port_id": "source_port_32",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_33",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -11.129999999999999,
+      "y": -6.547499999999999
+    },
+    "source_port_id": "source_port_33",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "top",
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_34",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -11.129999999999999,
+      "y": -7.147500000000001
+    },
+    "source_port_id": "source_port_34",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_35",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 1.3525000000000014,
+      "y": -7.7
+    },
+    "source_port_id": "source_port_35",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "VIN",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_36",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 1.3525000000000014,
+      "y": -7.9
+    },
+    "source_port_id": "source_port_36",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "GND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_37",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 1.3525000000000014,
+      "y": -8.1
+    },
+    "source_port_id": "source_port_37",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "EN",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_38",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 1.3525000000000014,
+      "y": -8.3
+    },
+    "source_port_id": "source_port_38",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "VOUT_1V8",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_39",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 4.052500000000002,
+      "y": -8.3
+    },
+    "source_port_id": "source_port_39",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "VOUT_0V9",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_40",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 4.052500000000002,
+      "y": -8.1
+    },
+    "source_port_id": "source_port_40",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "VOUT_1V1",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_41",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 4.052500000000002,
+      "y": -7.9
+    },
+    "source_port_id": "source_port_41",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "FB",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_42",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 4.052500000000002,
+      "y": -7.7
+    },
+    "source_port_id": "source_port_42",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "PG",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_43",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 6.399999999999993
+    },
+    "source_port_id": "source_port_43",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_44",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 6.199999999999993
+    },
+    "source_port_id": "source_port_44",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_45",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 5.999999999999993
+    },
+    "source_port_id": "source_port_45",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_46",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 5.799999999999994
+    },
+    "source_port_id": "source_port_46",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_47",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 5.599999999999993
+    },
+    "source_port_id": "source_port_47",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_48",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 5.399999999999993
+    },
+    "source_port_id": "source_port_48",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_49",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 5.199999999999993
+    },
+    "source_port_id": "source_port_49",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_50",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 4.999999999999993
+    },
+    "source_port_id": "source_port_50",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_51",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 4.799999999999994
+    },
+    "source_port_id": "source_port_51",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_52",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 4.599999999999993
+    },
+    "source_port_id": "source_port_52",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "display_pin_label": "DVDD_1",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_53",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 4.399999999999993
+    },
+    "source_port_id": "source_port_53",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 11,
+    "true_ccw_index": 10,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_54",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 4.199999999999994
+    },
+    "source_port_id": "source_port_54",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 12,
+    "true_ccw_index": 11,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_55",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 3.9999999999999933
+    },
+    "source_port_id": "source_port_55",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 13,
+    "true_ccw_index": 12,
+    "display_pin_label": "GPIO4_VCC",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_56",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 3.799999999999993
+    },
+    "source_port_id": "source_port_56",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 14,
+    "true_ccw_index": 13,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_57",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 3.599999999999993
+    },
+    "source_port_id": "source_port_57",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 15,
+    "true_ccw_index": 14,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_58",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 3.399999999999993
+    },
+    "source_port_id": "source_port_58",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 16,
+    "true_ccw_index": 15,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_59",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 3.1999999999999926
+    },
+    "source_port_id": "source_port_59",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 17,
+    "true_ccw_index": 16,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_60",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 2.9999999999999925
+    },
+    "source_port_id": "source_port_60",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 18,
+    "true_ccw_index": 17,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_61",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 2.7999999999999923
+    },
+    "source_port_id": "source_port_61",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 19,
+    "true_ccw_index": 18,
+    "display_pin_label": "RTC_AVDD3V3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_62",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 2.599999999999992
+    },
+    "source_port_id": "source_port_62",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 20,
+    "true_ccw_index": 19,
+    "display_pin_label": "RTC_XOUT",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_63",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 2.3999999999999924
+    },
+    "source_port_id": "source_port_63",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 21,
+    "true_ccw_index": 20,
+    "display_pin_label": "RTC_XIN",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_64",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 2.199999999999992
+    },
+    "source_port_id": "source_port_64",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 22,
+    "true_ccw_index": 21,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_65",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 1.999999999999992
+    },
+    "source_port_id": "source_port_65",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 23,
+    "true_ccw_index": 22,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_66",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 1.7999999999999918
+    },
+    "source_port_id": "source_port_66",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 24,
+    "true_ccw_index": 23,
+    "display_pin_label": "SARADC_USB_AVDD1V8",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_67",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 1.5999999999999917
+    },
+    "source_port_id": "source_port_67",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 25,
+    "true_ccw_index": 24,
+    "display_pin_label": "USB_VBUSDET",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_68",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 1.3999999999999915
+    },
+    "source_port_id": "source_port_68",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 26,
+    "true_ccw_index": 25,
+    "display_pin_label": "USB_DM",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_69",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 1.1999999999999913
+    },
+    "source_port_id": "source_port_69",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 27,
+    "true_ccw_index": 26,
+    "display_pin_label": "USB_DP",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_70",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 0.9999999999999911
+    },
+    "source_port_id": "source_port_70",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 28,
+    "true_ccw_index": 27,
+    "display_pin_label": "USB_AVDD3V3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_71",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 0.7999999999999909
+    },
+    "source_port_id": "source_port_71",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 29,
+    "true_ccw_index": 28,
+    "display_pin_label": "CODEC_LINEOUT",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_72",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 0.5999999999999908
+    },
+    "source_port_id": "source_port_72",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 30,
+    "true_ccw_index": 29,
+    "display_pin_label": "CODEC_VCM",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_73",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 0.3999999999999906
+    },
+    "source_port_id": "source_port_73",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 31,
+    "true_ccw_index": 30,
+    "display_pin_label": "CODEC_AVDD1V8",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_74",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": 0.1999999999999904
+    },
+    "source_port_id": "source_port_74",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 32,
+    "true_ccw_index": 31,
+    "display_pin_label": "CODEC_MICBIAS",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_75",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -9.769962616701378e-15
+    },
+    "source_port_id": "source_port_75",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 33,
+    "true_ccw_index": 32,
+    "display_pin_label": "CODEC_MIC0N",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_76",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -0.20000000000000995
+    },
+    "source_port_id": "source_port_76",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 34,
+    "true_ccw_index": 33,
+    "display_pin_label": "CODEC_MIC0P",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_77",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -0.4000000000000101
+    },
+    "source_port_id": "source_port_77",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 35,
+    "true_ccw_index": 34,
+    "display_pin_label": "CODEC_MIC1N",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_78",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -0.6000000000000103
+    },
+    "source_port_id": "source_port_78",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 36,
+    "true_ccw_index": 35,
+    "display_pin_label": "CODEC_MIC1P",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_79",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -0.8000000000000105
+    },
+    "source_port_id": "source_port_79",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 37,
+    "true_ccw_index": 36,
+    "display_pin_label": "CODEC_AVSS",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_80",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -1.0000000000000107
+    },
+    "source_port_id": "source_port_80",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 38,
+    "true_ccw_index": 37,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_81",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -1.2000000000000108
+    },
+    "source_port_id": "source_port_81",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 39,
+    "true_ccw_index": 38,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_82",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -1.400000000000011
+    },
+    "source_port_id": "source_port_82",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 40,
+    "true_ccw_index": 39,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_83",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -1.6000000000000103
+    },
+    "source_port_id": "source_port_83",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 41,
+    "true_ccw_index": 40,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_84",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -1.8000000000000096
+    },
+    "source_port_id": "source_port_84",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 42,
+    "true_ccw_index": 41,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_85",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -2.000000000000009
+    },
+    "source_port_id": "source_port_85",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 43,
+    "true_ccw_index": 42,
+    "display_pin_label": "GPIO3_VCC",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_86",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -2.200000000000008
+    },
+    "source_port_id": "source_port_86",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 44,
+    "true_ccw_index": 43,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_87",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -2.4000000000000075
+    },
+    "source_port_id": "source_port_87",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 45,
+    "true_ccw_index": 44,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_88",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -2.6000000000000068
+    },
+    "source_port_id": "source_port_88",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 46,
+    "true_ccw_index": 45,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_89",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -2.800000000000006
+    },
+    "source_port_id": "source_port_89",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 47,
+    "true_ccw_index": 46,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_90",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -3.0000000000000053
+    },
+    "source_port_id": "source_port_90",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 48,
+    "true_ccw_index": 47,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_91",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -3.2000000000000046
+    },
+    "source_port_id": "source_port_91",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 49,
+    "true_ccw_index": 48,
+    "display_pin_label": "DDR_VDDQ_1",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_92",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -3.400000000000004
+    },
+    "source_port_id": "source_port_92",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 50,
+    "true_ccw_index": 49,
+    "display_pin_label": "DDR_VDDQ_2",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_93",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -3.600000000000003
+    },
+    "source_port_id": "source_port_93",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 51,
+    "true_ccw_index": 50,
+    "display_pin_label": "DVDD_2D",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_94",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -3.8000000000000025
+    },
+    "source_port_id": "source_port_94",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 52,
+    "true_ccw_index": 51,
+    "display_pin_label": "RAM_ZQ",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_95",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -4.000000000000002
+    },
+    "source_port_id": "source_port_95",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 53,
+    "true_ccw_index": 52,
+    "display_pin_label": "DDR_PLL_AVDD1V8",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_96",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -4.200000000000001
+    },
+    "source_port_id": "source_port_96",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 54,
+    "true_ccw_index": 53,
+    "display_pin_label": "DVDD_3",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_97",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -4.4
+    },
+    "source_port_id": "source_port_97",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 55,
+    "true_ccw_index": 54,
+    "display_pin_label": "DVDD_4",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_98",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -4.6
+    },
+    "source_port_id": "source_port_98",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 56,
+    "true_ccw_index": 55,
+    "display_pin_label": "DDR_VDDQ_3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_99",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -4.799999999999999
+    },
+    "source_port_id": "source_port_99",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 57,
+    "true_ccw_index": 56,
+    "display_pin_label": "TVSS",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_100",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -4.999999999999998
+    },
+    "source_port_id": "source_port_100",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 58,
+    "true_ccw_index": 57,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_101",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -5.1999999999999975
+    },
+    "source_port_id": "source_port_101",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 59,
+    "true_ccw_index": 58,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_102",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -5.399999999999997
+    },
+    "source_port_id": "source_port_102",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 60,
+    "true_ccw_index": 59,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_103",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -5.599999999999996
+    },
+    "source_port_id": "source_port_103",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 61,
+    "true_ccw_index": 60,
+    "display_pin_label": "PMU_VCC3V3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_104",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -5.799999999999995
+    },
+    "source_port_id": "source_port_104",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 62,
+    "true_ccw_index": 61,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_105",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -5.999999999999995
+    },
+    "source_port_id": "source_port_105",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 63,
+    "true_ccw_index": 62,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_106",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -6.199999999999994
+    },
+    "source_port_id": "source_port_106",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 64,
+    "true_ccw_index": 63,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_107",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": -2,
+      "y": -6.399999999999993
+    },
+    "source_port_id": "source_port_107",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 65,
+    "true_ccw_index": 64,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_108",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -6.299999999999994
+    },
+    "source_port_id": "source_port_108",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 66,
+    "true_ccw_index": 65,
+    "display_pin_label": "POR",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_109",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -6.099999999999993
+    },
+    "source_port_id": "source_port_109",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 67,
+    "true_ccw_index": 66,
+    "display_pin_label": "PMU_DVDD0V9",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_110",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -5.899999999999993
+    },
+    "source_port_id": "source_port_110",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 68,
+    "true_ccw_index": 67,
+    "display_pin_label": "OSC_XIN",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_111",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -5.699999999999994
+    },
+    "source_port_id": "source_port_111",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 69,
+    "true_ccw_index": 68,
+    "display_pin_label": "OSC_XOUT",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_112",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -5.499999999999994
+    },
+    "source_port_id": "source_port_112",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 70,
+    "true_ccw_index": 69,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_113",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -5.299999999999994
+    },
+    "source_port_id": "source_port_113",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 71,
+    "true_ccw_index": 70,
+    "display_pin_label": "OSC_PLL_DVDD",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_114",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -5.099999999999993
+    },
+    "source_port_id": "source_port_114",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 72,
+    "true_ccw_index": 71,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_115",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -4.899999999999993
+    },
+    "source_port_id": "source_port_115",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 73,
+    "true_ccw_index": 72,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_116",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -4.699999999999994
+    },
+    "source_port_id": "source_port_116",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 74,
+    "true_ccw_index": 73,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_117",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -4.499999999999994
+    },
+    "source_port_id": "source_port_117",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 75,
+    "true_ccw_index": 74,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_118",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -4.299999999999994
+    },
+    "source_port_id": "source_port_118",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 76,
+    "true_ccw_index": 75,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_119",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -4.099999999999994
+    },
+    "source_port_id": "source_port_119",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 77,
+    "true_ccw_index": 76,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_120",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -3.8999999999999937
+    },
+    "source_port_id": "source_port_120",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 78,
+    "true_ccw_index": 77,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_121",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -3.6999999999999935
+    },
+    "source_port_id": "source_port_121",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 79,
+    "true_ccw_index": 78,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_122",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -3.4999999999999933
+    },
+    "source_port_id": "source_port_122",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 80,
+    "true_ccw_index": 79,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_123",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -3.299999999999993
+    },
+    "source_port_id": "source_port_123",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 81,
+    "true_ccw_index": 80,
+    "display_pin_label": "GPIO1_VCC3V3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_124",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -3.099999999999993
+    },
+    "source_port_id": "source_port_124",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 82,
+    "true_ccw_index": 81,
+    "display_pin_label": "DVDD_5",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_125",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -2.899999999999993
+    },
+    "source_port_id": "source_port_125",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 83,
+    "true_ccw_index": 82,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_126",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -2.6999999999999926
+    },
+    "source_port_id": "source_port_126",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 84,
+    "true_ccw_index": 83,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_127",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -2.4999999999999925
+    },
+    "source_port_id": "source_port_127",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 85,
+    "true_ccw_index": 84,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_128",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -2.2999999999999927
+    },
+    "source_port_id": "source_port_128",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 86,
+    "true_ccw_index": 85,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_129",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -2.0999999999999925
+    },
+    "source_port_id": "source_port_129",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 87,
+    "true_ccw_index": 86,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_130",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -1.8999999999999924
+    },
+    "source_port_id": "source_port_130",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 88,
+    "true_ccw_index": 87,
+    "display_pin_label": "GPIO6_VCC",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_131",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -1.6999999999999922
+    },
+    "source_port_id": "source_port_131",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 89,
+    "true_ccw_index": 88,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_132",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -1.499999999999992
+    },
+    "source_port_id": "source_port_132",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 90,
+    "true_ccw_index": 89,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_133",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -1.2999999999999918
+    },
+    "source_port_id": "source_port_133",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 91,
+    "true_ccw_index": 90,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_134",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -1.0999999999999917
+    },
+    "source_port_id": "source_port_134",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 92,
+    "true_ccw_index": 91,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_135",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -0.8999999999999915
+    },
+    "source_port_id": "source_port_135",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 93,
+    "true_ccw_index": 92,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_136",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -0.6999999999999913
+    },
+    "source_port_id": "source_port_136",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 94,
+    "true_ccw_index": 93,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_137",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -0.4999999999999911
+    },
+    "source_port_id": "source_port_137",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 95,
+    "true_ccw_index": 94,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_138",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -0.29999999999999094
+    },
+    "source_port_id": "source_port_138",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 96,
+    "true_ccw_index": 95,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_139",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": -0.09999999999999076
+    },
+    "source_port_id": "source_port_139",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 97,
+    "true_ccw_index": 96,
+    "display_pin_label": "ETH_PHY_RXN",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_140",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 0.10000000000000941
+    },
+    "source_port_id": "source_port_140",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 98,
+    "true_ccw_index": 97,
+    "display_pin_label": "ETH_PHY_RXP",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_141",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 0.3000000000000096
+    },
+    "source_port_id": "source_port_141",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 99,
+    "true_ccw_index": 98,
+    "display_pin_label": "ETH_PHY_TXN",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_142",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 0.5000000000000098
+    },
+    "source_port_id": "source_port_142",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 100,
+    "true_ccw_index": 99,
+    "display_pin_label": "ETH_PHY_TXP",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_143",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 0.70000000000001
+    },
+    "source_port_id": "source_port_143",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 101,
+    "true_ccw_index": 100,
+    "display_pin_label": "ETH_AVDD3V3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_144",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 0.9000000000000101
+    },
+    "source_port_id": "source_port_144",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 102,
+    "true_ccw_index": 101,
+    "display_pin_label": "ETH_EXTR",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_145",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 1.1000000000000103
+    },
+    "source_port_id": "source_port_145",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 103,
+    "true_ccw_index": 102,
+    "display_pin_label": "DVDD_6",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_146",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 1.3000000000000105
+    },
+    "source_port_id": "source_port_146",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 104,
+    "true_ccw_index": 103,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_147",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 1.5000000000000107
+    },
+    "source_port_id": "source_port_147",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 105,
+    "true_ccw_index": 104,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_148",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 1.70000000000001
+    },
+    "source_port_id": "source_port_148",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 106,
+    "true_ccw_index": 105,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_149",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 1.9000000000000092
+    },
+    "source_port_id": "source_port_149",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 107,
+    "true_ccw_index": 106,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_150",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 2.1000000000000085
+    },
+    "source_port_id": "source_port_150",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 108,
+    "true_ccw_index": 107,
+    "display_pin_label": "GPIO5_VCC",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_151",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 2.300000000000008
+    },
+    "source_port_id": "source_port_151",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 109,
+    "true_ccw_index": 108,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_152",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 2.500000000000007
+    },
+    "source_port_id": "source_port_152",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 110,
+    "true_ccw_index": 109,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_153",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 2.7000000000000064
+    },
+    "source_port_id": "source_port_153",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 111,
+    "true_ccw_index": 110,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_154",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 2.9000000000000057
+    },
+    "source_port_id": "source_port_154",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 112,
+    "true_ccw_index": 111,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_155",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 3.100000000000005
+    },
+    "source_port_id": "source_port_155",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 113,
+    "true_ccw_index": 112,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_156",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 3.3000000000000043
+    },
+    "source_port_id": "source_port_156",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 114,
+    "true_ccw_index": 113,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_157",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 3.5000000000000036
+    },
+    "source_port_id": "source_port_157",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 115,
+    "true_ccw_index": 114,
+    "display_pin_label": "CPU_DVDD",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_158",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 3.700000000000003
+    },
+    "source_port_id": "source_port_158",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 116,
+    "true_ccw_index": 115,
+    "display_pin_label": "DVDD_7",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_159",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 3.900000000000002
+    },
+    "source_port_id": "source_port_159",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 117,
+    "true_ccw_index": 116,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_160",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 4.100000000000001
+    },
+    "source_port_id": "source_port_160",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 118,
+    "true_ccw_index": 117,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_161",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 4.300000000000001
+    },
+    "source_port_id": "source_port_161",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 119,
+    "true_ccw_index": 118,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_162",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 4.5
+    },
+    "source_port_id": "source_port_162",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 120,
+    "true_ccw_index": 119,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_163",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 4.699999999999999
+    },
+    "source_port_id": "source_port_163",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 121,
+    "true_ccw_index": 120,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_164",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 4.899999999999999
+    },
+    "source_port_id": "source_port_164",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 122,
+    "true_ccw_index": 121,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_165",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 5.099999999999998
+    },
+    "source_port_id": "source_port_165",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 123,
+    "true_ccw_index": 122,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_166",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 5.299999999999997
+    },
+    "source_port_id": "source_port_166",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 124,
+    "true_ccw_index": 123,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_167",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 5.4999999999999964
+    },
+    "source_port_id": "source_port_167",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 125,
+    "true_ccw_index": 124,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_168",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 5.699999999999996
+    },
+    "source_port_id": "source_port_168",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 126,
+    "true_ccw_index": 125,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_169",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 5.899999999999995
+    },
+    "source_port_id": "source_port_169",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 127,
+    "true_ccw_index": 126,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_170",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 6.099999999999994
+    },
+    "source_port_id": "source_port_170",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 128,
+    "true_ccw_index": 127,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_171",
+    "schematic_component_id": "schematic_component_8",
+    "center": {
+      "x": 2,
+      "y": 6.299999999999994
+    },
+    "source_port_id": "source_port_171",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 129,
+    "true_ccw_index": 128,
+    "display_pin_label": "VSS",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_172",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 4.095,
+      "y": -1.1599999999999997
+    },
+    "source_port_id": "source_port_172",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_173",
+    "schematic_component_id": "schematic_component_9",
+    "center": {
+      "x": 5.194999999999999,
+      "y": -1.1599999999999997
+    },
+    "source_port_id": "source_port_173",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_174",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": 3.6249999999999996,
+      "y": -2.38
+    },
+    "source_port_id": "source_port_174",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "top",
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_175",
+    "schematic_component_id": "schematic_component_10",
+    "center": {
+      "x": 3.6249999999999996,
+      "y": -2.9799999999999995
+    },
+    "source_port_id": "source_port_175",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_176",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": 5.664999999999999,
+      "y": -2.38
+    },
+    "source_port_id": "source_port_176",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "top",
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_177",
+    "schematic_component_id": "schematic_component_11",
+    "center": {
+      "x": 5.664999999999999,
+      "y": -2.9799999999999995
+    },
+    "source_port_id": "source_port_177",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_178",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": -16.3875,
+      "y": -18.5
+    },
+    "source_port_id": "source_port_178",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "top",
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_179",
+    "schematic_component_id": "schematic_component_12",
+    "center": {
+      "x": -16.3875,
+      "y": -19.1
+    },
+    "source_port_id": "source_port_179",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_180",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": -15.177499999999998,
+      "y": -20.700000000000003
+    },
+    "source_port_id": "source_port_180",
+    "facing_direction": "left",
+    "distance_from_component_edge": 2.54,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_line",
+    "schematic_line_id": "schematic_line_0",
+    "schematic_component_id": "schematic_component_13",
+    "x1": -15.177499999999998,
+    "y1": -20.700000000000003,
+    "x2": -12.6375,
+    "y2": -20.700000000000003,
+    "stroke_width": 0.02,
+    "color": "rgba(132, 0, 0)",
+    "is_dashed": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_181",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": -15.177499999999998,
+      "y": -25.78
+    },
+    "source_port_id": "source_port_181",
+    "facing_direction": "right",
+    "distance_from_component_edge": 2.54,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_line",
+    "schematic_line_id": "schematic_line_1",
+    "schematic_component_id": "schematic_component_13",
+    "x1": -15.177499999999998,
+    "y1": -25.78,
+    "x2": -12.6375,
+    "y2": -25.78,
+    "stroke_width": 0.02,
+    "color": "rgba(132, 0, 0)",
+    "is_dashed": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_182",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": -5.017499999999998,
+      "y": -20.700000000000003
+    },
+    "source_port_id": "source_port_182",
+    "facing_direction": "left",
+    "distance_from_component_edge": 2.54,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_line",
+    "schematic_line_id": "schematic_line_2",
+    "schematic_component_id": "schematic_component_13",
+    "x1": -5.017499999999998,
+    "y1": -20.700000000000003,
+    "x2": -7.557499999999999,
+    "y2": -20.700000000000003,
+    "stroke_width": 0.02,
+    "color": "rgba(132, 0, 0)",
+    "is_dashed": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_183",
+    "schematic_component_id": "schematic_component_13",
+    "center": {
+      "x": -5.017499999999998,
+      "y": -25.78
+    },
+    "source_port_id": "source_port_183",
+    "facing_direction": "right",
+    "distance_from_component_edge": 2.54,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_line",
+    "schematic_line_id": "schematic_line_3",
+    "schematic_component_id": "schematic_component_13",
+    "x1": -5.017499999999998,
+    "y1": -25.78,
+    "x2": -7.557499999999999,
+    "y2": -25.78,
+    "stroke_width": 0.02,
+    "color": "rgba(132, 0, 0)",
+    "is_dashed": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_184",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": -6.097499999999999,
+      "y": -19.6
+    },
+    "source_port_id": "source_port_184",
+    "facing_direction": "left",
+    "distance_from_component_edge": 2.54,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_line",
+    "schematic_line_id": "schematic_line_4",
+    "schematic_component_id": "schematic_component_14",
+    "x1": -6.097499999999999,
+    "y1": -19.6,
+    "x2": -3.557499999999999,
+    "y2": -19.6,
+    "stroke_width": 0.02,
+    "color": "rgba(132, 0, 0)",
+    "is_dashed": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_185",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": -6.097499999999999,
+      "y": -24.68
+    },
+    "source_port_id": "source_port_185",
+    "facing_direction": "right",
+    "distance_from_component_edge": 2.54,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_line",
+    "schematic_line_id": "schematic_line_5",
+    "schematic_component_id": "schematic_component_14",
+    "x1": -6.097499999999999,
+    "y1": -24.68,
+    "x2": -3.557499999999999,
+    "y2": -24.68,
+    "stroke_width": 0.02,
+    "color": "rgba(132, 0, 0)",
+    "is_dashed": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_186",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": 4.062500000000001,
+      "y": -19.6
+    },
+    "source_port_id": "source_port_186",
+    "facing_direction": "left",
+    "distance_from_component_edge": 2.54,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_line",
+    "schematic_line_id": "schematic_line_6",
+    "schematic_component_id": "schematic_component_14",
+    "x1": 4.062500000000001,
+    "y1": -19.6,
+    "x2": 1.5225000000000009,
+    "y2": -19.6,
+    "stroke_width": 0.02,
+    "color": "rgba(132, 0, 0)",
+    "is_dashed": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_187",
+    "schematic_component_id": "schematic_component_14",
+    "center": {
+      "x": 4.062500000000001,
+      "y": -24.68
+    },
+    "source_port_id": "source_port_187",
+    "facing_direction": "right",
+    "distance_from_component_edge": 2.54,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_line",
+    "schematic_line_id": "schematic_line_7",
+    "schematic_component_id": "schematic_component_14",
+    "x1": 4.062500000000001,
+    "y1": -24.68,
+    "x2": 1.5225000000000009,
+    "y2": -24.68,
+    "stroke_width": 0.02,
+    "color": "rgba(132, 0, 0)",
+    "is_dashed": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_188",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 10.5,
+      "y": 4.3
+    },
+    "source_port_id": "source_port_188",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "CS",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_189",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 10.5,
+      "y": 4.1
+    },
+    "source_port_id": "source_port_189",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "DO",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_190",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 10.5,
+      "y": 3.9
+    },
+    "source_port_id": "source_port_190",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "IO2",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_191",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 10.5,
+      "y": 3.7
+    },
+    "source_port_id": "source_port_191",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "GND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_192",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 12.5,
+      "y": 3.7
+    },
+    "source_port_id": "source_port_192",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "DI",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_193",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 12.5,
+      "y": 3.9
+    },
+    "source_port_id": "source_port_193",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "CLK",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_194",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 12.5,
+      "y": 4.1
+    },
+    "source_port_id": "source_port_194",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "IO3",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_195",
+    "schematic_component_id": "schematic_component_15",
+    "center": {
+      "x": 12.5,
+      "y": 4.3
+    },
+    "source_port_id": "source_port_195",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "VCC",
+    "is_connected": true,
+    "has_input_arrow": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_196",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 11.5,
+      "y": 6.779999999999999
+    },
+    "source_port_id": "source_port_196",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_197",
+    "schematic_component_id": "schematic_component_16",
+    "center": {
+      "x": 11.5,
+      "y": 6.18
+    },
+    "source_port_id": "source_port_197",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_198",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": -13.93,
+      "y": 3.9
+    },
+    "source_port_id": "source_port_198",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "display_pin_label": "GND",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_199",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": -13.93,
+      "y": 3.7
+    },
+    "source_port_id": "source_port_199",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "display_pin_label": "3V3",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_200",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": -13.93,
+      "y": 3.5
+    },
+    "source_port_id": "source_port_200",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "display_pin_label": "GPIO0_P125",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_201",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": -13.93,
+      "y": 3.3
+    },
+    "source_port_id": "source_port_201",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "display_pin_label": "GPIO1_P126",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_202",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": -13.93,
+      "y": 3.1
+    },
+    "source_port_id": "source_port_202",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "display_pin_label": "I2C_SDA_P65",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_203",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": -13.93,
+      "y": 2.9000000000000004
+    },
+    "source_port_id": "source_port_203",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "display_pin_label": "I2C_SCL_P127",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_204",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": -13.93,
+      "y": 2.7
+    },
+    "source_port_id": "source_port_204",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "UART_TX_P122",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_205",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": -13.93,
+      "y": 2.5
+    },
+    "source_port_id": "source_port_205",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "display_pin_label": "UART_RX_P121",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_206",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": -13.93,
+      "y": 2.3
+    },
+    "source_port_id": "source_port_206",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "display_pin_label": "VBUS",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_207",
+    "schematic_component_id": "schematic_component_17",
+    "center": {
+      "x": -13.93,
+      "y": 2.1
+    },
+    "source_port_id": "source_port_207",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "display_pin_label": "GND_2",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_208",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 16.3875,
+      "y": -21
+    },
+    "source_port_id": "source_port_208",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "top",
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_209",
+    "schematic_component_id": "schematic_component_18",
+    "center": {
+      "x": 16.3875,
+      "y": -22.080000000000002
+    },
+    "source_port_id": "source_port_209",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_210",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": 16.3875,
+      "y": -22.705000000000002
+    },
+    "source_port_id": "source_port_210",
+    "facing_direction": "up",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "top",
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_211",
+    "schematic_component_id": "schematic_component_19",
+    "center": {
+      "x": 16.3875,
+      "y": -23.305
+    },
+    "source_port_id": "source_port_211",
+    "facing_direction": "down",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "bottom",
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_symbol",
+    "schematic_symbol_id": "schematic_symbol_0"
+  },
+  {
+    "type": "schematic_symbol",
+    "schematic_symbol_id": "schematic_symbol_1"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_0",
+    "schematic_component_id": "schematic_component_13",
+    "schematic_symbol_id": "schematic_symbol_0",
+    "points": [
+      {
+        "x": -12.6375,
+        "y": -20.700000000000003
+      },
+      {
+        "x": -7.557499999999999,
+        "y": -20.700000000000003
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_1",
+    "schematic_component_id": "schematic_component_13",
+    "schematic_symbol_id": "schematic_symbol_0",
+    "points": [
+      {
+        "x": -7.557499999999999,
+        "y": -25.78
+      },
+      {
+        "x": -12.6375,
+        "y": -25.78
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_2",
+    "schematic_component_id": "schematic_component_13",
+    "schematic_symbol_id": "schematic_symbol_0",
+    "points": [
+      {
+        "x": -10.0975,
+        "y": -20.700000000000003
+      },
+      {
+        "x": -10.0975,
+        "y": -21.716
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_3",
+    "schematic_component_id": "schematic_component_13",
+    "schematic_symbol_id": "schematic_symbol_0",
+    "points": [
+      {
+        "x": -10.0975,
+        "y": -25.78
+      },
+      {
+        "x": -10.0975,
+        "y": -24.002000000000002
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_4",
+    "schematic_component_id": "schematic_component_13",
+    "schematic_symbol_id": "schematic_symbol_0",
+    "points": [
+      {
+        "x": -10.0975,
+        "y": -21.716
+      },
+      {
+        "x": -10.0975,
+        "y": -22.478
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_5",
+    "schematic_component_id": "schematic_component_13",
+    "schematic_symbol_id": "schematic_symbol_0",
+    "points": [
+      {
+        "x": -8.5735,
+        "y": -22.224
+      },
+      {
+        "x": -9.843499999999999,
+        "y": -24.002000000000002
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_circle",
+    "schematic_circle_id": "schematic_circle_0",
+    "schematic_component_id": "schematic_component_13",
+    "schematic_symbol_id": "schematic_symbol_0",
+    "center": {
+      "x": -10.0975,
+      "y": -24.002000000000002
+    },
+    "radius": 0.254,
+    "stroke_width": 0.254,
+    "color": "#880000",
+    "is_filled": false,
+    "is_dashed": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_circle",
+    "schematic_circle_id": "schematic_circle_1",
+    "schematic_component_id": "schematic_component_13",
+    "schematic_symbol_id": "schematic_symbol_0",
+    "center": {
+      "x": -10.0975,
+      "y": -22.478
+    },
+    "radius": 0.254,
+    "stroke_width": 0.254,
+    "color": "#880000",
+    "is_filled": false,
+    "is_dashed": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_6",
+    "schematic_component_id": "schematic_component_14",
+    "schematic_symbol_id": "schematic_symbol_1",
+    "points": [
+      {
+        "x": -3.557499999999999,
+        "y": -19.6
+      },
+      {
+        "x": 1.5225000000000009,
+        "y": -19.6
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_7",
+    "schematic_component_id": "schematic_component_14",
+    "schematic_symbol_id": "schematic_symbol_1",
+    "points": [
+      {
+        "x": 1.5225000000000009,
+        "y": -24.68
+      },
+      {
+        "x": -3.557499999999999,
+        "y": -24.68
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_8",
+    "schematic_component_id": "schematic_component_14",
+    "schematic_symbol_id": "schematic_symbol_1",
+    "points": [
+      {
+        "x": -1.0174999999999992,
+        "y": -19.6
+      },
+      {
+        "x": -1.0174999999999992,
+        "y": -20.616
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_9",
+    "schematic_component_id": "schematic_component_14",
+    "schematic_symbol_id": "schematic_symbol_1",
+    "points": [
+      {
+        "x": -1.0174999999999992,
+        "y": -24.68
+      },
+      {
+        "x": -1.0174999999999992,
+        "y": -22.902
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_10",
+    "schematic_component_id": "schematic_component_14",
+    "schematic_symbol_id": "schematic_symbol_1",
+    "points": [
+      {
+        "x": -1.0174999999999992,
+        "y": -20.616
+      },
+      {
+        "x": -1.0174999999999992,
+        "y": -21.378
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_path",
+    "schematic_path_id": "schematic_path_11",
+    "schematic_component_id": "schematic_component_14",
+    "schematic_symbol_id": "schematic_symbol_1",
+    "points": [
+      {
+        "x": 0.5065000000000008,
+        "y": -21.124000000000002
+      },
+      {
+        "x": -0.7634999999999992,
+        "y": -22.902
+      }
+    ],
+    "is_filled": false,
+    "is_dashed": false,
+    "stroke_color": "#880000",
+    "stroke_width": 0.254,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_circle",
+    "schematic_circle_id": "schematic_circle_2",
+    "schematic_component_id": "schematic_component_14",
+    "schematic_symbol_id": "schematic_symbol_1",
+    "center": {
+      "x": -1.0174999999999992,
+      "y": -22.902
+    },
+    "radius": 0.254,
+    "stroke_width": 0.254,
+    "color": "#880000",
+    "is_filled": false,
+    "is_dashed": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_circle",
+    "schematic_circle_id": "schematic_circle_3",
+    "schematic_component_id": "schematic_component_14",
+    "schematic_symbol_id": "schematic_symbol_1",
+    "center": {
+      "x": -1.0174999999999992,
+      "y": -21.378
+    },
+    "radius": 0.254,
+    "stroke_width": 0.254,
+    "color": "#880000",
+    "is_filled": false,
+    "is_dashed": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_0",
+    "source_trace_id": "schematic_port_1-schematic_port_0",
+    "edges": [
+      {
+        "from": {
+          "x": -19,
+          "y": -7.5
+        },
+        "to": {
+          "x": -19.2,
+          "y": -7.5
+        }
+      },
+      {
+        "from": {
+          "x": -19.2,
+          "y": -7.5
+        },
+        "to": {
+          "x": -19.2,
+          "y": -7.3
+        }
+      },
+      {
+        "from": {
+          "x": -19.2,
+          "y": -7.3
+        },
+        "to": {
+          "x": -19,
+          "y": -7.3
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -19.2,
+        "y": -7.5
+      },
+      {
+        "x": -19.2,
+        "y": -7.3
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_1",
+    "source_trace_id": "schematic_port_2-schematic_port_1",
+    "edges": [
+      {
+        "from": {
+          "x": -19,
+          "y": -7.7
+        },
+        "to": {
+          "x": -19.2,
+          "y": -7.7
+        }
+      },
+      {
+        "from": {
+          "x": -19.2,
+          "y": -7.7
+        },
+        "to": {
+          "x": -19.2,
+          "y": -7.5
+        }
+      },
+      {
+        "from": {
+          "x": -19.2,
+          "y": -7.5
+        },
+        "to": {
+          "x": -19,
+          "y": -7.5
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -19.2,
+        "y": -7.5
+      },
+      {
+        "x": -19.2,
+        "y": -7.7
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_2",
+    "source_trace_id": "schematic_port_3-schematic_port_2",
+    "edges": [
+      {
+        "from": {
+          "x": -19,
+          "y": -7.9
+        },
+        "to": {
+          "x": -19.2,
+          "y": -7.9
+        }
+      },
+      {
+        "from": {
+          "x": -19.2,
+          "y": -7.9
+        },
+        "to": {
+          "x": -19.2,
+          "y": -7.7
+        }
+      },
+      {
+        "from": {
+          "x": -19.2,
+          "y": -7.7
+        },
+        "to": {
+          "x": -19,
+          "y": -7.7
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -19.2,
+        "y": -7.7
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_3",
+    "source_trace_id": "schematic_port_17-schematic_port_0",
+    "edges": [
+      {
+        "from": {
+          "x": -20.36,
+          "y": -6.590000000000001
+        },
+        "to": {
+          "x": -20.36,
+          "y": -7.300000000000002
+        }
+      },
+      {
+        "from": {
+          "x": -20.36,
+          "y": -7.300000000000002
+        },
+        "to": {
+          "x": -19,
+          "y": -7.300000000000002
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -19.2,
+        "y": -7.3
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_4",
+    "source_trace_id": "schematic_port_19-schematic_port_0",
+    "edges": [
+      {
+        "from": {
+          "x": -18.48,
+          "y": -5.495000000000001
+        },
+        "to": {
+          "x": -18.48,
+          "y": -6.397500000000001
+        }
+      },
+      {
+        "from": {
+          "x": -18.48,
+          "y": -6.397500000000001
+        },
+        "to": {
+          "x": -19.2,
+          "y": -6.397500000000001
+        }
+      },
+      {
+        "from": {
+          "x": -19.2,
+          "y": -6.397500000000001
+        },
+        "to": {
+          "x": -19.2,
+          "y": -7.3
+        }
+      },
+      {
+        "from": {
+          "x": -19.2,
+          "y": -7.3
+        },
+        "to": {
+          "x": -19,
+          "y": -7.3
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -19.2,
+        "y": -7.3
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_5",
+    "source_trace_id": "schematic_port_177-schematic_port_175",
+    "edges": [
+      {
+        "from": {
+          "x": 5.664999999999999,
+          "y": -2.9799999999999995
+        },
+        "to": {
+          "x": 5.664999999999999,
+          "y": -3.06
+        }
+      },
+      {
+        "from": {
+          "x": 5.664999999999999,
+          "y": -3.06
+        },
+        "to": {
+          "x": 5.664999999999999,
+          "y": -3.2600000000000002
+        }
+      },
+      {
+        "from": {
+          "x": 5.664999999999999,
+          "y": -3.2600000000000002
+        },
+        "to": {
+          "x": 3.6249999999999996,
+          "y": -3.2600000000000002
+        }
+      },
+      {
+        "from": {
+          "x": 3.6249999999999996,
+          "y": -3.2600000000000002
+        },
+        "to": {
+          "x": 3.6249999999999996,
+          "y": -3.06
+        }
+      },
+      {
+        "from": {
+          "x": 3.6249999999999996,
+          "y": -3.06
+        },
+        "to": {
+          "x": 3.6249999999999996,
+          "y": -2.9799999999999995
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_6",
+    "source_trace_id": "schematic_port_34-schematic_port_27",
+    "edges": [
+      {
+        "from": {
+          "x": -11.129999999999999,
+          "y": -7.147500000000001
+        },
+        "to": {
+          "x": -11.129999999999999,
+          "y": -7.2275
+        }
+      },
+      {
+        "from": {
+          "x": -11.129999999999999,
+          "y": -7.2275
+        },
+        "to": {
+          "x": -11.129999999999999,
+          "y": -8
+        }
+      },
+      {
+        "from": {
+          "x": -11.129999999999999,
+          "y": -8
+        },
+        "to": {
+          "x": -11,
+          "y": -8
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -11.129999999999999,
+        "y": -7.427499999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_7",
+    "source_trace_id": "schematic_port_32-schematic_port_34",
+    "edges": [
+      {
+        "from": {
+          "x": -12.37,
+          "y": -7.147500000000001
+        },
+        "to": {
+          "x": -12.37,
+          "y": -7.2275
+        }
+      },
+      {
+        "from": {
+          "x": -12.37,
+          "y": -7.2275
+        },
+        "to": {
+          "x": -12.37,
+          "y": -7.427499999999999
+        }
+      },
+      {
+        "from": {
+          "x": -12.37,
+          "y": -7.427499999999999
+        },
+        "to": {
+          "x": -11.129999999999999,
+          "y": -7.427499999999999
+        }
+      },
+      {
+        "from": {
+          "x": -11.129999999999999,
+          "y": -7.427499999999999
+        },
+        "to": {
+          "x": -11.129999999999999,
+          "y": -7.2275
+        }
+      },
+      {
+        "from": {
+          "x": -11.129999999999999,
+          "y": -7.2275
+        },
+        "to": {
+          "x": -11.129999999999999,
+          "y": -7.147500000000001
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -11.129999999999999,
+        "y": -7.427499999999999
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_8",
+    "source_trace_id": "schematic_port_28-schematic_port_26",
+    "edges": [
+      {
+        "from": {
+          "x": -11,
+          "y": -8.2
+        },
+        "to": {
+          "x": -11.2,
+          "y": -8.2
+        }
+      },
+      {
+        "from": {
+          "x": -11.2,
+          "y": -8.2
+        },
+        "to": {
+          "x": -11.2,
+          "y": -7.8
+        }
+      },
+      {
+        "from": {
+          "x": -11.2,
+          "y": -7.8
+        },
+        "to": {
+          "x": -11.167499999999999,
+          "y": -7.8
+        }
+      },
+      {
+        "from": {
+          "x": -11.167499999999999,
+          "y": -7.8
+        },
+        "to": {
+          "x": -11.0925,
+          "y": -7.8
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -11.0925,
+          "y": -7.8
+        },
+        "to": {
+          "x": -11,
+          "y": -7.8
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -11.2,
+        "y": -7.8
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_9",
+    "source_trace_id": "schematic_port_150-schematic_port_143",
+    "edges": [
+      {
+        "from": {
+          "x": 2,
+          "y": 2.1000000000000085
+        },
+        "to": {
+          "x": 2.1,
+          "y": 2.1000000000000085
+        }
+      },
+      {
+        "from": {
+          "x": 2.1,
+          "y": 2.1000000000000085
+        },
+        "to": {
+          "x": 2.1,
+          "y": 0.70000000000001
+        }
+      },
+      {
+        "from": {
+          "x": 2.1,
+          "y": 0.70000000000001
+        },
+        "to": {
+          "x": 2,
+          "y": 0.70000000000001
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 2.1,
+        "y": 2.1000000000000085
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_10",
+    "source_trace_id": "schematic_port_61-schematic_port_55",
+    "edges": [
+      {
+        "from": {
+          "x": -2,
+          "y": 2.7999999999999923
+        },
+        "to": {
+          "x": -2.2,
+          "y": 2.7999999999999923
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": 2.7999999999999923
+        },
+        "to": {
+          "x": -2.2,
+          "y": 3.9999999999999933
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": 3.9999999999999933
+        },
+        "to": {
+          "x": -2,
+          "y": 3.9999999999999933
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -2.2,
+        "y": 2.7999999999999923
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_11",
+    "source_trace_id": "schematic_port_145-schematic_port_138",
+    "edges": [
+      {
+        "from": {
+          "x": 2,
+          "y": 1.1000000000000103
+        },
+        "to": {
+          "x": 2.0625,
+          "y": 1.1000000000000103
+        }
+      },
+      {
+        "from": {
+          "x": 2.0625,
+          "y": 1.1000000000000103
+        },
+        "to": {
+          "x": 2.1375,
+          "y": 1.1000000000000103
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 2.1375,
+          "y": 1.1000000000000103
+        },
+        "to": {
+          "x": 2.3000000000000003,
+          "y": 1.1000000000000103
+        }
+      },
+      {
+        "from": {
+          "x": 2.3000000000000003,
+          "y": 1.1000000000000103
+        },
+        "to": {
+          "x": 2.3000000000000003,
+          "y": -0.29999999999999094
+        }
+      },
+      {
+        "from": {
+          "x": 2.3000000000000003,
+          "y": -0.29999999999999094
+        },
+        "to": {
+          "x": 2,
+          "y": -0.29999999999999094
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 2.3000000000000003,
+        "y": 1.1000000000000103
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_12",
+    "source_trace_id": "schematic_port_92-schematic_port_91",
+    "edges": [
+      {
+        "from": {
+          "x": -2,
+          "y": -3.400000000000004
+        },
+        "to": {
+          "x": -2.2,
+          "y": -3.400000000000004
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": -3.400000000000004
+        },
+        "to": {
+          "x": -2.2,
+          "y": -3.2000000000000046
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": -3.2000000000000046
+        },
+        "to": {
+          "x": -2,
+          "y": -3.2000000000000046
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -2.2,
+        "y": -3.400000000000004
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_13",
+    "source_trace_id": "schematic_port_95-schematic_port_92",
+    "edges": [
+      {
+        "from": {
+          "x": -2,
+          "y": -4.000000000000002
+        },
+        "to": {
+          "x": -2.2,
+          "y": -4.000000000000002
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": -4.000000000000002
+        },
+        "to": {
+          "x": -2.2,
+          "y": -3.400000000000004
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": -3.400000000000004
+        },
+        "to": {
+          "x": -2,
+          "y": -3.400000000000004
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -2.2,
+        "y": -3.400000000000004
+      },
+      {
+        "x": -2.2,
+        "y": -4.000000000000002
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_14",
+    "source_trace_id": "schematic_port_98-schematic_port_95",
+    "edges": [
+      {
+        "from": {
+          "x": -2,
+          "y": -4.6
+        },
+        "to": {
+          "x": -2.2,
+          "y": -4.6
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": -4.6
+        },
+        "to": {
+          "x": -2.2,
+          "y": -4.000000000000002
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": -4.000000000000002
+        },
+        "to": {
+          "x": -2,
+          "y": -4.000000000000002
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -2.2,
+        "y": -4.000000000000002
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_15",
+    "source_trace_id": "schematic_port_174-schematic_port_172",
+    "edges": [
+      {
+        "from": {
+          "x": 3.6249999999999996,
+          "y": -2.38
+        },
+        "to": {
+          "x": 3.6249999999999996,
+          "y": -2.2999999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 3.6249999999999996,
+          "y": -2.2999999999999994
+        },
+        "to": {
+          "x": 3.6249999999999996,
+          "y": -1.1600000000000001
+        }
+      },
+      {
+        "from": {
+          "x": 3.6249999999999996,
+          "y": -1.1600000000000001
+        },
+        "to": {
+          "x": 3.915,
+          "y": -1.1600000000000001
+        }
+      },
+      {
+        "from": {
+          "x": 3.915,
+          "y": -1.1600000000000001
+        },
+        "to": {
+          "x": 4.095,
+          "y": -1.1599999999999997
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net14"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_16",
+    "source_trace_id": "schematic_port_176-schematic_port_173",
+    "edges": [
+      {
+        "from": {
+          "x": 5.664999999999999,
+          "y": -2.38
+        },
+        "to": {
+          "x": 5.664999999999999,
+          "y": -2.2999999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 5.664999999999999,
+          "y": -2.2999999999999994
+        },
+        "to": {
+          "x": 5.664999999999999,
+          "y": -1.1599999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 5.664999999999999,
+          "y": -1.1599999999999997
+        },
+        "to": {
+          "x": 5.374999999999999,
+          "y": -1.1599999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 5.374999999999999,
+          "y": -1.1599999999999997
+        },
+        "to": {
+          "x": 5.194999999999999,
+          "y": -1.1599999999999997
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_17",
+    "source_trace_id": "schematic_port_209-schematic_port_210",
+    "edges": [
+      {
+        "from": {
+          "x": 16.3875,
+          "y": -22.080000000000002
+        },
+        "to": {
+          "x": 16.3875,
+          "y": -22.105
+        }
+      },
+      {
+        "from": {
+          "x": 16.3875,
+          "y": -22.105
+        },
+        "to": {
+          "x": 16.3875,
+          "y": -22.705000000000002
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net29"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_18",
+    "source_trace_id": "schematic_port_181-schematic_port_183",
+    "edges": [
+      {
+        "from": {
+          "x": -15.177499999999998,
+          "y": -25.78
+        },
+        "to": {
+          "x": -15.177499999999998,
+          "y": -25.98
+        }
+      },
+      {
+        "from": {
+          "x": -15.177499999999998,
+          "y": -25.98
+        },
+        "to": {
+          "x": -5.017500000000002,
+          "y": -25.98
+        }
+      },
+      {
+        "from": {
+          "x": -5.017500000000002,
+          "y": -25.98
+        },
+        "to": {
+          "x": -5.017500000000002,
+          "y": -25.78
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_19",
+    "source_trace_id": "schematic_port_30-schematic_port_33",
+    "edges": [
+      {
+        "from": {
+          "x": -9,
+          "y": -7.900000000000001
+        },
+        "to": {
+          "x": -8.8,
+          "y": -7.900000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -8.8,
+          "y": -7.900000000000001
+        },
+        "to": {
+          "x": -8.8,
+          "y": -6.267500000000001
+        }
+      },
+      {
+        "from": {
+          "x": -8.8,
+          "y": -6.267500000000001
+        },
+        "to": {
+          "x": -11.129999999999999,
+          "y": -6.267500000000001
+        }
+      },
+      {
+        "from": {
+          "x": -11.129999999999999,
+          "y": -6.267500000000001
+        },
+        "to": {
+          "x": -11.129999999999999,
+          "y": -6.4675
+        }
+      },
+      {
+        "from": {
+          "x": -11.129999999999999,
+          "y": -6.4675
+        },
+        "to": {
+          "x": -11.129999999999999,
+          "y": -6.547499999999999
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_20",
+    "source_trace_id": "schematic_port_195-schematic_port_196",
+    "edges": [
+      {
+        "from": {
+          "x": 12.5,
+          "y": 4.300000000000001
+        },
+        "to": {
+          "x": 12.7,
+          "y": 4.300000000000001
+        }
+      },
+      {
+        "from": {
+          "x": 12.7,
+          "y": 4.300000000000001
+        },
+        "to": {
+          "x": 12.7,
+          "y": 7.059999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 12.7,
+          "y": 7.059999999999999
+        },
+        "to": {
+          "x": 11.5,
+          "y": 7.059999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 11.5,
+          "y": 7.059999999999999
+        },
+        "to": {
+          "x": 11.5,
+          "y": 6.859999999999999
+        }
+      },
+      {
+        "from": {
+          "x": 11.5,
+          "y": 6.859999999999999
+        },
+        "to": {
+          "x": 11.5,
+          "y": 6.779999999999999
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_21",
+    "source_trace_id": "schematic_port_179-schematic_port_180",
+    "edges": [
+      {
+        "from": {
+          "x": -16.3875,
+          "y": -19.1
+        },
+        "to": {
+          "x": -16.3875,
+          "y": -19.900000000000002
+        }
+      },
+      {
+        "from": {
+          "x": -16.3875,
+          "y": -19.900000000000002
+        },
+        "to": {
+          "x": -15.177499999999998,
+          "y": -19.900000000000002
+        }
+      },
+      {
+        "from": {
+          "x": -15.177499999999998,
+          "y": -19.900000000000002
+        },
+        "to": {
+          "x": -15.177499999999998,
+          "y": -20.700000000000003
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_22",
+    "source_trace_id": "schematic_port_13-schematic_port_12",
+    "edges": [
+      {
+        "from": {
+          "x": -17,
+          "y": -7.7
+        },
+        "to": {
+          "x": -16.900000000000002,
+          "y": -7.7
+        }
+      },
+      {
+        "from": {
+          "x": -16.900000000000002,
+          "y": -7.7
+        },
+        "to": {
+          "x": -16.900000000000002,
+          "y": -7.9
+        }
+      },
+      {
+        "from": {
+          "x": -16.900000000000002,
+          "y": -7.9
+        },
+        "to": {
+          "x": -17,
+          "y": -7.9
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_23",
+    "source_trace_id": "schematic_port_207-schematic_port_198",
+    "edges": [
+      {
+        "from": {
+          "x": -13.93,
+          "y": 2.1
+        },
+        "to": {
+          "x": -12.749,
+          "y": 2.0999999999999996
+        }
+      },
+      {
+        "from": {
+          "x": -12.749,
+          "y": 2.0999999999999996
+        },
+        "to": {
+          "x": -12.749,
+          "y": 3.9000000000000004
+        }
+      },
+      {
+        "from": {
+          "x": -12.749,
+          "y": 3.9000000000000004
+        },
+        "to": {
+          "x": -13.4115,
+          "y": 3.9
+        }
+      },
+      {
+        "from": {
+          "x": -13.4115,
+          "y": 3.9
+        },
+        "to": {
+          "x": -13.486500000000001,
+          "y": 3.9
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -13.486500000000001,
+          "y": 3.9
+        },
+        "to": {
+          "x": -13.93,
+          "y": 3.9
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_24",
+    "source_trace_id": "schematic_port_15-schematic_port_14",
+    "edges": [
+      {
+        "from": {
+          "x": -17,
+          "y": -7.3
+        },
+        "to": {
+          "x": -16.900000000000002,
+          "y": -7.3
+        }
+      },
+      {
+        "from": {
+          "x": -16.900000000000002,
+          "y": -7.3
+        },
+        "to": {
+          "x": -16.900000000000002,
+          "y": -7.5
+        }
+      },
+      {
+        "from": {
+          "x": -16.900000000000002,
+          "y": -7.5
+        },
+        "to": {
+          "x": -17,
+          "y": -7.5
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -16.900000000000002,
+        "y": -7.3
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_25",
+    "source_trace_id": "schematic_port_130-schematic_port_123",
+    "edges": [
+      {
+        "from": {
+          "x": 2,
+          "y": -1.8999999999999924
+        },
+        "to": {
+          "x": 2.521,
+          "y": -1.8999999999999924
+        }
+      },
+      {
+        "from": {
+          "x": 2.521,
+          "y": -1.8999999999999924
+        },
+        "to": {
+          "x": 2.521,
+          "y": -3.299999999999993
+        }
+      },
+      {
+        "from": {
+          "x": 2.521,
+          "y": -3.299999999999993
+        },
+        "to": {
+          "x": 2,
+          "y": -3.299999999999993
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_26",
+    "source_trace_id": "schematic_port_70-schematic_port_61",
+    "edges": [
+      {
+        "from": {
+          "x": -2,
+          "y": 0.9999999999999911
+        },
+        "to": {
+          "x": -2.2,
+          "y": 0.9999999999999911
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": 0.9999999999999911
+        },
+        "to": {
+          "x": -2.2,
+          "y": 0.6999999999999912
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": 0.6999999999999912
+        },
+        "to": {
+          "x": -3.721,
+          "y": 0.6999999999999912
+        }
+      },
+      {
+        "from": {
+          "x": -3.721,
+          "y": 0.6999999999999912
+        },
+        "to": {
+          "x": -3.721,
+          "y": 1.8999999999999915
+        }
+      },
+      {
+        "from": {
+          "x": -3.721,
+          "y": 1.8999999999999915
+        },
+        "to": {
+          "x": -3.3609999999999998,
+          "y": 1.8999999999999915
+        }
+      },
+      {
+        "from": {
+          "x": -3.3609999999999998,
+          "y": 1.8999999999999915
+        },
+        "to": {
+          "x": -3.3609999999999998,
+          "y": 1.750999999999992
+        }
+      },
+      {
+        "from": {
+          "x": -3.3609999999999998,
+          "y": 1.750999999999992
+        },
+        "to": {
+          "x": -3.2935,
+          "y": 1.750999999999992
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -3.2935,
+          "y": 1.750999999999992
+        },
+        "to": {
+          "x": -2.2009999999999996,
+          "y": 1.750999999999992
+        }
+      },
+      {
+        "from": {
+          "x": -2.2009999999999996,
+          "y": 1.750999999999992
+        },
+        "to": {
+          "x": -2.2009999999999996,
+          "y": 1.8999999999999915
+        }
+      },
+      {
+        "from": {
+          "x": -2.2009999999999996,
+          "y": 1.8999999999999915
+        },
+        "to": {
+          "x": -2.2,
+          "y": 1.8999999999999915
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": 1.8999999999999915
+        },
+        "to": {
+          "x": -2.2,
+          "y": 2.7999999999999923
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": 2.7999999999999923
+        },
+        "to": {
+          "x": -2,
+          "y": 2.7999999999999923
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -2.2,
+        "y": 2.7999999999999923
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_27",
+    "source_trace_id": "schematic_port_113-schematic_port_109",
+    "edges": [
+      {
+        "from": {
+          "x": 2,
+          "y": -5.299999999999994
+        },
+        "to": {
+          "x": 2.2,
+          "y": -5.299999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 2.2,
+          "y": -5.299999999999994
+        },
+        "to": {
+          "x": 2.2,
+          "y": -5.199999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 2.2,
+          "y": -5.199999999999994
+        },
+        "to": {
+          "x": 3.0009999999999994,
+          "y": -5.199999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 3.0009999999999994,
+          "y": -5.199999999999994
+        },
+        "to": {
+          "x": 3.0009999999999994,
+          "y": -6.099999999999993
+        }
+      },
+      {
+        "from": {
+          "x": 3.0009999999999994,
+          "y": -6.099999999999993
+        },
+        "to": {
+          "x": 2,
+          "y": -6.099999999999993
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 2.2,
+        "y": -5.299999999999994
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_28",
+    "source_trace_id": "schematic_port_191-schematic_port_197",
+    "edges": [
+      {
+        "from": {
+          "x": 10.5,
+          "y": 3.7
+        },
+        "to": {
+          "x": 9.319,
+          "y": 3.6999999999999997
+        }
+      },
+      {
+        "from": {
+          "x": 9.319,
+          "y": 3.6999999999999997
+        },
+        "to": {
+          "x": 9.319,
+          "y": 4.9
+        }
+      },
+      {
+        "from": {
+          "x": 9.319,
+          "y": 4.9
+        },
+        "to": {
+          "x": 11.5,
+          "y": 4.9
+        }
+      },
+      {
+        "from": {
+          "x": 11.5,
+          "y": 4.9
+        },
+        "to": {
+          "x": 11.5,
+          "y": 6.1
+        }
+      },
+      {
+        "from": {
+          "x": 11.5,
+          "y": 6.1
+        },
+        "to": {
+          "x": 11.5,
+          "y": 6.18
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_29",
+    "source_trace_id": "schematic_port_6-schematic_port_20",
+    "edges": [
+      {
+        "from": {
+          "x": -19,
+          "y": -8.5
+        },
+        "to": {
+          "x": -23.7,
+          "y": -8.5
+        }
+      },
+      {
+        "from": {
+          "x": -23.7,
+          "y": -8.5
+        },
+        "to": {
+          "x": -23.7,
+          "y": -7.8
+        }
+      },
+      {
+        "from": {
+          "x": -23.7,
+          "y": -7.8
+        },
+        "to": {
+          "x": -23.5,
+          "y": -7.8
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_30",
+    "source_trace_id": "schematic_port_52-schematic_port_158",
+    "edges": [
+      {
+        "from": {
+          "x": -2,
+          "y": 4.599999999999993
+        },
+        "to": {
+          "x": -2.2,
+          "y": 4.599999999999993
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": 4.599999999999993
+        },
+        "to": {
+          "x": -2.2,
+          "y": 6.799999999999994
+        }
+      },
+      {
+        "from": {
+          "x": -2.2,
+          "y": 6.799999999999994
+        },
+        "to": {
+          "x": 3.481,
+          "y": 6.799999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 3.481,
+          "y": 6.799999999999994
+        },
+        "to": {
+          "x": 3.481,
+          "y": 3.700000000000003
+        }
+      },
+      {
+        "from": {
+          "x": 3.481,
+          "y": 3.700000000000003
+        },
+        "to": {
+          "x": 2,
+          "y": 3.700000000000003
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_31",
+    "source_trace_id": "available-net-orientation-2-GND",
+    "edges": [
+      {
+        "from": {
+          "x": -23.5,
+          "y": -8
+        },
+        "to": {
+          "x": -23.6625,
+          "y": -8
+        }
+      },
+      {
+        "from": {
+          "x": -23.6625,
+          "y": -8
+        },
+        "to": {
+          "x": -23.7375,
+          "y": -8
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -23.7375,
+          "y": -8
+        },
+        "to": {
+          "x": -24.541,
+          "y": -8
+        }
+      },
+      {
+        "from": {
+          "x": -24.541,
+          "y": -8
+        },
+        "to": {
+          "x": -24.541,
+          "y": -8.600999999999999
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_32",
+    "source_trace_id": "available-net-orientation-4-GND",
+    "edges": [
+      {
+        "from": {
+          "x": 1.352500000000001,
+          "y": -7.9
+        },
+        "to": {
+          "x": 0.9115000000000011,
+          "y": -7.9
+        }
+      },
+      {
+        "from": {
+          "x": 0.9115000000000011,
+          "y": -7.9
+        },
+        "to": {
+          "x": 0.9115000000000011,
+          "y": -8.401
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_33",
+    "source_trace_id": "available-net-orientation-5-GND",
+    "edges": [
+      {
+        "from": {
+          "x": 2,
+          "y": 6.299999999999994
+        },
+        "to": {
+          "x": 3.091,
+          "y": 6.299999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 3.091,
+          "y": 6.299999999999994
+        },
+        "to": {
+          "x": 3.091,
+          "y": 5.798999999999993
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_34",
+    "source_trace_id": "available-net-orientation-14-USB_CC1",
+    "edges": [
+      {
+        "from": {
+          "x": -20.36,
+          "y": -5.989999999999999
+        },
+        "to": {
+          "x": -20.36,
+          "y": -5.888999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -20.36,
+          "y": -5.888999999999999
+        },
+        "to": {
+          "x": -20.711000000000002,
+          "y": -5.888999999999999
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net0"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_35",
+    "source_trace_id": "available-net-orientation-21-USB_CC2",
+    "edges": [
+      {
+        "from": {
+          "x": -18.48,
+          "y": -4.895
+        },
+        "to": {
+          "x": -18.48,
+          "y": -4.794
+        }
+      },
+      {
+        "from": {
+          "x": -18.48,
+          "y": -4.794
+        },
+        "to": {
+          "x": -18.831000000000003,
+          "y": -4.794
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_36",
+    "source_trace_id": "available-net-orientation-22-VBUS_5V",
+    "edges": [
+      {
+        "from": {
+          "x": -16.900000000000002,
+          "y": -7.3
+        },
+        "to": {
+          "x": -16.37,
+          "y": -7.3
+        }
+      },
+      {
+        "from": {
+          "x": -16.37,
+          "y": -7.3
+        },
+        "to": {
+          "x": -16.37,
+          "y": -7.2989999999999995
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -16.900000000000002,
+        "y": -7.3
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_37",
+    "source_trace_id": "available-net-orientation-45-VCC_1V8",
+    "edges": [
+      {
+        "from": {
+          "x": -2,
+          "y": 1.7999999999999918
+        },
+        "to": {
+          "x": -2.1635,
+          "y": 1.7999999999999918
+        }
+      },
+      {
+        "from": {
+          "x": -2.1635,
+          "y": 1.7999999999999918
+        },
+        "to": {
+          "x": -2.2385,
+          "y": 1.7999999999999918
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -2.2385,
+          "y": 1.7999999999999918
+        },
+        "to": {
+          "x": -2.7809999999999997,
+          "y": 1.7999999999999918
+        }
+      },
+      {
+        "from": {
+          "x": -2.7809999999999997,
+          "y": 1.7999999999999918
+        },
+        "to": {
+          "x": -2.7809999999999997,
+          "y": 1.8509999999999918
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_38",
+    "source_trace_id": "available-net-orientation-54-VBUS_DET",
+    "edges": [
+      {
+        "from": {
+          "x": -2,
+          "y": 1.5999999999999917
+        },
+        "to": {
+          "x": -3.331,
+          "y": 1.5999999999999917
+        }
+      },
+      {
+        "from": {
+          "x": -3.331,
+          "y": 1.5999999999999917
+        },
+        "to": {
+          "x": -3.331,
+          "y": 2.3009999999999917
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net12"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_39",
+    "source_trace_id": "available-net-orientation-27-VBUS_5V",
+    "edges": [
+      {
+        "from": {
+          "x": -13.93,
+          "y": 2.3
+        },
+        "to": {
+          "x": -12.7865,
+          "y": 2.3
+        }
+      },
+      {
+        "from": {
+          "x": -12.7865,
+          "y": 2.3
+        },
+        "to": {
+          "x": -12.7115,
+          "y": 2.3
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": -12.7115,
+          "y": 2.3
+        },
+        "to": {
+          "x": -12.149,
+          "y": 2.3
+        }
+      },
+      {
+        "from": {
+          "x": -12.149,
+          "y": 2.3
+        },
+        "to": {
+          "x": -12.149,
+          "y": 2.3509999999999995
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_40",
+    "source_trace_id": "available-net-orientation-34-VCC_3V3",
+    "edges": [
+      {
+        "from": {
+          "x": -2.2,
+          "y": 2.7999999999999923
+        },
+        "to": {
+          "x": -3.9000000000000012,
+          "y": 2.7999999999999923
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -2.2,
+        "y": 2.7999999999999923
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_41",
+    "source_trace_id": "available-net-orientation-35-VCC_3V3",
+    "edges": [
+      {
+        "from": {
+          "x": -2,
+          "y": -2.000000000000009
+        },
+        "to": {
+          "x": -3.5810000000000004,
+          "y": -2.000000000000009
+        }
+      },
+      {
+        "from": {
+          "x": -3.5810000000000004,
+          "y": -2.000000000000009
+        },
+        "to": {
+          "x": -3.5810000000000004,
+          "y": -1.949000000000009
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_42",
+    "source_trace_id": "available-net-orientation-46-VCC_1V8",
+    "edges": [
+      {
+        "from": {
+          "x": -2.2,
+          "y": -3.400000000000004
+        },
+        "to": {
+          "x": -3.6000000000000005,
+          "y": -3.400000000000004
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -2.2,
+        "y": -3.400000000000004
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_43",
+    "source_trace_id": "available-net-orientation-36-VCC_3V3",
+    "edges": [
+      {
+        "from": {
+          "x": -2,
+          "y": -5.599999999999996
+        },
+        "to": {
+          "x": -2.5309999999999997,
+          "y": -5.599999999999996
+        }
+      },
+      {
+        "from": {
+          "x": -2.5309999999999997,
+          "y": -5.599999999999996
+        },
+        "to": {
+          "x": -2.5309999999999997,
+          "y": -5.548999999999996
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_44",
+    "source_trace_id": "available-net-orientation-38-VCC_3V3",
+    "edges": [
+      {
+        "from": {
+          "x": 2.1,
+          "y": 2.1000000000000085
+        },
+        "to": {
+          "x": 2.63,
+          "y": 2.1000000000000085
+        }
+      },
+      {
+        "from": {
+          "x": 2.63,
+          "y": 2.1000000000000085
+        },
+        "to": {
+          "x": 2.63,
+          "y": 2.1010000000000084
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 2.1,
+        "y": 2.1000000000000085
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_45",
+    "source_trace_id": "available-net-orientation-41-VCC_3V3",
+    "edges": [
+      {
+        "from": {
+          "x": -13.93,
+          "y": 3.7
+        },
+        "to": {
+          "x": -13.449,
+          "y": 3.7
+        }
+      },
+      {
+        "from": {
+          "x": -13.449,
+          "y": 3.7
+        },
+        "to": {
+          "x": -13.449,
+          "y": 4.101
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_46",
+    "source_trace_id": "available-net-orientation-26-VBUS_5V",
+    "edges": [
+      {
+        "from": {
+          "x": 1.352500000000001,
+          "y": -7.7
+        },
+        "to": {
+          "x": 0.8715000000000009,
+          "y": -7.7
+        }
+      },
+      {
+        "from": {
+          "x": 0.8715000000000009,
+          "y": -7.7
+        },
+        "to": {
+          "x": 0.8715000000000009,
+          "y": -7.499
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_47",
+    "source_trace_id": "available-net-orientation-33-VCC_3V3",
+    "edges": [
+      {
+        "from": {
+          "x": 1.352500000000001,
+          "y": -8.1
+        },
+        "to": {
+          "x": 0.949000000000001,
+          "y": -8.1
+        }
+      },
+      {
+        "from": {
+          "x": 0.949000000000001,
+          "y": -8.1
+        },
+        "to": {
+          "x": 0.874000000000001,
+          "y": -8.1
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 0.874000000000001,
+          "y": -8.1
+        },
+        "to": {
+          "x": 0.27150000000000096,
+          "y": -8.1
+        }
+      },
+      {
+        "from": {
+          "x": 0.27150000000000096,
+          "y": -8.1
+        },
+        "to": {
+          "x": 0.27150000000000096,
+          "y": -8.049
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_48",
+    "source_trace_id": "available-net-orientation-24-VBUS_5V",
+    "edges": [
+      {
+        "from": {
+          "x": -11.2,
+          "y": -7.8
+        },
+        "to": {
+          "x": -12.03,
+          "y": -7.8
+        }
+      },
+      {
+        "from": {
+          "x": -12.03,
+          "y": -7.8
+        },
+        "to": {
+          "x": -12.03,
+          "y": -7.947499999999999
+        }
+      },
+      {
+        "from": {
+          "x": -12.03,
+          "y": -7.947499999999999
+        },
+        "to": {
+          "x": -12.709999999999999,
+          "y": -7.947499999999999
+        }
+      },
+      {
+        "from": {
+          "x": -12.709999999999999,
+          "y": -7.947499999999999
+        },
+        "to": {
+          "x": -12.709999999999999,
+          "y": -7.8
+        }
+      },
+      {
+        "from": {
+          "x": -12.709999999999999,
+          "y": -7.8
+        },
+        "to": {
+          "x": -13.1,
+          "y": -7.8
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": -11.2,
+        "y": -7.8
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_49",
+    "source_trace_id": "available-net-orientation-51-VDD_0V9",
+    "edges": [
+      {
+        "from": {
+          "x": 2.2,
+          "y": -5.299999999999994
+        },
+        "to": {
+          "x": 2.73,
+          "y": -5.299999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 2.73,
+          "y": -5.299999999999994
+        },
+        "to": {
+          "x": 2.73,
+          "y": -5.298999999999993
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 2.2,
+        "y": -5.299999999999994
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_50",
+    "source_trace_id": "available-net-orientation-47-VCC_1V8",
+    "edges": [
+      {
+        "from": {
+          "x": 2,
+          "y": -5.499999999999994
+        },
+        "to": {
+          "x": 2.9635,
+          "y": -5.499999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 2.9635,
+          "y": -5.499999999999994
+        },
+        "to": {
+          "x": 3.0385,
+          "y": -5.499999999999994
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.0385,
+          "y": -5.499999999999994
+        },
+        "to": {
+          "x": 3.231,
+          "y": -5.499999999999994
+        }
+      },
+      {
+        "from": {
+          "x": 3.231,
+          "y": -5.499999999999994
+        },
+        "to": {
+          "x": 3.231,
+          "y": -4.848999999999993
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_51",
+    "source_trace_id": "available-net-orientation-48-VCC_1V8",
+    "edges": [
+      {
+        "from": {
+          "x": 2,
+          "y": -3.099999999999993
+        },
+        "to": {
+          "x": 2.4835000000000003,
+          "y": -3.099999999999993
+        }
+      },
+      {
+        "from": {
+          "x": 2.4835000000000003,
+          "y": -3.099999999999993
+        },
+        "to": {
+          "x": 2.5585,
+          "y": -3.099999999999993
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 2.5585,
+          "y": -3.099999999999993
+        },
+        "to": {
+          "x": 3.5875,
+          "y": -3.099999999999993
+        }
+      },
+      {
+        "from": {
+          "x": 3.5875,
+          "y": -3.099999999999993
+        },
+        "to": {
+          "x": 3.6625,
+          "y": -3.099999999999993
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 3.6625,
+          "y": -3.099999999999993
+        },
+        "to": {
+          "x": 4.731,
+          "y": -3.099999999999993
+        }
+      },
+      {
+        "from": {
+          "x": 4.731,
+          "y": -3.099999999999993
+        },
+        "to": {
+          "x": 4.731,
+          "y": -3.0489999999999933
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_52",
+    "source_trace_id": "available-net-orientation-49-VCC_1V8",
+    "edges": [
+      {
+        "from": {
+          "x": 2.3000000000000003,
+          "y": 1.1000000000000103
+        },
+        "to": {
+          "x": 2.83,
+          "y": 1.1000000000000103
+        }
+      },
+      {
+        "from": {
+          "x": 2.83,
+          "y": 1.1000000000000103
+        },
+        "to": {
+          "x": 2.83,
+          "y": 1.1010000000000102
+        }
+      }
+    ],
+    "junctions": [
+      {
+        "x": 2.3000000000000003,
+        "y": 1.1000000000000103
+      }
+    ],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_53",
+    "source_trace_id": "available-net-orientation-50-VDD_0V9",
+    "edges": [
+      {
+        "from": {
+          "x": 4.052500000000002,
+          "y": -8.3
+        },
+        "to": {
+          "x": 4.533500000000003,
+          "y": -8.3
+        }
+      },
+      {
+        "from": {
+          "x": 4.533500000000003,
+          "y": -8.3
+        },
+        "to": {
+          "x": 4.533500000000003,
+          "y": -7.499000000000001
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_54",
+    "source_trace_id": "available-net-orientation-52-VDD_CORE",
+    "edges": [
+      {
+        "from": {
+          "x": 4.052500000000002,
+          "y": -8.1
+        },
+        "to": {
+          "x": 4.496000000000002,
+          "y": -8.1
+        }
+      },
+      {
+        "from": {
+          "x": 4.496000000000002,
+          "y": -8.1
+        },
+        "to": {
+          "x": 4.5710000000000015,
+          "y": -8.1
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 4.5710000000000015,
+          "y": -8.1
+        },
+        "to": {
+          "x": 5.093500000000002,
+          "y": -8.1
+        }
+      },
+      {
+        "from": {
+          "x": 5.093500000000002,
+          "y": -8.1
+        },
+        "to": {
+          "x": 5.093500000000002,
+          "y": -8.049
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_55",
+    "source_trace_id": "available-net-orientation-53-VDD_CORE",
+    "edges": [
+      {
+        "from": {
+          "x": 2,
+          "y": 3.5000000000000036
+        },
+        "to": {
+          "x": 4.041,
+          "y": 3.5000000000000036
+        }
+      },
+      {
+        "from": {
+          "x": 4.041,
+          "y": 3.5000000000000036
+        },
+        "to": {
+          "x": 4.041,
+          "y": 3.5510000000000033
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net11"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_56",
+    "source_trace_id": "available-net-orientation-43-VCC_1V8",
+    "edges": [
+      {
+        "from": {
+          "x": 1.352500000000001,
+          "y": -8.3
+        },
+        "to": {
+          "x": 0.9490000000000008,
+          "y": -8.3
+        }
+      },
+      {
+        "from": {
+          "x": 0.9490000000000008,
+          "y": -8.3
+        },
+        "to": {
+          "x": 0.874000000000001,
+          "y": -8.3
+        },
+        "is_crossing": true
+      },
+      {
+        "from": {
+          "x": 0.874000000000001,
+          "y": -8.3
+        },
+        "to": {
+          "x": -0.22849999999999948,
+          "y": -8.3
+        }
+      },
+      {
+        "from": {
+          "x": -0.22849999999999937,
+          "y": -8.3
+        },
+        "to": {
+          "x": -0.22849999999999937,
+          "y": -7.599000000000001
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_0",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": -19.87,
+      "y": -7.300000000000002
+    },
+    "center": {
+      "x": -19.87,
+      "y": -7.3900000000000015
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_1",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": -16.900000000000002,
+      "y": -7.7
+    },
+    "center": {
+      "x": -16.660000000000004,
+      "y": -7.7
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_2",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": -24.541,
+      "y": -8.600999999999999
+    },
+    "center": {
+      "x": -24.541,
+      "y": -8.690999999999999
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_3",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": -12.37,
+      "y": -7.427499999999999
+    },
+    "center": {
+      "x": -12.37,
+      "y": -7.517499999999999
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_4",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": 0.9115000000000011,
+      "y": -8.401
+    },
+    "center": {
+      "x": 0.9115000000000011,
+      "y": -8.491
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_5",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": 3.091,
+      "y": 5.798999999999993
+    },
+    "center": {
+      "x": 3.091,
+      "y": 5.708999999999993
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_6",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": 5.664999999999999,
+      "y": -3.2600000000000002
+    },
+    "center": {
+      "x": 5.664999999999999,
+      "y": -3.35
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_7",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": -15.177499999999998,
+      "y": -25.98
+    },
+    "center": {
+      "x": -15.177499999999998,
+      "y": -26.07
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_8",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": -6.097499999999999,
+      "y": -24.68
+    },
+    "center": {
+      "x": -6.097499999999999,
+      "y": -24.77
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_9",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": 4.062500000000001,
+      "y": -24.68
+    },
+    "center": {
+      "x": 4.062500000000001,
+      "y": -24.77
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_10",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": 9.319,
+      "y": 3.6999999999999997
+    },
+    "center": {
+      "x": 9.319,
+      "y": 3.61
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_11",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": -12.749,
+      "y": 2.0999999999999996
+    },
+    "center": {
+      "x": -12.749,
+      "y": 2.01
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_12",
+    "text": "GND",
+    "source_net_id": "source_net_4",
+    "anchor_position": {
+      "x": 16.3875,
+      "y": -23.305
+    },
+    "center": {
+      "x": 16.3875,
+      "y": -23.395
+    },
+    "anchor_side": "top",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_13",
+    "text": "USB_CC1",
+    "source_net_id": "source_net_0",
+    "anchor_position": {
+      "x": -19,
+      "y": -8.3
+    },
+    "center": {
+      "x": -19.48,
+      "y": -8.3
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_14",
+    "text": "USB_CC1",
+    "source_net_id": "source_net_0",
+    "anchor_position": {
+      "x": -20.711000000000002,
+      "y": -5.888999999999999
+    },
+    "center": {
+      "x": -21.191000000000003,
+      "y": -5.888999999999999
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_15",
+    "text": "USB_DM",
+    "source_net_id": "source_net_2",
+    "anchor_position": {
+      "x": -23.7,
+      "y": -8.5
+    },
+    "center": {
+      "x": -24.12,
+      "y": -8.5
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_16",
+    "text": "USB_DM",
+    "source_net_id": "source_net_2",
+    "anchor_position": {
+      "x": -17,
+      "y": -8.7
+    },
+    "center": {
+      "x": -16.58,
+      "y": -8.7
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_17",
+    "text": "USB_DP",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": -19,
+      "y": -8.7
+    },
+    "center": {
+      "x": -19.42,
+      "y": -8.7
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_18",
+    "text": "USB_DP",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": -17,
+      "y": -8.5
+    },
+    "center": {
+      "x": -16.58,
+      "y": -8.5
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_19",
+    "text": "USB_DP",
+    "source_net_id": "source_net_3",
+    "anchor_position": {
+      "x": -23.5,
+      "y": -8.2
+    },
+    "center": {
+      "x": -23.92,
+      "y": -8.2
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_20",
+    "text": "USB_CC2",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -17,
+      "y": -8.1
+    },
+    "center": {
+      "x": -16.52,
+      "y": -8.1
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_21",
+    "text": "USB_CC2",
+    "source_net_id": "source_net_1",
+    "anchor_position": {
+      "x": -18.831000000000003,
+      "y": -4.794
+    },
+    "center": {
+      "x": -19.311000000000003,
+      "y": -4.794
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_22",
+    "text": "VBUS_5V",
+    "source_net_id": "source_net_5",
+    "anchor_position": {
+      "x": -16.37,
+      "y": -7.2989999999999995
+    },
+    "center": {
+      "x": -16.37,
+      "y": -7.209
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_23",
+    "text": "VBUS_5V",
+    "source_net_id": "source_net_5",
+    "anchor_position": {
+      "x": -21.5,
+      "y": -8
+    },
+    "center": {
+      "x": -21.02,
+      "y": -8
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_24",
+    "text": "VBUS_5V",
+    "source_net_id": "source_net_5",
+    "anchor_position": {
+      "x": -13.1,
+      "y": -7.8
+    },
+    "center": {
+      "x": -13.1,
+      "y": -7.71
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_25",
+    "text": "VBUS_5V",
+    "source_net_id": "source_net_5",
+    "anchor_position": {
+      "x": -12.37,
+      "y": -6.547499999999999
+    },
+    "center": {
+      "x": -12.37,
+      "y": -6.4575
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_26",
+    "text": "VBUS_5V",
+    "source_net_id": "source_net_5",
+    "anchor_position": {
+      "x": 0.8715000000000009,
+      "y": -7.499
+    },
+    "center": {
+      "x": 0.8715000000000009,
+      "y": -7.409
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_27",
+    "text": "VBUS_5V",
+    "source_net_id": "source_net_5",
+    "anchor_position": {
+      "x": -12.149,
+      "y": 2.3509999999999995
+    },
+    "center": {
+      "x": -12.149,
+      "y": 2.4409999999999994
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_28",
+    "text": "USB_DP_SOC",
+    "source_net_id": "source_net_7",
+    "anchor_position": {
+      "x": -21.5,
+      "y": -8.2
+    },
+    "center": {
+      "x": -20.84,
+      "y": -8.2
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_29",
+    "text": "USB_DP_SOC",
+    "source_net_id": "source_net_7",
+    "anchor_position": {
+      "x": -2,
+      "y": 1.1999999999999913
+    },
+    "center": {
+      "x": -2.66,
+      "y": 1.1999999999999913
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_30",
+    "text": "USB_DM_SOC",
+    "source_net_id": "source_net_6",
+    "anchor_position": {
+      "x": -21.5,
+      "y": -7.8
+    },
+    "center": {
+      "x": -20.84,
+      "y": -7.8
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_31",
+    "text": "USB_DM_SOC",
+    "source_net_id": "source_net_6",
+    "anchor_position": {
+      "x": -2,
+      "y": 1.3999999999999915
+    },
+    "center": {
+      "x": -2.66,
+      "y": 1.3999999999999915
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_32",
+    "text": "VCC_3V3",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": -11.129999999999999,
+      "y": -6.267500000000001
+    },
+    "center": {
+      "x": -11.129999999999999,
+      "y": -6.177500000000001
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_33",
+    "text": "VCC_3V3",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": 0.27150000000000096,
+      "y": -8.049
+    },
+    "center": {
+      "x": 0.27150000000000096,
+      "y": -7.959
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_34",
+    "text": "VCC_3V3",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": -3.9000000000000012,
+      "y": 2.7999999999999923
+    },
+    "center": {
+      "x": -3.9000000000000012,
+      "y": 2.889999999999992
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_35",
+    "text": "VCC_3V3",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": -3.5810000000000004,
+      "y": -1.949000000000009
+    },
+    "center": {
+      "x": -3.5810000000000004,
+      "y": -1.8590000000000089
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_36",
+    "text": "VCC_3V3",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": -2.5309999999999997,
+      "y": -5.548999999999996
+    },
+    "center": {
+      "x": -2.5309999999999997,
+      "y": -5.458999999999996
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_37",
+    "text": "VCC_3V3",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": 2.521,
+      "y": -1.8999999999999924
+    },
+    "center": {
+      "x": 2.521,
+      "y": -1.8099999999999923
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_38",
+    "text": "VCC_3V3",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": 2.63,
+      "y": 2.1010000000000084
+    },
+    "center": {
+      "x": 2.63,
+      "y": 2.1910000000000083
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_39",
+    "text": "VCC_3V3",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": -16.3875,
+      "y": -18.5
+    },
+    "center": {
+      "x": -16.3875,
+      "y": -18.41
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_40",
+    "text": "VCC_3V3",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": 11.5,
+      "y": 7.059999999999999
+    },
+    "center": {
+      "x": 11.5,
+      "y": 7.149999999999999
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_41",
+    "text": "VCC_3V3",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": -13.449,
+      "y": 4.101
+    },
+    "center": {
+      "x": -13.449,
+      "y": 4.191
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_42",
+    "text": "VCC_3V3",
+    "source_net_id": "source_net_8",
+    "anchor_position": {
+      "x": 16.3875,
+      "y": -21
+    },
+    "center": {
+      "x": 16.3875,
+      "y": -20.91
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_43",
+    "text": "VCC_1V8",
+    "source_net_id": "source_net_9",
+    "anchor_position": {
+      "x": -0.22849999999999937,
+      "y": -7.599000000000001
+    },
+    "center": {
+      "x": -0.22849999999999937,
+      "y": -7.509000000000001
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_44",
+    "text": "VCC_1V8",
+    "source_net_id": "source_net_9",
+    "anchor_position": {
+      "x": -2.2,
+      "y": 6.799999999999994
+    },
+    "center": {
+      "x": -2.2,
+      "y": 6.8899999999999935
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_45",
+    "text": "VCC_1V8",
+    "source_net_id": "source_net_9",
+    "anchor_position": {
+      "x": -2.7809999999999997,
+      "y": 1.8509999999999918
+    },
+    "center": {
+      "x": -2.7809999999999997,
+      "y": 1.9409999999999918
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_46",
+    "text": "VCC_1V8",
+    "source_net_id": "source_net_9",
+    "anchor_position": {
+      "x": -3.6000000000000005,
+      "y": -3.400000000000004
+    },
+    "center": {
+      "x": -3.6000000000000005,
+      "y": -3.310000000000004
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_47",
+    "text": "VCC_1V8",
+    "source_net_id": "source_net_9",
+    "anchor_position": {
+      "x": 3.231,
+      "y": -4.848999999999993
+    },
+    "center": {
+      "x": 3.231,
+      "y": -4.758999999999993
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_48",
+    "text": "VCC_1V8",
+    "source_net_id": "source_net_9",
+    "anchor_position": {
+      "x": 4.731,
+      "y": -3.0489999999999933
+    },
+    "center": {
+      "x": 4.731,
+      "y": -2.9589999999999934
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_49",
+    "text": "VCC_1V8",
+    "source_net_id": "source_net_9",
+    "anchor_position": {
+      "x": 2.83,
+      "y": 1.1010000000000102
+    },
+    "center": {
+      "x": 2.83,
+      "y": 1.1910000000000103
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_50",
+    "text": "VDD_0V9",
+    "source_net_id": "source_net_10",
+    "anchor_position": {
+      "x": 4.533500000000003,
+      "y": -7.499000000000001
+    },
+    "center": {
+      "x": 4.533500000000003,
+      "y": -7.409000000000002
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_51",
+    "text": "VDD_0V9",
+    "source_net_id": "source_net_10",
+    "anchor_position": {
+      "x": 2.73,
+      "y": -5.298999999999993
+    },
+    "center": {
+      "x": 2.73,
+      "y": -5.208999999999993
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_52",
+    "text": "VDD_CORE",
+    "source_net_id": "source_net_11",
+    "anchor_position": {
+      "x": 5.093500000000002,
+      "y": -8.049
+    },
+    "center": {
+      "x": 5.093500000000002,
+      "y": -7.959
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_53",
+    "text": "VDD_CORE",
+    "source_net_id": "source_net_11",
+    "anchor_position": {
+      "x": 4.041,
+      "y": 3.5510000000000033
+    },
+    "center": {
+      "x": 4.041,
+      "y": 3.641000000000003
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_54",
+    "text": "VBUS_DET",
+    "source_net_id": "source_net_12",
+    "anchor_position": {
+      "x": -3.331,
+      "y": 2.3009999999999917
+    },
+    "center": {
+      "x": -3.331,
+      "y": 2.3909999999999916
+    },
+    "anchor_side": "bottom",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_55",
+    "text": "FSPI_IO3",
+    "source_net_id": "source_net_16",
+    "anchor_position": {
+      "x": -2,
+      "y": -1.2000000000000108
+    },
+    "center": {
+      "x": -2.54,
+      "y": -1.2000000000000108
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_56",
+    "text": "FSPI_IO3",
+    "source_net_id": "source_net_16",
+    "anchor_position": {
+      "x": 12.5,
+      "y": 4.1
+    },
+    "center": {
+      "x": 13.04,
+      "y": 4.1
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_57",
+    "text": "FSPI_IO0",
+    "source_net_id": "source_net_17",
+    "anchor_position": {
+      "x": -2,
+      "y": -1.6000000000000103
+    },
+    "center": {
+      "x": -2.54,
+      "y": -1.6000000000000103
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_58",
+    "text": "FSPI_IO0",
+    "source_net_id": "source_net_17",
+    "anchor_position": {
+      "x": 12.5,
+      "y": 3.7
+    },
+    "center": {
+      "x": 13.04,
+      "y": 3.7
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_59",
+    "text": "FSPI_IO1",
+    "source_net_id": "source_net_18",
+    "anchor_position": {
+      "x": -2,
+      "y": -1.8000000000000096
+    },
+    "center": {
+      "x": -2.54,
+      "y": -1.8000000000000096
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_60",
+    "text": "FSPI_IO1",
+    "source_net_id": "source_net_18",
+    "anchor_position": {
+      "x": 10.5,
+      "y": 4.1
+    },
+    "center": {
+      "x": 9.96,
+      "y": 4.1
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_61",
+    "text": "FSPI_IO2",
+    "source_net_id": "source_net_19",
+    "anchor_position": {
+      "x": -2,
+      "y": -2.200000000000008
+    },
+    "center": {
+      "x": -2.54,
+      "y": -2.200000000000008
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_62",
+    "text": "FSPI_IO2",
+    "source_net_id": "source_net_19",
+    "anchor_position": {
+      "x": 10.5,
+      "y": 3.9
+    },
+    "center": {
+      "x": 9.96,
+      "y": 3.9
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_63",
+    "text": "FSPI_CS",
+    "source_net_id": "source_net_20",
+    "anchor_position": {
+      "x": -2,
+      "y": -2.800000000000006
+    },
+    "center": {
+      "x": -2.48,
+      "y": -2.800000000000006
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_64",
+    "text": "FSPI_CS",
+    "source_net_id": "source_net_20",
+    "anchor_position": {
+      "x": 10.5,
+      "y": 4.3
+    },
+    "center": {
+      "x": 10.02,
+      "y": 4.3
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_65",
+    "text": "FSPI_CLK",
+    "source_net_id": "source_net_21",
+    "anchor_position": {
+      "x": -2,
+      "y": -3.0000000000000053
+    },
+    "center": {
+      "x": -2.54,
+      "y": -3.0000000000000053
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_66",
+    "text": "FSPI_CLK",
+    "source_net_id": "source_net_21",
+    "anchor_position": {
+      "x": 12.5,
+      "y": 3.9
+    },
+    "center": {
+      "x": 13.04,
+      "y": 3.9
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_67",
+    "text": "I2C1_SDA",
+    "source_net_id": "source_net_27",
+    "anchor_position": {
+      "x": -2,
+      "y": -6.399999999999993
+    },
+    "center": {
+      "x": -2.54,
+      "y": -6.399999999999993
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_68",
+    "text": "I2C1_SDA",
+    "source_net_id": "source_net_27",
+    "anchor_position": {
+      "x": -13.93,
+      "y": 3.1
+    },
+    "center": {
+      "x": -13.39,
+      "y": 3.1
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_69",
+    "text": "RESET_N",
+    "source_net_id": "source_net_13",
+    "anchor_position": {
+      "x": 2,
+      "y": -6.299999999999994
+    },
+    "center": {
+      "x": 2.48,
+      "y": -6.299999999999994
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_70",
+    "text": "RESET_N",
+    "source_net_id": "source_net_13",
+    "anchor_position": {
+      "x": -16.3875,
+      "y": -19.5
+    },
+    "center": {
+      "x": -16.8675,
+      "y": -19.5
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_71",
+    "text": "RESET_N",
+    "source_net_id": "source_net_13",
+    "anchor_position": {
+      "x": -5.017499999999998,
+      "y": -20.700000000000003
+    },
+    "center": {
+      "x": -5.017499999999998,
+      "y": -20.610000000000003
+    },
+    "anchor_side": "bottom"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_72",
+    "text": "XIN",
+    "source_net_id": "source_net_14",
+    "anchor_position": {
+      "x": 2,
+      "y": -5.899999999999993
+    },
+    "center": {
+      "x": 2.24,
+      "y": -5.899999999999993
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_73",
+    "text": "XIN",
+    "source_net_id": "source_net_14",
+    "anchor_position": {
+      "x": 3.6249999999999996,
+      "y": -1.7299999999999998
+    },
+    "center": {
+      "x": 3.385,
+      "y": -1.7299999999999998
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_74",
+    "text": "XOUT",
+    "source_net_id": "source_net_15",
+    "anchor_position": {
+      "x": 2,
+      "y": -5.699999999999994
+    },
+    "center": {
+      "x": 2.3,
+      "y": -5.699999999999994
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_75",
+    "text": "XOUT",
+    "source_net_id": "source_net_15",
+    "anchor_position": {
+      "x": 5.664999999999999,
+      "y": -1.7299999999999995
+    },
+    "center": {
+      "x": 5.964999999999999,
+      "y": -1.7299999999999995
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_76",
+    "text": "UART0_RX",
+    "source_net_id": "source_net_22",
+    "anchor_position": {
+      "x": 2,
+      "y": 4.699999999999999
+    },
+    "center": {
+      "x": 2.54,
+      "y": 4.699999999999999
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_77",
+    "text": "UART0_RX",
+    "source_net_id": "source_net_22",
+    "anchor_position": {
+      "x": -13.93,
+      "y": 2.5
+    },
+    "center": {
+      "x": -13.39,
+      "y": 2.5
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_78",
+    "text": "UART0_TX",
+    "source_net_id": "source_net_23",
+    "anchor_position": {
+      "x": 2,
+      "y": 4.899999999999999
+    },
+    "center": {
+      "x": 2.54,
+      "y": 4.899999999999999
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_79",
+    "text": "UART0_TX",
+    "source_net_id": "source_net_23",
+    "anchor_position": {
+      "x": -13.93,
+      "y": 2.7
+    },
+    "center": {
+      "x": -13.39,
+      "y": 2.7
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_80",
+    "text": "GPIO0",
+    "source_net_id": "source_net_24",
+    "anchor_position": {
+      "x": 2,
+      "y": 5.4999999999999964
+    },
+    "center": {
+      "x": 2.36,
+      "y": 5.4999999999999964
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_81",
+    "text": "GPIO0",
+    "source_net_id": "source_net_24",
+    "anchor_position": {
+      "x": -13.93,
+      "y": 3.5
+    },
+    "center": {
+      "x": -13.57,
+      "y": 3.5
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_82",
+    "text": "GPIO1",
+    "source_net_id": "source_net_25",
+    "anchor_position": {
+      "x": 2,
+      "y": 5.699999999999996
+    },
+    "center": {
+      "x": 2.36,
+      "y": 5.699999999999996
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_83",
+    "text": "GPIO1",
+    "source_net_id": "source_net_25",
+    "anchor_position": {
+      "x": -13.93,
+      "y": 3.3
+    },
+    "center": {
+      "x": -13.57,
+      "y": 3.3
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_84",
+    "text": "I2C1_SCL",
+    "source_net_id": "source_net_26",
+    "anchor_position": {
+      "x": 2,
+      "y": 5.899999999999995
+    },
+    "center": {
+      "x": 2.54,
+      "y": 5.899999999999995
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_85",
+    "text": "I2C1_SCL",
+    "source_net_id": "source_net_26",
+    "anchor_position": {
+      "x": -13.93,
+      "y": 2.9000000000000004
+    },
+    "center": {
+      "x": -13.39,
+      "y": 2.9000000000000004
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_86",
+    "text": "BOOT_STRAP",
+    "source_net_id": "source_net_28",
+    "anchor_position": {
+      "x": -6.097499999999999,
+      "y": -19.6
+    },
+    "center": {
+      "x": -6.757499999999999,
+      "y": -19.6
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_87",
+    "text": "BOOT_STRAP",
+    "source_net_id": "source_net_28",
+    "anchor_position": {
+      "x": 4.062500000000001,
+      "y": -19.6
+    },
+    "center": {
+      "x": 4.722500000000001,
+      "y": -19.6
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_88",
+    "text": "POWER_LED",
+    "source_net_id": "source_net_29",
+    "anchor_position": {
+      "x": 16.3875,
+      "y": -22.405
+    },
+    "center": {
+      "x": 15.7875,
+      "y": -22.405
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_0",
+    "center": {
+      "x": 0,
+      "y": -28.425043549999998
+    },
+    "width": 9.8502216,
+    "height": 6.498170900000002,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 0,
+    "display_offset_y": -28
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_1",
+    "center": {
+      "x": -6,
+      "y": -21
+    },
+    "width": 2.450000000000001,
+    "height": 0.9500000000000028,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -6,
+    "display_offset_y": -21
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_2",
+    "center": {
+      "x": -3,
+      "y": -21
+    },
+    "width": 2.4500000000000006,
+    "height": 0.9500000000000028,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -3,
+    "display_offset_y": -21
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_3",
+    "center": {
+      "x": 5,
+      "y": -20
+    },
+    "width": 2.4319229999999994,
+    "height": 3.3701989999999995,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 5,
+    "display_offset_y": -20
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_4",
+    "center": {
+      "x": -12,
+      "y": 15
+    },
+    "width": 2.521712000000001,
+    "height": 3.7048440000000014,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -12,
+    "display_offset_y": 15
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_5",
+    "center": {
+      "x": -11,
+      "y": 18
+    },
+    "width": 2.4499999999999993,
+    "height": 0.9500000000000028,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -11,
+    "display_offset_y": 18
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_6",
+    "center": {
+      "x": 0,
+      "y": 20
+    },
+    "width": 2.45,
+    "height": 0.9500000000000028,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 0,
+    "display_offset_y": 20
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_7",
+    "center": {
+      "x": -5,
+      "y": 16
+    },
+    "width": 5.300000000000001,
+    "height": 4.410000000000002,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -5,
+    "display_offset_y": 16
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_8",
+    "center": {
+      "x": 0,
+      "y": 1
+    },
+    "width": 12.779781400000001,
+    "height": 12.779781400000001,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_8",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 0,
+    "display_offset_y": 1
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_9",
+    "center": {
+      "x": 9,
+      "y": 1
+    },
+    "width": 3.5,
+    "height": 2.4000000000000004,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_9",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 9,
+    "display_offset_y": 1
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_10",
+    "center": {
+      "x": 9,
+      "y": -1
+    },
+    "width": 1.5599999999999987,
+    "height": 0.6400000000000001,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_10",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 9,
+    "display_offset_y": -1
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_11",
+    "center": {
+      "x": 12,
+      "y": 2.5
+    },
+    "width": 1.5599999999999987,
+    "height": 0.6399999999999997,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_11",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 12,
+    "display_offset_y": 2.5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_12",
+    "center": {
+      "x": 3,
+      "y": -9
+    },
+    "width": 2.4500000000000006,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_12",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 3,
+    "display_offset_y": -9
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_13",
+    "center": {
+      "x": 10,
+      "y": -10
+    },
+    "width": 5.499963600000001,
+    "height": 2.800121400000002,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_13",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 10,
+    "display_offset_y": -10
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_14",
+    "center": {
+      "x": 10,
+      "y": -18
+    },
+    "width": 5.499963600000001,
+    "height": 2.8001213999999948,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_14",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 10,
+    "display_offset_y": -18
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_15",
+    "center": {
+      "x": 10,
+      "y": 9
+    },
+    "width": 4.4399961999999995,
+    "height": 9.3101922,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_15",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 10,
+    "display_offset_y": 9
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_16",
+    "center": {
+      "x": 5,
+      "y": 14
+    },
+    "width": 1.5599999999999987,
+    "height": 0.6400000000000006,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_16",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 5,
+    "display_offset_y": 14
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_17",
+    "center": {
+      "x": -20.5,
+      "y": 0
+    },
+    "width": 1.5,
+    "height": 24.36,
+    "layer": "top",
+    "rotation": 90,
+    "source_component_id": "source_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": -20.5,
+    "display_offset_y": 0
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_18",
+    "center": {
+      "x": 12,
+      "y": -5
+    },
+    "width": 2.4499999999999993,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_18",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 12,
+    "display_offset_y": -5
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_19",
+    "center": {
+      "x": 12,
+      "y": -3
+    },
+    "width": 2.4499999999999993,
+    "height": 0.9500000000000002,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_19",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "is_allowed_to_be_off_board": false,
+    "position_mode": "relative_to_group_anchor",
+    "positioned_relative_to_pcb_board_id": "pcb_board_0",
+    "display_offset_x": 12,
+    "display_offset_y": -3
+  },
+  {
+    "type": "pcb_board",
+    "pcb_board_id": "pcb_board_0",
+    "source_board_id": "source_board_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "thickness": 1.6,
+    "num_layers": 4,
+    "width": 48,
+    "height": 64,
+    "outline": [
+      {
+        "x": -22.75,
+        "y": -32
+      },
+      {
+        "x": 22.75,
+        "y": -32
+      },
+      {
+        "x": 22.848073869659807,
+        "y": -31.99614666716641
+      },
+      {
+        "x": 22.94554308130029,
+        "y": -31.984610425743924
+      },
+      {
+        "x": 23.041806704819884,
+        "y": -31.965462400497096
+      },
+      {
+        "x": 23.136271242968686,
+        "y": -31.938820645368942
+      },
+      {
+        "x": 23.228354290456362,
+        "y": -31.90484941563911
+      },
+      {
+        "x": 23.317488124674433,
+        "y": -31.86375815523546
+      },
+      {
+        "x": 23.403123205894936,
+        "y": -31.815800205442613
+      },
+      {
+        "x": 23.484731565365593,
+        "y": -31.761271242968686
+      },
+      {
+        "x": 23.56181006041273,
+        "y": -31.70050745700004
+      },
+      {
+        "x": 23.633883476483184,
+        "y": -31.633883476483184
+      },
+      {
+        "x": 23.70050745700004,
+        "y": -31.56181006041273
+      },
+      {
+        "x": 23.761271242968686,
+        "y": -31.484731565365593
+      },
+      {
+        "x": 23.815800205442613,
+        "y": -31.403123205894936
+      },
+      {
+        "x": 23.86375815523546,
+        "y": -31.317488124674433
+      },
+      {
+        "x": 23.90484941563911,
+        "y": -31.228354290456362
+      },
+      {
+        "x": 23.938820645368942,
+        "y": -31.136271242968686
+      },
+      {
+        "x": 23.965462400497096,
+        "y": -31.04180670481988
+      },
+      {
+        "x": 23.984610425743924,
+        "y": -30.94554308130029
+      },
+      {
+        "x": 23.99614666716641,
+        "y": -30.848073869659807
+      },
+      {
+        "x": 24,
+        "y": -30.75
+      },
+      {
+        "x": 24,
+        "y": 30.75
+      },
+      {
+        "x": 23.99614666716641,
+        "y": 30.848073869659807
+      },
+      {
+        "x": 23.984610425743924,
+        "y": 30.94554308130029
+      },
+      {
+        "x": 23.965462400497096,
+        "y": 31.04180670481988
+      },
+      {
+        "x": 23.938820645368942,
+        "y": 31.136271242968686
+      },
+      {
+        "x": 23.90484941563911,
+        "y": 31.228354290456362
+      },
+      {
+        "x": 23.86375815523546,
+        "y": 31.317488124674433
+      },
+      {
+        "x": 23.815800205442613,
+        "y": 31.403123205894936
+      },
+      {
+        "x": 23.761271242968686,
+        "y": 31.484731565365593
+      },
+      {
+        "x": 23.70050745700004,
+        "y": 31.56181006041273
+      },
+      {
+        "x": 23.633883476483184,
+        "y": 31.633883476483184
+      },
+      {
+        "x": 23.56181006041273,
+        "y": 31.70050745700004
+      },
+      {
+        "x": 23.484731565365593,
+        "y": 31.761271242968686
+      },
+      {
+        "x": 23.403123205894936,
+        "y": 31.815800205442613
+      },
+      {
+        "x": 23.317488124674433,
+        "y": 31.86375815523546
+      },
+      {
+        "x": 23.228354290456362,
+        "y": 31.90484941563911
+      },
+      {
+        "x": 23.136271242968686,
+        "y": 31.938820645368942
+      },
+      {
+        "x": 23.041806704819884,
+        "y": 31.965462400497096
+      },
+      {
+        "x": 22.94554308130029,
+        "y": 31.984610425743924
+      },
+      {
+        "x": 22.848073869659807,
+        "y": 31.99614666716641
+      },
+      {
+        "x": 22.75,
+        "y": 32
+      },
+      {
+        "x": -22.75,
+        "y": 32
+      },
+      {
+        "x": -22.848073869659807,
+        "y": 31.99614666716641
+      },
+      {
+        "x": -22.94554308130029,
+        "y": 31.984610425743924
+      },
+      {
+        "x": -23.04180670481988,
+        "y": 31.965462400497096
+      },
+      {
+        "x": -23.136271242968686,
+        "y": 31.938820645368942
+      },
+      {
+        "x": -23.228354290456362,
+        "y": 31.90484941563911
+      },
+      {
+        "x": -23.317488124674433,
+        "y": 31.86375815523546
+      },
+      {
+        "x": -23.403123205894936,
+        "y": 31.815800205442617
+      },
+      {
+        "x": -23.484731565365593,
+        "y": 31.761271242968686
+      },
+      {
+        "x": -23.56181006041273,
+        "y": 31.70050745700004
+      },
+      {
+        "x": -23.633883476483184,
+        "y": 31.633883476483184
+      },
+      {
+        "x": -23.70050745700004,
+        "y": 31.56181006041273
+      },
+      {
+        "x": -23.761271242968682,
+        "y": 31.484731565365593
+      },
+      {
+        "x": -23.815800205442613,
+        "y": 31.403123205894936
+      },
+      {
+        "x": -23.86375815523546,
+        "y": 31.317488124674433
+      },
+      {
+        "x": -23.90484941563911,
+        "y": 31.228354290456362
+      },
+      {
+        "x": -23.938820645368942,
+        "y": 31.136271242968686
+      },
+      {
+        "x": -23.965462400497096,
+        "y": 31.041806704819884
+      },
+      {
+        "x": -23.984610425743924,
+        "y": 30.94554308130029
+      },
+      {
+        "x": -23.99614666716641,
+        "y": 30.848073869659807
+      },
+      {
+        "x": -24,
+        "y": 30.75
+      },
+      {
+        "x": -24,
+        "y": -30.75
+      },
+      {
+        "x": -23.99614666716641,
+        "y": -30.848073869659807
+      },
+      {
+        "x": -23.984610425743924,
+        "y": -30.94554308130029
+      },
+      {
+        "x": -23.965462400497096,
+        "y": -31.04180670481988
+      },
+      {
+        "x": -23.938820645368942,
+        "y": -31.136271242968682
+      },
+      {
+        "x": -23.90484941563911,
+        "y": -31.228354290456362
+      },
+      {
+        "x": -23.86375815523546,
+        "y": -31.317488124674433
+      },
+      {
+        "x": -23.815800205442617,
+        "y": -31.403123205894936
+      },
+      {
+        "x": -23.761271242968686,
+        "y": -31.484731565365593
+      },
+      {
+        "x": -23.70050745700004,
+        "y": -31.56181006041273
+      },
+      {
+        "x": -23.633883476483184,
+        "y": -31.633883476483184
+      },
+      {
+        "x": -23.56181006041273,
+        "y": -31.70050745700004
+      },
+      {
+        "x": -23.484731565365593,
+        "y": -31.761271242968682
+      },
+      {
+        "x": -23.403123205894936,
+        "y": -31.815800205442617
+      },
+      {
+        "x": -23.317488124674433,
+        "y": -31.86375815523546
+      },
+      {
+        "x": -23.228354290456362,
+        "y": -31.90484941563911
+      },
+      {
+        "x": -23.136271242968686,
+        "y": -31.938820645368942
+      },
+      {
+        "x": -23.04180670481988,
+        "y": -31.965462400497096
+      },
+      {
+        "x": -22.94554308130029,
+        "y": -31.984610425743924
+      },
+      {
+        "x": -22.848073869659807,
+        "y": -31.99614666716641
+      },
+      {
+        "x": -22.75,
+        "y": -32
+      }
+    ],
+    "material": "fr4",
+    "min_trace_width": 0.1,
+    "min_via_hole_diameter": 0.2,
+    "min_via_pad_diameter": 0.3,
+    "min_via_hole_edge_to_via_hole_edge_clearance": 0.1,
+    "min_trace_to_pad_edge_clearance": 0.1,
+    "min_pad_edge_to_pad_edge_clearance": 0.1,
+    "min_plated_hole_drill_edge_to_drill_edge_clearance": 0.15,
+    "min_board_edge_clearance": 0.2
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_0",
+    "pcb_component_id": "pcb_component_0",
+    "hole_shape": "circle",
+    "hole_diameter": 0.5999988,
+    "x": -2.899918,
+    "y": -27.0944328,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_hole",
+    "pcb_hole_id": "pcb_hole_1",
+    "pcb_component_id": "pcb_component_0",
+    "hole_shape": "circle",
+    "hole_diameter": 0.5999988,
+    "x": 2.899918,
+    "y": -27.0944328,
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_0",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_1",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.7999984,
+    "hole_height": 1.3999972,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole1",
+      "pin2"
+    ],
+    "x": 4.325112,
+    "y": -30.774130800000002,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_0",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": 4.325112,
+    "y": -30.774130800000002,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_1",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": 4.325112,
+    "y": -30.774130800000002,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_1",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_0",
+    "outer_width": 1.1999976,
+    "outer_height": 1.999996,
+    "hole_width": 0.7999984,
+    "hole_height": 1.5999968,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole2",
+      "pin1"
+    ],
+    "x": 4.325112,
+    "y": -26.5943068,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_2",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.999996,
+    "x": 4.325112,
+    "y": -26.5943068,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_3",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.999996,
+    "x": 4.325112,
+    "y": -26.5943068,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_2",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_3",
+    "outer_width": 1.1999976,
+    "outer_height": 1.999996,
+    "hole_width": 0.7999984,
+    "hole_height": 1.5999968,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole3",
+      "pin4"
+    ],
+    "x": -4.325112,
+    "y": -26.5943068,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_4",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.999996,
+    "x": -4.325112,
+    "y": -26.5943068,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_5",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.999996,
+    "x": -4.325112,
+    "y": -26.5943068,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_3",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_2",
+    "outer_width": 1.1999976,
+    "outer_height": 1.7999964,
+    "hole_width": 0.7999984,
+    "hole_height": 1.3999972,
+    "shape": "pill",
+    "port_hints": [
+      "unnamed_platedhole4",
+      "pin3"
+    ],
+    "x": -4.325112,
+    "y": -30.774130800000002,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "ccw_rotation": 0
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_6",
+    "layer": "top",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -4.325112,
+    "y": -30.774130800000002,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_7",
+    "layer": "bottom",
+    "shape": "pill",
+    "width": 1.1999976,
+    "height": 1.7999964,
+    "x": -4.325112,
+    "y": -30.774130800000002,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_4",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.2999974,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.75006,
+    "y": -25.8259568,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.90999818,
+    "x": -1.75006,
+    "y": -25.8259568,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_5",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.2999974,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.249934,
+    "y": -25.8259568,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.90999818,
+    "x": -1.249934,
+    "y": -25.8259568,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_6",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.2999974,
+    "port_hints": [
+      "pin7"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.750062,
+    "y": -25.8259568,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.90999818,
+    "x": -0.750062,
+    "y": -25.8259568,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_7",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.2999974,
+    "port_hints": [
+      "pin8"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.249936,
+    "y": -25.8259568,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.90999818,
+    "x": -0.249936,
+    "y": -25.8259568,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.2999974,
+    "port_hints": [
+      "pin9"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.249936,
+    "y": -25.8259568,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_12",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.90999818,
+    "x": 0.249936,
+    "y": -25.8259568,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.2999974,
+    "port_hints": [
+      "pin10"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.750062,
+    "y": -25.8259568,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_13",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.90999818,
+    "x": 0.750062,
+    "y": -25.8259568,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.2999974,
+    "port_hints": [
+      "pin11"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.24968,
+    "y": -25.8259568,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_14",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.90999818,
+    "x": 1.24968,
+    "y": -25.8259568,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.2999994,
+    "height": 1.2999974,
+    "port_hints": [
+      "pin12"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.75006,
+    "y": -25.8259568,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_15",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.20999958000000002,
+    "height": 0.90999818,
+    "x": 1.75006,
+    "y": -25.8259568,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_12",
+    "layer": "top",
+    "shape": "polygon",
+    "points": [
+      {
+        "x": -2.8999688,
+        "y": -26.475892
+      },
+      {
+        "x": -2.8999688,
+        "y": -25.1758692
+      },
+      {
+        "x": -2.8999688,
+        "y": -25.1758692
+      },
+      {
+        "x": -3.1999682,
+        "y": -25.1758692
+      },
+      {
+        "x": -3.1999682,
+        "y": -25.1758692
+      },
+      {
+        "x": -3.1999682,
+        "y": -25.1760216
+      },
+      {
+        "x": -3.1999682,
+        "y": -25.1760216
+      },
+      {
+        "x": -3.4999422,
+        "y": -25.1760216
+      },
+      {
+        "x": -3.4999422,
+        "y": -25.1760216
+      },
+      {
+        "x": -3.4999422,
+        "y": -26.4760444
+      },
+      {
+        "x": -3.4999422,
+        "y": -26.4760444
+      },
+      {
+        "x": -3.1999428,
+        "y": -26.4760444
+      },
+      {
+        "x": -3.1999428,
+        "y": -26.4760444
+      },
+      {
+        "x": -3.1999428,
+        "y": -26.475892
+      },
+      {
+        "x": -3.1999428,
+        "y": -26.475892
+      },
+      {
+        "x": -2.8999688,
+        "y": -26.475892
+      }
+    ],
+    "port_hints": [
+      "pin13"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_13",
+    "layer": "top",
+    "shape": "polygon",
+    "points": [
+      {
+        "x": 2.8999942,
+        "y": -25.1758692
+      },
+      {
+        "x": 2.8999942,
+        "y": -26.4758412
+      },
+      {
+        "x": 2.8999942,
+        "y": -26.4758412
+      },
+      {
+        "x": 3.1999936,
+        "y": -26.4758412
+      },
+      {
+        "x": 3.1999936,
+        "y": -26.4758412
+      },
+      {
+        "x": 3.200019,
+        "y": -26.4758412
+      },
+      {
+        "x": 3.200019,
+        "y": -26.4758412
+      },
+      {
+        "x": 3.5000184,
+        "y": -26.4758412
+      },
+      {
+        "x": 3.5000184,
+        "y": -26.4758412
+      },
+      {
+        "x": 3.5000184,
+        "y": -25.1758692
+      },
+      {
+        "x": 3.5000184,
+        "y": -25.1758692
+      },
+      {
+        "x": 3.200019,
+        "y": -25.1758692
+      },
+      {
+        "x": 3.200019,
+        "y": -25.1758692
+      },
+      {
+        "x": 3.1999936,
+        "y": -25.1758692
+      },
+      {
+        "x": 3.1999936,
+        "y": -25.1758692
+      },
+      {
+        "x": 2.8999942,
+        "y": -25.1758692
+      }
+    ],
+    "port_hints": [
+      "pin14"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_14",
+    "layer": "top",
+    "shape": "polygon",
+    "points": [
+      {
+        "x": 2.7001724,
+        "y": -26.4758412
+      },
+      {
+        "x": 2.7001724,
+        "y": -25.1758692
+      },
+      {
+        "x": 2.7001724,
+        "y": -25.1758692
+      },
+      {
+        "x": 2.400173,
+        "y": -25.1758692
+      },
+      {
+        "x": 2.400173,
+        "y": -25.1758692
+      },
+      {
+        "x": 2.4001476,
+        "y": -25.1758692
+      },
+      {
+        "x": 2.4001476,
+        "y": -25.1758692
+      },
+      {
+        "x": 2.1001482,
+        "y": -25.1758692
+      },
+      {
+        "x": 2.1001482,
+        "y": -25.1758692
+      },
+      {
+        "x": 2.1001482,
+        "y": -26.4758412
+      },
+      {
+        "x": 2.1001482,
+        "y": -26.4758412
+      },
+      {
+        "x": 2.4001476,
+        "y": -26.4758412
+      },
+      {
+        "x": 2.4001476,
+        "y": -26.4758412
+      },
+      {
+        "x": 2.400173,
+        "y": -26.4758412
+      },
+      {
+        "x": 2.400173,
+        "y": -26.4758412
+      },
+      {
+        "x": 2.7001724,
+        "y": -26.4758412
+      }
+    ],
+    "port_hints": [
+      "pin15"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_15",
+    "layer": "top",
+    "shape": "polygon",
+    "points": [
+      {
+        "x": -2.0999704,
+        "y": -26.4759936
+      },
+      {
+        "x": -2.0999704,
+        "y": -25.1760216
+      },
+      {
+        "x": -2.0999704,
+        "y": -25.1760216
+      },
+      {
+        "x": -2.3999952,
+        "y": -25.1760216
+      },
+      {
+        "x": -2.3999952,
+        "y": -25.1760216
+      },
+      {
+        "x": -2.3999952,
+        "y": -25.176047
+      },
+      {
+        "x": -2.3999952,
+        "y": -25.176047
+      },
+      {
+        "x": -2.6999438,
+        "y": -25.176047
+      },
+      {
+        "x": -2.6999438,
+        "y": -25.176047
+      },
+      {
+        "x": -2.6999438,
+        "y": -26.476019
+      },
+      {
+        "x": -2.6999438,
+        "y": -26.476019
+      },
+      {
+        "x": -2.399919,
+        "y": -26.476019
+      },
+      {
+        "x": -2.399919,
+        "y": -26.476019
+      },
+      {
+        "x": -2.399919,
+        "y": -26.4759936
+      },
+      {
+        "x": -2.399919,
+        "y": -26.4759936
+      },
+      {
+        "x": -2.0999704,
+        "y": -26.4759936
+      }
+    ],
+    "port_hints": [
+      "pin16"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_0",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": -4.4689776000000165,
+        "y": -29.675758599999995
+      },
+      {
+        "x": -4.4689776000000165,
+        "y": -27.812846400000126
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_1",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": 4.471009600000116,
+        "y": -33.39414080000006
+      },
+      {
+        "x": -4.4689776000000165,
+        "y": -33.39414080000006
+      },
+      {
+        "x": -4.4689776000000165,
+        "y": -31.91283820000001
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_2",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": 4.471009600000116,
+        "y": -29.67611420000003
+      },
+      {
+        "x": 4.471009600000116,
+        "y": -27.812490799999978
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_3",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": 4.471009600000116,
+        "y": -33.39414080000006
+      },
+      {
+        "x": 4.471009600000116,
+        "y": -31.912482600000203
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_0",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 0.002794,
+      "y": -24.1713988
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "J1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_0",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_0",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -5.174805999999876,
+        "y": -24.921398800000134
+      },
+      {
+        "x": 5.180394000000092,
+        "y": -24.921398800000134
+      },
+      {
+        "x": 5.180394000000092,
+        "y": -33.650998800000025
+      },
+      {
+        "x": -5.174805999999876,
+        "y": -33.650998800000025
+      },
+      {
+        "x": -5.174805999999876,
+        "y": -24.921398800000134
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_16",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.825,
+    "y": -21,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_16",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -6.825,
+    "y": -21,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_17",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -5.175,
+    "y": -21,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_17",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -5.175,
+    "y": -21,
+    "pcb_component_id": "pcb_component_1",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_4",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.237258,
+        "y": -20.4775
+      },
+      {
+        "x": -5.762742,
+        "y": -20.4775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_5",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.237258,
+        "y": -21.5225
+      },
+      {
+        "x": -5.762742,
+        "y": -21.5225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_1",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -6,
+      "y": -19.625
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_1",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_0",
+    "pcb_component_id": "pcb_component_1",
+    "layer": "top",
+    "center": {
+      "x": -6,
+      "y": -21
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_18",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.825,
+    "y": -21,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_18",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -3.825,
+    "y": -21,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_19",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.175,
+    "y": -21,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_19",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -2.175,
+    "y": -21,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_6",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -3.237258,
+        "y": -20.4775
+      },
+      {
+        "x": -2.762742,
+        "y": -20.4775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_7",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": -3.237258,
+        "y": -21.5225
+      },
+      {
+        "x": -2.762742,
+        "y": -21.5225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_2",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -3,
+      "y": -19.625
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_2",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_1",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "center": {
+      "x": -3,
+      "y": -21
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_20",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.532003,
+    "height": 1.072007,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.05004,
+    "y": -21.149096,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_20",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.37240209999999996,
+    "height": 0.7504048999999999,
+    "x": 4.05004,
+    "y": -21.149096,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_21",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.532003,
+    "height": 1.072007,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5,
+    "y": -21.149096,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_21",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.37240209999999996,
+    "height": 0.7504048999999999,
+    "x": 5,
+    "y": -21.149096,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_22",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.532003,
+    "height": 1.072007,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.94996,
+    "y": -21.149096,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_22",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.37240209999999996,
+    "height": 0.7504048999999999,
+    "x": 5.94996,
+    "y": -21.149096,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_23",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.532003,
+    "height": 1.072007,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.94996,
+    "y": -18.850904,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_23",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.37240209999999996,
+    "height": 0.7504048999999999,
+    "x": 5.94996,
+    "y": -18.850904,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_24",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.532003,
+    "height": 1.072007,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5,
+    "y": -18.850904,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_24",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.37240209999999996,
+    "height": 0.7504048999999999,
+    "x": 5,
+    "y": -18.850904,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_25",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.532003,
+    "height": 1.072007,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.05004,
+    "y": -18.850904,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_25",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.37240209999999996,
+    "height": 0.7504048999999999,
+    "x": 4.05004,
+    "y": -18.850904,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_8",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": 6.539189199999896,
+        "y": -20.889203199999884
+      },
+      {
+        "x": 6.539189199999896,
+        "y": -19.110796800000003
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_9",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": 3.46081079999999,
+        "y": -20.889203199999884
+      },
+      {
+        "x": 3.46081079999999,
+        "y": -19.110796800000003
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_10",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": 3.481841999999915,
+        "y": -21.301496000000043
+      },
+      {
+        "x": 3.4767269894873607,
+        "y": -21.34034836213641
+      },
+      {
+        "x": 3.461730537463609,
+        "y": -21.376552999999944
+      },
+      {
+        "x": 3.4378746273509933,
+        "y": -21.407642627350924
+      },
+      {
+        "x": 3.4067849999999,
+        "y": -21.43149853746354
+      },
+      {
+        "x": 3.3705803621364794,
+        "y": -21.446494989487405
+      },
+      {
+        "x": 3.3317279999998846,
+        "y": -21.451609999999846
+      },
+      {
+        "x": 3.2928756378632897,
+        "y": -21.446494989487405
+      },
+      {
+        "x": 3.2566709999998693,
+        "y": -21.43149853746354
+      },
+      {
+        "x": 3.2255813726488896,
+        "y": -21.407642627350924
+      },
+      {
+        "x": 3.201725462536274,
+        "y": -21.376552999999944
+      },
+      {
+        "x": 3.1867290105124084,
+        "y": -21.34034836213641
+      },
+      {
+        "x": 3.181613999999854,
+        "y": -21.301496000000043
+      },
+      {
+        "x": 3.1867290105124084,
+        "y": -21.262643637863334
+      },
+      {
+        "x": 3.201725462536274,
+        "y": -21.226438999999914
+      },
+      {
+        "x": 3.2255813726488896,
+        "y": -21.195349372648934
+      },
+      {
+        "x": 3.2566709999998693,
+        "y": -21.17149346253632
+      },
+      {
+        "x": 3.2928756378632897,
+        "y": -21.156497010512453
+      },
+      {
+        "x": 3.3317279999998846,
+        "y": -21.1513819999999
+      },
+      {
+        "x": 3.3705803621364794,
+        "y": -21.156497010512453
+      },
+      {
+        "x": 3.4067849999999,
+        "y": -21.17149346253632
+      },
+      {
+        "x": 3.4378746273509933,
+        "y": -21.195349372648934
+      },
+      {
+        "x": 3.461730537463609,
+        "y": -21.226438999999914
+      },
+      {
+        "x": 3.4767269894873607,
+        "y": -21.262643637863334
+      },
+      {
+        "x": 3.481841999999915,
+        "y": -21.301496000000043
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_3",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 4.8476,
+      "y": -17.3236
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "D1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_3",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_1",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 2.921199999999999,
+        "y": -18.073599999999942
+      },
+      {
+        "x": 6.773999999999887,
+        "y": -18.073599999999942
+      },
+      {
+        "x": 6.773999999999887,
+        "y": -22.027999999999906
+      },
+      {
+        "x": 2.921199999999999,
+        "y": -22.027999999999906
+      },
+      {
+        "x": 2.921199999999999,
+        "y": -18.073599999999942
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_29",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6223,
+    "height": 1.1049,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -11.050294,
+    "y": 16.299972,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_26",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.43560999999999994,
+    "height": 0.77343,
+    "x": -11.050294,
+    "y": 16.299972,
+    "pcb_component_id": "pcb_component_4",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_30",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6223,
+    "height": 1.1049,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -12.949706,
+    "y": 16.299972,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_27",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.43560999999999994,
+    "height": 0.77343,
+    "x": -12.949706,
+    "y": 16.299972,
+    "pcb_component_id": "pcb_component_4",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_26",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6223,
+    "height": 1.1049,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -12.949706,
+    "y": 13.700028,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.43560999999999994,
+    "height": 0.77343,
+    "x": -12.949706,
+    "y": 13.700028,
+    "pcb_component_id": "pcb_component_4",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_27",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6223,
+    "height": 1.1049,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -12.000508,
+    "y": 13.700028,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_29",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.43560999999999994,
+    "height": 0.77343,
+    "x": -12.000508,
+    "y": 13.700028,
+    "pcb_component_id": "pcb_component_4",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6223,
+    "height": 1.1049,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -11.050294,
+    "y": 13.700028,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_30",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.43560999999999994,
+    "height": 0.77343,
+    "x": -11.050294,
+    "y": 13.700028,
+    "pcb_component_id": "pcb_component_4",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_11",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": -10.58806479999987,
+        "y": 14.49962000000005
+      },
+      {
+        "x": -13.387144799999987,
+        "y": 14.49962000000005
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_12",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": -13.387144799999987,
+        "y": 14.49962000000005
+      },
+      {
+        "x": -13.387144799999987,
+        "y": 15.50037999999995
+      },
+      {
+        "x": -10.58806479999987,
+        "y": 15.50037999999995
+      },
+      {
+        "x": -10.58806479999987,
+        "y": 14.49962000000005
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_13",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": -13.779549399999837,
+        "y": 13.478540000000066
+      },
+      {
+        "x": -13.902737780049279,
+        "y": 13.353451471495532
+      },
+      {
+        "x": -13.77827939999986,
+        "y": 13.229626479760555
+      },
+      {
+        "x": -13.65382101995067,
+        "y": 13.353451471495418
+      },
+      {
+        "x": -13.777009399999997,
+        "y": 13.478540000000066
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_4",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -12.228854,
+      "y": 17.8542
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "U2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_4",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_2",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -14.1552539999999,
+        "y": 17.104200000000105
+      },
+      {
+        "x": -10.302453999999898,
+        "y": 17.104200000000105
+      },
+      {
+        "x": -10.302453999999898,
+        "y": 12.895800000000122
+      },
+      {
+        "x": -14.1552539999999,
+        "y": 12.895800000000122
+      },
+      {
+        "x": -14.1552539999999,
+        "y": 17.104200000000105
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_31",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -11.825,
+    "y": 18,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_31",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -11.825,
+    "y": 18,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_32",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -10.175,
+    "y": 18,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_32",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -10.175,
+    "y": 18,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_14",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": -10.175,
+        "y": 18.875
+      },
+      {
+        "x": -12.425,
+        "y": 18.875
+      },
+      {
+        "x": -12.425,
+        "y": 17.125
+      },
+      {
+        "x": -10.175,
+        "y": 17.125
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_5",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -11,
+      "y": 19.375
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_5",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_2",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "center": {
+      "x": -11,
+      "y": 18
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "pcb_component_id": "pcb_component_6",
+    "pcb_port_id": "pcb_port_33",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.825,
+    "y": 20,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_33",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": -0.825,
+    "y": 20,
+    "pcb_component_id": "pcb_component_6",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_30",
+    "pcb_component_id": "pcb_component_6",
+    "pcb_port_id": "pcb_port_34",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.825,
+    "y": 20,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_34",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 0.825,
+    "y": 20,
+    "pcb_component_id": "pcb_component_6",
+    "pcb_smtpad_id": "pcb_smtpad_30",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_15",
+    "pcb_component_id": "pcb_component_6",
+    "layer": "top",
+    "route": [
+      {
+        "x": 0.825,
+        "y": 20.875
+      },
+      {
+        "x": -1.425,
+        "y": 20.875
+      },
+      {
+        "x": -1.425,
+        "y": 19.125
+      },
+      {
+        "x": 0.825,
+        "y": 19.125
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_6",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 0,
+      "y": 21.375
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_6",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_3",
+    "pcb_component_id": "pcb_component_6",
+    "layer": "top",
+    "center": {
+      "x": 0,
+      "y": 20
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_31",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_35",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1,
+    "height": 0.6,
+    "port_hints": [
+      "1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.15,
+    "y": 17.905,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_35",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7,
+    "height": 0.42,
+    "x": -7.15,
+    "y": 17.905,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_31",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_32",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_36",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1,
+    "height": 0.6,
+    "port_hints": [
+      "2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.15,
+    "y": 16.635,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_36",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7,
+    "height": 0.42,
+    "x": -7.15,
+    "y": 16.635,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_32",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_33",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_37",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1,
+    "height": 0.6,
+    "port_hints": [
+      "3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.15,
+    "y": 15.365,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_37",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7,
+    "height": 0.42,
+    "x": -7.15,
+    "y": 15.365,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_33",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_34",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_38",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1,
+    "height": 0.6,
+    "port_hints": [
+      "4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -7.15,
+    "y": 14.095,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_38",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7,
+    "height": 0.42,
+    "x": -7.15,
+    "y": 14.095,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_34",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_35",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_39",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1,
+    "height": 0.6,
+    "port_hints": [
+      "5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.85,
+    "y": 14.095,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_39",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7,
+    "height": 0.42,
+    "x": -2.85,
+    "y": 14.095,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_35",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_36",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_40",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1,
+    "height": 0.6,
+    "port_hints": [
+      "6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.85,
+    "y": 15.365,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_40",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7,
+    "height": 0.42,
+    "x": -2.85,
+    "y": 15.365,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_36",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_37",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_41",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1,
+    "height": 0.6,
+    "port_hints": [
+      "7"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.85,
+    "y": 16.635,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_41",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7,
+    "height": 0.42,
+    "x": -2.85,
+    "y": 16.635,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_37",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_38",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_42",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1,
+    "height": 0.6,
+    "port_hints": [
+      "8"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.85,
+    "y": 17.905,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_42",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.7,
+    "height": 0.42,
+    "x": -2.85,
+    "y": 17.905,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_38",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_16",
+    "pcb_component_id": "pcb_component_7",
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.55,
+        "y": 13.4775
+      },
+      {
+        "x": -6.55,
+        "y": 18.5225
+      },
+      {
+        "x": -5.516666666666667,
+        "y": 18.5225
+      },
+      {
+        "x": -5.477337758464165,
+        "y": 18.32478022661137
+      },
+      {
+        "x": -5.365338503613049,
+        "y": 18.15716149638695
+      },
+      {
+        "x": -5.19771977338863,
+        "y": 18.045162241535834
+      },
+      {
+        "x": -5,
+        "y": 18.005833333333335
+      },
+      {
+        "x": -4.80228022661137,
+        "y": 18.045162241535834
+      },
+      {
+        "x": -4.634661496386951,
+        "y": 18.15716149638695
+      },
+      {
+        "x": -4.522662241535835,
+        "y": 18.32478022661137
+      },
+      {
+        "x": -4.483333333333333,
+        "y": 18.5225
+      },
+      {
+        "x": -3.45,
+        "y": 18.5225
+      },
+      {
+        "x": -3.45,
+        "y": 13.4775
+      },
+      {
+        "x": -6.55,
+        "y": 13.4775
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_7",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -5,
+      "y": 18.9225
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.6204166666666666,
+    "layer": "top",
+    "text": "U3",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_7",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_3",
+    "pcb_component_id": "pcb_component_7",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -7.9,
+        "y": 18.455
+      },
+      {
+        "x": -7.9,
+        "y": 18.455
+      },
+      {
+        "x": -7.9,
+        "y": 18.7725
+      },
+      {
+        "x": -2.1,
+        "y": 18.7725
+      },
+      {
+        "x": -2.1,
+        "y": 18.455
+      },
+      {
+        "x": -2.1,
+        "y": 18.455
+      },
+      {
+        "x": -2.1,
+        "y": 13.545
+      },
+      {
+        "x": -2.1,
+        "y": 13.545
+      },
+      {
+        "x": -2.1,
+        "y": 13.2275
+      },
+      {
+        "x": -7.9,
+        "y": 13.2275
+      },
+      {
+        "x": -7.9,
+        "y": 13.545
+      },
+      {
+        "x": -7.9,
+        "y": 13.545
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_39",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_171",
+    "layer": "top",
+    "shape": "rect",
+    "width": 6.999986,
+    "height": 6.999986,
+    "port_hints": [
+      "pin129"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0,
+    "y": 1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_43",
+    "layer": "top",
+    "shape": "rect",
+    "width": 4.8999901999999995,
+    "height": 4.8999901999999995,
+    "x": 0,
+    "y": 1,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_39",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_40",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_170",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin128"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -5.424932,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_44",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -5.424932,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_40",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_41",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_169",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin127"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -5.07492,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_45",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -5.07492,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_41",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_42",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_168",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin126"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.724908,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_46",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -4.724908,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_42",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_43",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_167",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin125"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.374896,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_47",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -4.374896,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_43",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_44",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_166",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin124"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.024884,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_48",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -4.024884,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_44",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_45",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_165",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin123"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.674872,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_49",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -3.674872,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_45",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_46",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_164",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin122"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.325114,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_50",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -3.325114,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_46",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_47",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_163",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin121"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.975102,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_51",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -2.975102,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_47",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_48",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_162",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin120"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.62509,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_52",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -2.62509,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_48",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_49",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_161",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin119"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.275078,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_53",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -2.275078,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_49",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_50",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_160",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin118"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.925066,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_54",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -1.925066,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_50",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_51",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_159",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin117"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.575054,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_55",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -1.575054,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_51",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_52",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_158",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin116"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.225042,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_56",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -1.225042,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_52",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_53",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_157",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin115"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.87503,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_57",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -0.87503,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_53",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_54",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_156",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin114"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.525018,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_58",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -0.525018,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_54",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_55",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_155",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin113"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.175006,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_59",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -0.175006,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_55",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_56",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_154",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin112"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.175006,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_60",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 0.175006,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_56",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_57",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_153",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin111"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.525018,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_61",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 0.525018,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_57",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_58",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_152",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin110"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.87503,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_62",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 0.87503,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_58",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_59",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_151",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin109"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.225042,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_63",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 1.225042,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_59",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_60",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_150",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin108"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.575054,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_64",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 1.575054,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_60",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_61",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_149",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin107"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.925066,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_65",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 1.925066,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_61",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_62",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_148",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin106"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.275078,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_66",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 2.275078,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_62",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_63",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_147",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin105"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.62509,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_67",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 2.62509,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_63",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_64",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_146",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin104"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.975102,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_68",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 2.975102,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_64",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_65",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_145",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin103"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 3.325114,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_69",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 3.325114,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_65",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_66",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_144",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin102"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 3.674872,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_70",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 3.674872,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_66",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_67",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_143",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin101"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.024884,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_71",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 4.024884,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_67",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_68",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_142",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin100"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.374896,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_72",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 4.374896,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_68",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_69",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_141",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin99"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.724908,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_73",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 4.724908,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_69",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_70",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_140",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin98"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.07492,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_74",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 5.07492,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_70",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_71",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_139",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin97"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.424932,
+    "y": 7.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_75",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 5.424932,
+    "y": 7.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_71",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_72",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_138",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin96"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 6.424932,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_76",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 6.424932,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_72",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_73",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_137",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin95"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 6.07492,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_77",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 6.07492,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_73",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_74",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_136",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin94"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 5.724908,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_78",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 5.724908,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_74",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_75",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_135",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin93"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 5.374896,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_79",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 5.374896,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_75",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_76",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_134",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin92"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 5.024884,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_80",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 5.024884,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_76",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_77",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_133",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin91"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 4.674872000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_81",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 4.674872000000001,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_77",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_78",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_132",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin90"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 4.325114,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_82",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 4.325114,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_78",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_79",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_131",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin89"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 3.975102,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_83",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 3.975102,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_79",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_80",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_130",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin88"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 3.62509,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_84",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 3.62509,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_80",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_81",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_129",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin87"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 3.275078,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_85",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 3.275078,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_81",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_82",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_128",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin86"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 2.925066,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_86",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 2.925066,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_82",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_83",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_127",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin85"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 2.5750539999999997,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_87",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 2.5750539999999997,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_83",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_84",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_126",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin84"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 2.225042,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_88",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 2.225042,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_84",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_85",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_125",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin83"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 1.87503,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_89",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 1.87503,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_85",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_86",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_124",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin82"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 1.525018,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_90",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 1.525018,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_86",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_87",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_123",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin81"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 1.175006,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_91",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 1.175006,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_87",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_88",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_122",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin80"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 0.824994,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_92",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 0.824994,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_88",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_89",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_121",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin79"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 0.474982,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_93",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 0.474982,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_89",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_90",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_120",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin78"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": 0.12497000000000003,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_94",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": 0.12497000000000003,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_90",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_91",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_119",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin77"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -0.22504199999999996,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_95",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -0.22504199999999996,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_91",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_92",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_118",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin76"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -0.575054,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_96",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -0.575054,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_92",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_93",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_117",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin75"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -0.9250659999999999,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_97",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -0.9250659999999999,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_93",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_94",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_116",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin74"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -1.2750780000000002,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_98",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -1.2750780000000002,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_94",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_95",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_115",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin73"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -1.6250900000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_99",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -1.6250900000000001,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_95",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_96",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_114",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin72"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -1.9751020000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_100",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -1.9751020000000001,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_96",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_97",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_113",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin71"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -2.325114,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_101",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -2.325114,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_97",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_98",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_112",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin70"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -2.674872,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_102",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -2.674872,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_98",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_99",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_111",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin69"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -3.024884,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_103",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -3.024884,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_99",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_100",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_110",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin68"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -3.3748959999999997,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_104",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -3.3748959999999997,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_100",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_101",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_109",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin67"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -3.724908,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_105",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -3.724908,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_101",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_102",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_108",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin66"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -4.07492,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_106",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -4.07492,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_102",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_103",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_107",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin65"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 6.057392,
+    "y": -4.424932,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_107",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": 6.057392,
+    "y": -4.424932,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_103",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_104",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_106",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin64"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.424932,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_108",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 5.424932,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_104",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_105",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_105",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin63"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.07492,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_109",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 5.07492,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_105",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_106",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_104",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin62"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.724908,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_110",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 4.724908,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_106",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_107",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_103",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin61"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.374896,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_111",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 4.374896,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_107",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_108",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_102",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin60"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.024884,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_112",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 4.024884,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_108",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_109",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_101",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin59"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 3.674872,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_113",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 3.674872,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_109",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_110",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_100",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin58"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 3.325114,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_114",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 3.325114,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_110",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_111",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_99",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin57"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.975102,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_115",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 2.975102,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_111",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_112",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_98",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin56"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.62509,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_116",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 2.62509,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_112",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_113",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_97",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin55"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.275078,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_117",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 2.275078,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_113",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_114",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_96",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin54"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.925066,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_118",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 1.925066,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_114",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_115",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_95",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin53"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.575054,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_119",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 1.575054,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_115",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_116",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_94",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin52"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.225042,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_120",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 1.225042,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_116",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_117",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_93",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin51"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.87503,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_121",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 0.87503,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_117",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_118",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_92",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin50"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.525018,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_122",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 0.525018,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_118",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_119",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_91",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin49"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 0.175006,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_123",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": 0.175006,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_119",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_120",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_90",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin48"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.175006,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_124",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -0.175006,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_120",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_121",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_89",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin47"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.525018,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_125",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -0.525018,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_121",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_122",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_88",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin46"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -0.87503,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_126",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -0.87503,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_122",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_123",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_87",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin45"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.225042,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_127",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -1.225042,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_123",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_124",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_86",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin44"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.575054,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_128",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -1.575054,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_124",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_125",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_85",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin43"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -1.925066,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_129",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -1.925066,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_125",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_126",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_84",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin42"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.275078,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_130",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -2.275078,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_126",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_127",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_83",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin41"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.62509,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_131",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -2.62509,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_127",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_128",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_82",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin40"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.975102,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_132",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -2.975102,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_128",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_129",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_81",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin39"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.325114,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_133",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -3.325114,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_129",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_130",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_80",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin38"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -3.674872,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_134",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -3.674872,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_130",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_131",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_79",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin37"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.024884,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_135",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -4.024884,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_131",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_132",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_78",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin36"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.374896,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_136",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -4.374896,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_132",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_133",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_77",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin35"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -4.724908,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_137",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -4.724908,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_133",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_134",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_76",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin34"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -5.07492,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_138",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -5.07492,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_134",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_135",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_75",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.1960118,
+    "height": 0.6649974,
+    "port_hints": [
+      "pin33"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -5.424932,
+    "y": -5.057392,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_139",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.13720826,
+    "height": 0.46549817999999993,
+    "x": -5.424932,
+    "y": -5.057392,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_135",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_136",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_74",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin32"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -4.424932,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_140",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -4.424932,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_136",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_137",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_73",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin31"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -4.07492,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_141",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -4.07492,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_137",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_138",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_72",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin30"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -3.724908,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_142",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -3.724908,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_138",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_139",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_71",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin29"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -3.3748959999999997,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_143",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -3.3748959999999997,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_139",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_140",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_70",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin28"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -3.024884,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_144",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -3.024884,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_140",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_141",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_69",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin27"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -2.674872,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_145",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -2.674872,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_141",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_142",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_68",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin26"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -2.325114,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_146",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -2.325114,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_142",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_143",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_67",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin25"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -1.9751020000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_147",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -1.9751020000000001,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_143",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_144",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_66",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin24"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -1.6250900000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_148",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -1.6250900000000001,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_144",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_145",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_65",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin23"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -1.2750780000000002,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_149",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -1.2750780000000002,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_145",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_146",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_64",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin22"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -0.9250659999999999,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_150",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -0.9250659999999999,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_146",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_147",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_63",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin21"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -0.575054,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_151",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -0.575054,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_147",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_148",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_62",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin20"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": -0.22504199999999996,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_152",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": -0.22504199999999996,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_148",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_149",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_61",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin19"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 0.12497000000000003,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_153",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 0.12497000000000003,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_149",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_150",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_60",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin18"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 0.474982,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_154",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 0.474982,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_150",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_151",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_59",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin17"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 0.824994,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_155",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 0.824994,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_151",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_152",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_58",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin16"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 1.175006,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_156",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 1.175006,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_152",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_153",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_57",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin15"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 1.525018,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_157",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 1.525018,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_153",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_154",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_56",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin14"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 1.87503,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_158",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 1.87503,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_154",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_155",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_55",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin13"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 2.225042,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_159",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 2.225042,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_155",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_156",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_54",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin12"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 2.5750539999999997,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_160",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 2.5750539999999997,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_156",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_157",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_53",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin11"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 2.925066,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_161",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 2.925066,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_157",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_158",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_52",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin10"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 3.275078,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_162",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 3.275078,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_158",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_159",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_51",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin9"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 3.62509,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_163",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 3.62509,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_159",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_160",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_50",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin8"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 3.975102,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_164",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 3.975102,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_160",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_161",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_49",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin7"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 4.325114,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_165",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 4.325114,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_161",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_162",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_48",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 4.674872000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_166",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 4.674872000000001,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_162",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_163",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_47",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 5.024884,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_167",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 5.024884,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_163",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_164",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_46",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 5.374896,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_168",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 5.374896,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_164",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_165",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_45",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 5.724908,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_169",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 5.724908,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_165",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_166",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_44",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 6.07492,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_170",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 6.07492,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_166",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_167",
+    "pcb_component_id": "pcb_component_8",
+    "pcb_port_id": "pcb_port_43",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649974,
+    "height": 0.1960118,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -6.057392,
+    "y": 6.424932,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_171",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.46549817999999993,
+    "height": 0.13720826,
+    "x": -6.057392,
+    "y": 6.424932,
+    "pcb_component_id": "pcb_component_8",
+    "pcb_smtpad_id": "pcb_smtpad_167",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_17",
+    "pcb_component_id": "pcb_component_8",
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.226302000000032,
+        "y": 6.675376000000028
+      },
+      {
+        "x": -6.226302000000032,
+        "y": 7.226175000000012
+      },
+      {
+        "x": -5.675502999999935,
+        "y": 7.226175000000012
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_18",
+    "pcb_component_id": "pcb_component_8",
+    "layer": "top",
+    "route": [
+      {
+        "x": 6.226073399999905,
+        "y": 6.675376000000028
+      },
+      {
+        "x": 6.226073399999905,
+        "y": 7.226175000000012
+      },
+      {
+        "x": 5.675274400000035,
+        "y": 7.226175000000012
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_19",
+    "pcb_component_id": "pcb_component_8",
+    "layer": "top",
+    "route": [
+      {
+        "x": 6.226073399999905,
+        "y": -4.6754013999999415
+      },
+      {
+        "x": 6.226073399999905,
+        "y": -5.226174999999898
+      },
+      {
+        "x": 5.675274400000035,
+        "y": -5.226174999999898
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_20",
+    "pcb_component_id": "pcb_component_8",
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.226302000000032,
+        "y": -4.6754013999999415
+      },
+      {
+        "x": -6.226302000000032,
+        "y": -5.226174999999898
+      },
+      {
+        "x": -5.675502999999935,
+        "y": -5.226174999999898
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_21",
+    "pcb_component_id": "pcb_component_8",
+    "layer": "top",
+    "route": [
+      {
+        "x": -6.428231999999866,
+        "y": 6.424932000000126
+      },
+      {
+        "x": -6.432490181340199,
+        "y": 6.392587901571574
+      },
+      {
+        "x": -6.444974537339817,
+        "y": 6.362448000000086
+      },
+      {
+        "x": -6.464834279768638,
+        "y": 6.336566279768817
+      },
+      {
+        "x": -6.490715999999907,
+        "y": 6.316706537339996
+      },
+      {
+        "x": -6.520855901571622,
+        "y": 6.304222181340265
+      },
+      {
+        "x": -6.553199999999947,
+        "y": 6.299964000000045
+      },
+      {
+        "x": -6.585544098428386,
+        "y": 6.304222181340265
+      },
+      {
+        "x": -6.6156839999999875,
+        "y": 6.316706537339996
+      },
+      {
+        "x": -6.64156572023137,
+        "y": 6.336566279768817
+      },
+      {
+        "x": -6.661425462660077,
+        "y": 6.362448000000086
+      },
+      {
+        "x": -6.673909818659695,
+        "y": 6.392587901571574
+      },
+      {
+        "x": -6.678168000000028,
+        "y": 6.424932000000126
+      },
+      {
+        "x": -6.673909818659695,
+        "y": 6.457276098428338
+      },
+      {
+        "x": -6.661425462660077,
+        "y": 6.487416000000167
+      },
+      {
+        "x": -6.64156572023137,
+        "y": 6.513297720231321
+      },
+      {
+        "x": -6.6156839999999875,
+        "y": 6.533157462660256
+      },
+      {
+        "x": -6.585544098428386,
+        "y": 6.54564181865976
+      },
+      {
+        "x": -6.553199999999947,
+        "y": 6.549900000000207
+      },
+      {
+        "x": -6.520855901571622,
+        "y": 6.54564181865976
+      },
+      {
+        "x": -6.490715999999907,
+        "y": 6.533157462660256
+      },
+      {
+        "x": -6.464834279768638,
+        "y": 6.513297720231321
+      },
+      {
+        "x": -6.444974537339817,
+        "y": 6.487416000000167
+      },
+      {
+        "x": -6.432490181340199,
+        "y": 6.457276098428338
+      },
+      {
+        "x": -6.428231999999866,
+        "y": 6.424932000000126
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_8",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -0.155702,
+      "y": 8.386576
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "U1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_8",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_4",
+    "pcb_component_id": "pcb_component_8",
+    "layer": "top",
+    "outline": [
+      {
+        "x": -6.9335020000000895,
+        "y": 7.636576000000105
+      },
+      {
+        "x": 6.6220979999998235,
+        "y": 7.636576000000105
+      },
+      {
+        "x": 6.6220979999998235,
+        "y": -5.639624000000026
+      },
+      {
+        "x": -6.9335020000000895,
+        "y": -5.639624000000026
+      },
+      {
+        "x": -6.9335020000000895,
+        "y": 7.636576000000105
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_168",
+    "pcb_component_id": "pcb_component_9",
+    "pcb_port_id": "pcb_port_172",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2,
+    "height": 2.4,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.85,
+    "y": 1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_172",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.84,
+    "height": 1.68,
+    "x": 7.85,
+    "y": 1,
+    "pcb_component_id": "pcb_component_9",
+    "pcb_smtpad_id": "pcb_smtpad_168",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_169",
+    "pcb_component_id": "pcb_component_9",
+    "pcb_port_id": "pcb_port_173",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2,
+    "height": 2.4,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 10.15,
+    "y": 1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_173",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.84,
+    "height": 1.68,
+    "x": 10.15,
+    "y": 1,
+    "pcb_component_id": "pcb_component_9",
+    "pcb_smtpad_id": "pcb_smtpad_169",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_rect",
+    "pcb_silkscreen_rect_id": "pcb_silkscreen_rect_0",
+    "pcb_component_id": "pcb_component_9",
+    "layer": "top",
+    "center": {
+      "x": 9,
+      "y": 1
+    },
+    "width": 3.4,
+    "height": 2.7,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "stroke_width": 0.1,
+    "is_filled": false
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_170",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_174",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 8.49,
+    "y": -1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_174",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 8.49,
+    "y": -1,
+    "pcb_component_id": "pcb_component_10",
+    "pcb_smtpad_id": "pcb_smtpad_170",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_171",
+    "pcb_component_id": "pcb_component_10",
+    "pcb_port_id": "pcb_port_175",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 9.51,
+    "y": -1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_175",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 9.51,
+    "y": -1,
+    "pcb_component_id": "pcb_component_10",
+    "pcb_smtpad_id": "pcb_smtpad_171",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_22",
+    "pcb_component_id": "pcb_component_10",
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.51,
+        "y": -0.28
+      },
+      {
+        "x": 8.02,
+        "y": -0.28
+      },
+      {
+        "x": 8.02,
+        "y": -1.72
+      },
+      {
+        "x": 9.51,
+        "y": -1.72
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_9",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 9,
+      "y": -2.2199999999999998
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C3",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_10",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_4",
+    "pcb_component_id": "pcb_component_10",
+    "layer": "top",
+    "center": {
+      "x": 9,
+      "y": -1
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_172",
+    "pcb_component_id": "pcb_component_11",
+    "pcb_port_id": "pcb_port_176",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 11.49,
+    "y": 2.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_176",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 11.49,
+    "y": 2.5,
+    "pcb_component_id": "pcb_component_11",
+    "pcb_smtpad_id": "pcb_smtpad_172",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_173",
+    "pcb_component_id": "pcb_component_11",
+    "pcb_port_id": "pcb_port_177",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 12.51,
+    "y": 2.5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_177",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 12.51,
+    "y": 2.5,
+    "pcb_component_id": "pcb_component_11",
+    "pcb_smtpad_id": "pcb_smtpad_173",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_23",
+    "pcb_component_id": "pcb_component_11",
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.51,
+        "y": 3.2199999999999998
+      },
+      {
+        "x": 11.02,
+        "y": 3.2199999999999998
+      },
+      {
+        "x": 11.02,
+        "y": 1.78
+      },
+      {
+        "x": 12.51,
+        "y": 1.78
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_10",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 12,
+      "y": 3.7199999999999998
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C4",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_11",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_5",
+    "pcb_component_id": "pcb_component_11",
+    "layer": "top",
+    "center": {
+      "x": 12,
+      "y": 2.5
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_174",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_178",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.175,
+    "y": -9,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_178",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 2.175,
+    "y": -9,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_174",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_175",
+    "pcb_component_id": "pcb_component_12",
+    "pcb_port_id": "pcb_port_179",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 3.825,
+    "y": -9,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_179",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 3.825,
+    "y": -9,
+    "pcb_component_id": "pcb_component_12",
+    "pcb_smtpad_id": "pcb_smtpad_175",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_24",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "route": [
+      {
+        "x": 2.762742,
+        "y": -8.4775
+      },
+      {
+        "x": 3.237258,
+        "y": -8.4775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_25",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "route": [
+      {
+        "x": 2.762742,
+        "y": -9.5225
+      },
+      {
+        "x": 3.237258,
+        "y": -9.5225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_11",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 3,
+      "y": -7.625
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R3",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_12",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_6",
+    "pcb_component_id": "pcb_component_12",
+    "layer": "top",
+    "center": {
+      "x": 3,
+      "y": -9
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_176",
+    "pcb_component_id": "pcb_component_13",
+    "pcb_port_id": "pcb_port_180",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.1999976,
+    "height": 0.6500114,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.850016999999999,
+    "y": -8.924945,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_180",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8399983200000001,
+    "height": 0.45500798,
+    "x": 7.850016999999999,
+    "y": -8.924945,
+    "pcb_component_id": "pcb_component_13",
+    "pcb_smtpad_id": "pcb_smtpad_176",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_177",
+    "pcb_component_id": "pcb_component_13",
+    "pcb_port_id": "pcb_port_182",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.1999976,
+    "height": 0.6500114,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 12.149983,
+    "y": -8.924945,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_181",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8399983200000001,
+    "height": 0.45500798,
+    "x": 12.149983,
+    "y": -8.924945,
+    "pcb_component_id": "pcb_component_13",
+    "pcb_smtpad_id": "pcb_smtpad_177",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_178",
+    "pcb_component_id": "pcb_component_13",
+    "pcb_port_id": "pcb_port_181",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.1999976,
+    "height": 0.6500114,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.850016999999999,
+    "y": -11.075055,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_182",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8399983200000001,
+    "height": 0.45500798,
+    "x": 7.850016999999999,
+    "y": -11.075055,
+    "pcb_component_id": "pcb_component_13",
+    "pcb_smtpad_id": "pcb_smtpad_178",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_179",
+    "pcb_component_id": "pcb_component_13",
+    "pcb_port_id": "pcb_port_183",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.1999976,
+    "height": 0.6500114,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 12.149983,
+    "y": -11.075055,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_183",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8399983200000001,
+    "height": 0.45500798,
+    "x": 12.149983,
+    "y": -11.075055,
+    "pcb_component_id": "pcb_component_13",
+    "pcb_smtpad_id": "pcb_smtpad_179",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_26",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.900055000000066,
+        "y": -8.299927199999956
+      },
+      {
+        "x": 12.100046600000042,
+        "y": -8.299952600000097
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_27",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.900055000000066,
+        "y": -11.699971199999936
+      },
+      {
+        "x": 12.100046600000042,
+        "y": -11.69994579999991
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_28",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.900055000000066,
+        "y": -8.299927199999956
+      },
+      {
+        "x": 7.900055000000066,
+        "y": -8.368811999999934
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_29",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.900055000000066,
+        "y": -9.481078000000025
+      },
+      {
+        "x": 7.900055000000066,
+        "y": -10.518820399999981
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_30",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.900055000000066,
+        "y": -11.631086400000072
+      },
+      {
+        "x": 7.900055000000066,
+        "y": -11.699971199999936
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_31",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.100046600000042,
+        "y": -8.299952600000097
+      },
+      {
+        "x": 12.100046600000042,
+        "y": -8.368811999999934
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_32",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.100046600000042,
+        "y": -9.481078000000025
+      },
+      {
+        "x": 12.100046600000042,
+        "y": -10.518820399999981
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_33",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.100046600000042,
+        "y": -11.631086400000072
+      },
+      {
+        "x": 12.100046600000042,
+        "y": -11.69994579999991
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_34",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.238050799999996,
+        "y": -9.36494920000007
+      },
+      {
+        "x": 10.762050799999997,
+        "y": -9.36494920000007
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_35",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.238076200000023,
+        "y": -10.634923800000024
+      },
+      {
+        "x": 10.762076200000024,
+        "y": -10.634923800000024
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_36",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.238076200000023,
+        "y": -10.634923800000024
+      },
+      {
+        "x": 9.236856999999986,
+        "y": -9.36436500000002
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_37",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "route": [
+      {
+        "x": 10.762050799999997,
+        "y": -9.36494920000007
+      },
+      {
+        "x": 11.003679257342014,
+        "y": -9.414625328443776
+      },
+      {
+        "x": 11.208120748887836,
+        "y": -9.552667733773546
+      },
+      {
+        "x": 11.344495159000417,
+        "y": -9.758225631702999
+      },
+      {
+        "x": 11.392203647774977,
+        "y": -10.000250277624673
+      },
+      {
+        "x": 11.344040028057293,
+        "y": -10.242184762290094
+      },
+      {
+        "x": 11.20727923281288,
+        "y": -10.44748579496843
+      },
+      {
+        "x": 11.002578463961981,
+        "y": -10.585143429578807
+      },
+      {
+        "x": 10.760856999999987,
+        "y": -10.634365000000003
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_5",
+    "pcb_component_id": "pcb_component_13",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 6.9904169999999795,
+        "y": -8.014544999999998
+      },
+      {
+        "x": 13.002216999999973,
+        "y": -8.014544999999998
+      },
+      {
+        "x": 13.002216999999973,
+        "y": -11.943544999999972
+      },
+      {
+        "x": 6.9904169999999795,
+        "y": -11.943544999999972
+      },
+      {
+        "x": 6.9904169999999795,
+        "y": -8.014544999999998
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_180",
+    "pcb_component_id": "pcb_component_14",
+    "pcb_port_id": "pcb_port_184",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.1999976,
+    "height": 0.6500114,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.850016999999999,
+    "y": -16.924945,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_184",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8399983200000001,
+    "height": 0.45500798,
+    "x": 7.850016999999999,
+    "y": -16.924945,
+    "pcb_component_id": "pcb_component_14",
+    "pcb_smtpad_id": "pcb_smtpad_180",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_181",
+    "pcb_component_id": "pcb_component_14",
+    "pcb_port_id": "pcb_port_186",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.1999976,
+    "height": 0.6500114,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 12.149983,
+    "y": -16.924945,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_185",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8399983200000001,
+    "height": 0.45500798,
+    "x": 12.149983,
+    "y": -16.924945,
+    "pcb_component_id": "pcb_component_14",
+    "pcb_smtpad_id": "pcb_smtpad_181",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_182",
+    "pcb_component_id": "pcb_component_14",
+    "pcb_port_id": "pcb_port_185",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.1999976,
+    "height": 0.6500114,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7.850016999999999,
+    "y": -19.075055,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_186",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8399983200000001,
+    "height": 0.45500798,
+    "x": 7.850016999999999,
+    "y": -19.075055,
+    "pcb_component_id": "pcb_component_14",
+    "pcb_smtpad_id": "pcb_smtpad_182",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_183",
+    "pcb_component_id": "pcb_component_14",
+    "pcb_port_id": "pcb_port_187",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.1999976,
+    "height": 0.6500114,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 12.149983,
+    "y": -19.075055,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_187",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8399983200000001,
+    "height": 0.45500798,
+    "x": 12.149983,
+    "y": -19.075055,
+    "pcb_component_id": "pcb_component_14",
+    "pcb_smtpad_id": "pcb_smtpad_183",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_38",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.900055000000066,
+        "y": -16.299927199999956
+      },
+      {
+        "x": 12.100046600000042,
+        "y": -16.299952600000097
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_39",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.900055000000066,
+        "y": -19.699971199999936
+      },
+      {
+        "x": 12.100046600000042,
+        "y": -19.69994579999991
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_40",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.900055000000066,
+        "y": -16.299927199999956
+      },
+      {
+        "x": 7.900055000000066,
+        "y": -16.368811999999934
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_41",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.900055000000066,
+        "y": -17.481078000000025
+      },
+      {
+        "x": 7.900055000000066,
+        "y": -18.51882039999998
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_42",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.900055000000066,
+        "y": -19.631086400000072
+      },
+      {
+        "x": 7.900055000000066,
+        "y": -19.699971199999936
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_43",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.100046600000042,
+        "y": -16.299952600000097
+      },
+      {
+        "x": 12.100046600000042,
+        "y": -16.368811999999934
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_44",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.100046600000042,
+        "y": -17.481078000000025
+      },
+      {
+        "x": 12.100046600000042,
+        "y": -18.51882039999998
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_45",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.100046600000042,
+        "y": -19.631086400000072
+      },
+      {
+        "x": 12.100046600000042,
+        "y": -19.69994579999991
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_46",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.238050799999996,
+        "y": -17.36494920000007
+      },
+      {
+        "x": 10.762050799999997,
+        "y": -17.36494920000007
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_47",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.238076200000023,
+        "y": -18.634923800000024
+      },
+      {
+        "x": 10.762076200000024,
+        "y": -18.634923800000024
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_48",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.238076200000023,
+        "y": -18.634923800000024
+      },
+      {
+        "x": 9.236856999999986,
+        "y": -17.36436500000002
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_49",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "route": [
+      {
+        "x": 10.762050799999997,
+        "y": -17.36494920000007
+      },
+      {
+        "x": 11.003679257342014,
+        "y": -17.414625328443776
+      },
+      {
+        "x": 11.208120748887836,
+        "y": -17.552667733773546
+      },
+      {
+        "x": 11.344495159000417,
+        "y": -17.758225631703
+      },
+      {
+        "x": 11.392203647774977,
+        "y": -18.000250277624673
+      },
+      {
+        "x": 11.344040028057293,
+        "y": -18.242184762290094
+      },
+      {
+        "x": 11.20727923281288,
+        "y": -18.44748579496843
+      },
+      {
+        "x": 11.002578463961981,
+        "y": -18.585143429578807
+      },
+      {
+        "x": 10.760856999999987,
+        "y": -18.634365000000003
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_6",
+    "pcb_component_id": "pcb_component_14",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 6.9904169999999795,
+        "y": -16.014545
+      },
+      {
+        "x": 13.002216999999973,
+        "y": -16.014545
+      },
+      {
+        "x": 13.002216999999973,
+        "y": -19.943544999999972
+      },
+      {
+        "x": 6.9904169999999795,
+        "y": -19.943544999999972
+      },
+      {
+        "x": 6.9904169999999795,
+        "y": -16.014545
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_184",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_188",
+    "layer": "top",
+    "shape": "pill",
+    "x": 8.095,
+    "y": 5.469908,
+    "radius": 0.3149981,
+    "height": 2.2500082,
+    "width": 0.6299962,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_185",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_189",
+    "layer": "top",
+    "shape": "pill",
+    "x": 9.365,
+    "y": 5.469908,
+    "radius": 0.3149981,
+    "height": 2.2500082,
+    "width": 0.6299962,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_186",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_190",
+    "layer": "top",
+    "shape": "pill",
+    "x": 10.635,
+    "y": 5.469908,
+    "radius": 0.3149981,
+    "height": 2.2500082,
+    "width": 0.6299962,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_187",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_191",
+    "layer": "top",
+    "shape": "pill",
+    "x": 11.905,
+    "y": 5.469908,
+    "radius": 0.3149981,
+    "height": 2.2500082,
+    "width": 0.6299962,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_188",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_195",
+    "layer": "top",
+    "shape": "pill",
+    "x": 8.095,
+    "y": 12.530092,
+    "radius": 0.3149981,
+    "height": 2.2500082,
+    "width": 0.6299962,
+    "port_hints": [
+      "pin8"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_189",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_194",
+    "layer": "top",
+    "shape": "pill",
+    "x": 9.365,
+    "y": 12.530092,
+    "radius": 0.3149981,
+    "height": 2.2500082,
+    "width": 0.6299962,
+    "port_hints": [
+      "pin7"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_190",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_193",
+    "layer": "top",
+    "shape": "pill",
+    "x": 10.635,
+    "y": 12.530092,
+    "radius": 0.3149981,
+    "height": 2.2500082,
+    "width": 0.6299962,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_191",
+    "pcb_component_id": "pcb_component_15",
+    "pcb_port_id": "pcb_port_192",
+    "layer": "top",
+    "shape": "pill",
+    "x": 11.905,
+    "y": 12.530092,
+    "radius": 0.3149981,
+    "height": 2.2500082,
+    "width": 0.6299962,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_50",
+    "pcb_component_id": "pcb_component_15",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.3612955999999485,
+        "y": 6.823601000000053
+      },
+      {
+        "x": 7.3612955999999485,
+        "y": 11.17639900000006
+      },
+      {
+        "x": 12.638704400000051,
+        "y": 11.17639900000006
+      },
+      {
+        "x": 12.638704400000051,
+        "y": 6.823601000000053
+      },
+      {
+        "x": 7.3612955999999485,
+        "y": 6.823601000000053
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_51",
+    "pcb_component_id": "pcb_component_15",
+    "layer": "top",
+    "route": [
+      {
+        "x": 8.245114000000058,
+        "y": 7.576075999999944
+      },
+      {
+        "x": 8.239998989487503,
+        "y": 7.5372236378634625
+      },
+      {
+        "x": 8.225002537463638,
+        "y": 7.501018999999928
+      },
+      {
+        "x": 8.201146627351022,
+        "y": 7.469929372648949
+      },
+      {
+        "x": 8.170057000000043,
+        "y": 7.446073462536219
+      },
+      {
+        "x": 8.133852362136622,
+        "y": 7.4310770105124675
+      },
+      {
+        "x": 8.094999999999914,
+        "y": 7.425962000000027
+      },
+      {
+        "x": 8.056147637863432,
+        "y": 7.4310770105124675
+      },
+      {
+        "x": 8.019943000000012,
+        "y": 7.446073462536219
+      },
+      {
+        "x": 7.988853372648919,
+        "y": 7.469929372648949
+      },
+      {
+        "x": 7.964997462536303,
+        "y": 7.501018999999928
+      },
+      {
+        "x": 7.950001010512551,
+        "y": 7.5372236378634625
+      },
+      {
+        "x": 7.944885999999997,
+        "y": 7.576075999999944
+      },
+      {
+        "x": 7.950001010512551,
+        "y": 7.6149283621365385
+      },
+      {
+        "x": 7.964997462536303,
+        "y": 7.651133000000073
+      },
+      {
+        "x": 7.988853372648919,
+        "y": 7.682222627350939
+      },
+      {
+        "x": 8.019943000000012,
+        "y": 7.706078537463554
+      },
+      {
+        "x": 8.056147637863432,
+        "y": 7.7210749894875335
+      },
+      {
+        "x": 8.094999999999914,
+        "y": 7.726189999999974
+      },
+      {
+        "x": 8.133852362136622,
+        "y": 7.7210749894875335
+      },
+      {
+        "x": 8.170057000000043,
+        "y": 7.706078537463554
+      },
+      {
+        "x": 8.201146627351022,
+        "y": 7.682222627350939
+      },
+      {
+        "x": 8.225002537463638,
+        "y": 7.651133000000073
+      },
+      {
+        "x": 8.239998989487503,
+        "y": 7.6149283621365385
+      },
+      {
+        "x": 8.245114000000058,
+        "y": 7.576075999999944
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_52",
+    "pcb_component_id": "pcb_component_15",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.477779999999939,
+        "y": 5.4699079999999185
+      },
+      {
+        "x": 7.4726649894873844,
+        "y": 5.431055637863437
+      },
+      {
+        "x": 7.457668537463519,
+        "y": 5.394851000000017
+      },
+      {
+        "x": 7.433812627350903,
+        "y": 5.3637613726489235
+      },
+      {
+        "x": 7.402722999999924,
+        "y": 5.339905462536308
+      },
+      {
+        "x": 7.366518362136503,
+        "y": 5.324909010512556
+      },
+      {
+        "x": 7.327665999999908,
+        "y": 5.319794000000002
+      },
+      {
+        "x": 7.2888136378633135,
+        "y": 5.324909010512556
+      },
+      {
+        "x": 7.252608999999893,
+        "y": 5.339905462536308
+      },
+      {
+        "x": 7.221519372648913,
+        "y": 5.3637613726489235
+      },
+      {
+        "x": 7.197663462536184,
+        "y": 5.394851000000017
+      },
+      {
+        "x": 7.182667010512432,
+        "y": 5.431055637863437
+      },
+      {
+        "x": 7.177551999999878,
+        "y": 5.4699079999999185
+      },
+      {
+        "x": 7.182667010512432,
+        "y": 5.508760362136627
+      },
+      {
+        "x": 7.197663462536184,
+        "y": 5.544965000000047
+      },
+      {
+        "x": 7.221519372648913,
+        "y": 5.576054627351027
+      },
+      {
+        "x": 7.252608999999893,
+        "y": 5.599910537463643
+      },
+      {
+        "x": 7.2888136378633135,
+        "y": 5.614906989487508
+      },
+      {
+        "x": 7.327665999999908,
+        "y": 5.620022000000063
+      },
+      {
+        "x": 7.366518362136503,
+        "y": 5.614906989487508
+      },
+      {
+        "x": 7.402722999999924,
+        "y": 5.599910537463643
+      },
+      {
+        "x": 7.433812627350903,
+        "y": 5.576054627351027
+      },
+      {
+        "x": 7.457668537463519,
+        "y": 5.544965000000047
+      },
+      {
+        "x": 7.4726649894873844,
+        "y": 5.508760362136627
+      },
+      {
+        "x": 7.477779999999939,
+        "y": 5.4699079999999185
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_12",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 9.9111,
+      "y": 14.343399999999999
+    },
+    "font": "tscircuit2024",
+    "font_size": 1,
+    "layer": "top",
+    "text": "U4",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_15",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_outline",
+    "pcb_courtyard_outline_id": "pcb_courtyard_outline_7",
+    "pcb_component_id": "pcb_component_15",
+    "layer": "top",
+    "outline": [
+      {
+        "x": 6.930600000000027,
+        "y": 13.593399999999974
+      },
+      {
+        "x": 12.891599999999926,
+        "y": 13.593399999999974
+      },
+      {
+        "x": 12.891599999999926,
+        "y": 4.254199999999969
+      },
+      {
+        "x": 6.930600000000027,
+        "y": 4.254199999999969
+      },
+      {
+        "x": 6.930600000000027,
+        "y": 13.593399999999974
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_192",
+    "pcb_component_id": "pcb_component_16",
+    "pcb_port_id": "pcb_port_196",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 4.49,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_188",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 4.49,
+    "y": 14,
+    "pcb_component_id": "pcb_component_16",
+    "pcb_smtpad_id": "pcb_smtpad_192",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_193",
+    "pcb_component_id": "pcb_component_16",
+    "pcb_port_id": "pcb_port_197",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.54,
+    "height": 0.64,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 5.51,
+    "y": 14,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_189",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.378,
+    "height": 0.44799999999999995,
+    "x": 5.51,
+    "y": 14,
+    "pcb_component_id": "pcb_component_16",
+    "pcb_smtpad_id": "pcb_smtpad_193",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_53",
+    "pcb_component_id": "pcb_component_16",
+    "layer": "top",
+    "route": [
+      {
+        "x": 5.51,
+        "y": 14.72
+      },
+      {
+        "x": 4.02,
+        "y": 14.72
+      },
+      {
+        "x": 4.02,
+        "y": 13.28
+      },
+      {
+        "x": 5.51,
+        "y": 13.28
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_13",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 5,
+      "y": 15.22
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C5",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_16",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_7",
+    "pcb_component_id": "pcb_component_16",
+    "layer": "top",
+    "center": {
+      "x": 5,
+      "y": 14
+    },
+    "width": 1.86,
+    "height": 0.94,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_4",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_198",
+    "hole_diameter": 1,
+    "rect_pad_width": 1.5,
+    "rect_pad_height": 1.5,
+    "shape": "circular_hole_with_rect_pad",
+    "port_hints": [
+      "unnamed_platedhole5",
+      "1"
+    ],
+    "x": -20.5,
+    "y": -11.43,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0",
+    "hole_offset_x": 0,
+    "hole_offset_y": 0,
+    "rect_border_radius": 0,
+    "rect_ccw_rotation": 90
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_14",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -21.85,
+      "y": -11.43
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "G",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_5",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_199",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole6",
+      "2"
+    ],
+    "x": -20.5,
+    "y": -8.89,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_190",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": -8.89,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_191",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": -8.89,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_15",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -21.85,
+      "y": -8.89
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "3V3",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_6",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_200",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole7",
+      "3"
+    ],
+    "x": -20.5,
+    "y": -6.35,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_192",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": -6.35,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_193",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": -6.35,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_16",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -21.85,
+      "y": -6.35
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "GP0",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_7",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_201",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole8",
+      "4"
+    ],
+    "x": -20.5,
+    "y": -3.8099999999999996,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_194",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": -3.8099999999999996,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_195",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": -3.8099999999999996,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_17",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -21.85,
+      "y": -3.8099999999999996
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "GP1",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_8",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_202",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole9",
+      "5"
+    ],
+    "x": -20.5,
+    "y": -1.2699999999999996,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_196",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": -1.2699999999999996,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_197",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": -1.2699999999999996,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_18",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -21.85,
+      "y": -1.2699999999999996
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "SDA",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_9",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_203",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole10",
+      "6"
+    ],
+    "x": -20.5,
+    "y": 1.2699999999999996,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_198",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": 1.2699999999999996,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_199",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": 1.2699999999999996,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_19",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -21.85,
+      "y": 1.2699999999999996
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "SCL",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_10",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_204",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole11",
+      "7"
+    ],
+    "x": -20.5,
+    "y": 3.8100000000000005,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_200",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": 3.8100000000000005,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_201",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": 3.8100000000000005,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_20",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -21.85,
+      "y": 3.8100000000000005
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "TX",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_11",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_205",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole12",
+      "8"
+    ],
+    "x": -20.5,
+    "y": 6.350000000000001,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_202",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": 6.350000000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_203",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": 6.350000000000001,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_21",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -21.85,
+      "y": 6.350000000000001
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "RX",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_12",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_206",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole13",
+      "9"
+    ],
+    "x": -20.5,
+    "y": 8.89,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_204",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": 8.89,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_205",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": 8.89,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_22",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -21.85,
+      "y": 8.89
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "5V",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_13",
+    "pcb_component_id": "pcb_component_17",
+    "pcb_port_id": "pcb_port_207",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole14",
+      "10"
+    ],
+    "x": -20.5,
+    "y": 11.43,
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_206",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": 11.43,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_207",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": -20.5,
+    "y": 11.43,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_23",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -21.849999999999998,
+      "y": 11.43
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "G",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_24",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -23.04,
+      "y": 1.5553014349171386e-16
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.7,
+    "layer": "top",
+    "text": "J_DEBUG",
+    "ccw_rotation": 90,
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_8",
+    "pcb_component_id": "pcb_component_17",
+    "layer": "top",
+    "center": {
+      "x": -20.5,
+      "y": 0
+    },
+    "width": 26.4,
+    "height": 3.54,
+    "ccw_rotation": 90,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_194",
+    "pcb_component_id": "pcb_component_18",
+    "pcb_port_id": "pcb_port_208",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 11.175,
+    "y": -5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_208",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 11.175,
+    "y": -5,
+    "pcb_component_id": "pcb_component_18",
+    "pcb_smtpad_id": "pcb_smtpad_194",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_195",
+    "pcb_component_id": "pcb_component_18",
+    "pcb_port_id": "pcb_port_209",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 12.825,
+    "y": -5,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_209",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 12.825,
+    "y": -5,
+    "pcb_component_id": "pcb_component_18",
+    "pcb_smtpad_id": "pcb_smtpad_195",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_54",
+    "pcb_component_id": "pcb_component_18",
+    "layer": "top",
+    "route": [
+      {
+        "x": 12.825,
+        "y": -4.125
+      },
+      {
+        "x": 10.575,
+        "y": -4.125
+      },
+      {
+        "x": 10.575,
+        "y": -5.875
+      },
+      {
+        "x": 12.825,
+        "y": -5.875
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_25",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 12,
+      "y": -3.625
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "D2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_18",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_9",
+    "pcb_component_id": "pcb_component_18",
+    "layer": "top",
+    "center": {
+      "x": 12,
+      "y": -5
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_196",
+    "pcb_component_id": "pcb_component_19",
+    "pcb_port_id": "pcb_port_210",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 11.175,
+    "y": -3,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_210",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 11.175,
+    "y": -3,
+    "pcb_component_id": "pcb_component_19",
+    "pcb_smtpad_id": "pcb_smtpad_196",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_197",
+    "pcb_component_id": "pcb_component_19",
+    "pcb_port_id": "pcb_port_211",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 12.825,
+    "y": -3,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_211",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 12.825,
+    "y": -3,
+    "pcb_component_id": "pcb_component_19",
+    "pcb_smtpad_id": "pcb_smtpad_197",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_55",
+    "pcb_component_id": "pcb_component_19",
+    "layer": "top",
+    "route": [
+      {
+        "x": 11.762742,
+        "y": -2.4775
+      },
+      {
+        "x": 12.237258,
+        "y": -2.4775
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_56",
+    "pcb_component_id": "pcb_component_19",
+    "layer": "top",
+    "route": [
+      {
+        "x": 11.762742,
+        "y": -3.5225
+      },
+      {
+        "x": 12.237258,
+        "y": -3.5225
+      }
+    ],
+    "stroke_width": 0.12,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_26",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 12,
+      "y": -1.625
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R6",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_19",
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_courtyard_rect",
+    "pcb_courtyard_rect_id": "pcb_courtyard_rect_10",
+    "pcb_component_id": "pcb_component_19",
+    "layer": "top",
+    "center": {
+      "x": 12,
+      "y": -3
+    },
+    "width": 2.96,
+    "height": 1.46,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_27",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -9,
+      "y": 11
+    },
+    "font": "tscircuit2024",
+    "font_size": 1.2,
+    "layer": "top",
+    "text": "RV1106G2 PICO",
+    "ccw_rotation": 0,
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_28",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 0,
+      "y": -24.4
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.8,
+    "layer": "top",
+    "text": "USB-C",
+    "ccw_rotation": 0,
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_29",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 10,
+      "y": -6.4
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.75,
+    "layer": "top",
+    "text": "RESET",
+    "ccw_rotation": 0,
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_30",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 10,
+      "y": -14.4
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.75,
+    "layer": "top",
+    "text": "BOOT",
+    "ccw_rotation": 0,
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_31",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 14,
+      "y": -6.5
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.65,
+    "layer": "top",
+    "text": "PWR",
+    "ccw_rotation": 0,
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_32",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 0,
+      "y": 20
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.55,
+    "layer": "top",
+    "text": "GPIO0=P125  GPIO1=P126",
+    "ccw_rotation": 0,
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_33",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 0,
+      "y": 18.5
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.55,
+    "layer": "top",
+    "text": "I2C: SDA=P65  SCL=P127",
+    "ccw_rotation": 0,
+    "pcb_component_id": null,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_0",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.325112,
+    "y": -26.5943068,
+    "source_port_id": "source_port_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_1",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.325112,
+    "y": -30.774130800000002,
+    "source_port_id": "source_port_1"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_2",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.325112,
+    "y": -30.774130800000002,
+    "source_port_id": "source_port_2"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_3",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.325112,
+    "y": -26.5943068,
+    "source_port_id": "source_port_3"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_4",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.75006,
+    "y": -25.8259568,
+    "source_port_id": "source_port_4"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_5",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.249934,
+    "y": -25.8259568,
+    "source_port_id": "source_port_5"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_6",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.750062,
+    "y": -25.8259568,
+    "source_port_id": "source_port_6"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_7",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.249936,
+    "y": -25.8259568,
+    "source_port_id": "source_port_7"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_8",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.249936,
+    "y": -25.8259568,
+    "source_port_id": "source_port_8"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_9",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.750062,
+    "y": -25.8259568,
+    "source_port_id": "source_port_9"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_10",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.24968,
+    "y": -25.8259568,
+    "source_port_id": "source_port_10"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_11",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.75006,
+    "y": -25.8259568,
+    "source_port_id": "source_port_11"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_12",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.1999554999999997,
+    "y": -25.8259568,
+    "source_port_id": "source_port_12"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_13",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 3.2000063,
+    "y": -25.8258552,
+    "source_port_id": "source_port_13"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_14",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.4001603,
+    "y": -25.8258552,
+    "source_port_id": "source_port_14"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_15",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.3999571,
+    "y": -25.8260203,
+    "source_port_id": "source_port_15"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_16",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.825,
+    "y": -21,
+    "source_port_id": "source_port_16"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_17",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -5.175,
+    "y": -21,
+    "source_port_id": "source_port_17"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_18",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.825,
+    "y": -21,
+    "source_port_id": "source_port_18"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_19",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.175,
+    "y": -21,
+    "source_port_id": "source_port_19"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_20",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.05004,
+    "y": -21.149096,
+    "source_port_id": "source_port_20"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_21",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5,
+    "y": -21.149096,
+    "source_port_id": "source_port_21"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_22",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.94996,
+    "y": -21.149096,
+    "source_port_id": "source_port_22"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_23",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.94996,
+    "y": -18.850904,
+    "source_port_id": "source_port_23"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_24",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5,
+    "y": -18.850904,
+    "source_port_id": "source_port_24"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_25",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.05004,
+    "y": -18.850904,
+    "source_port_id": "source_port_25"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_26",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -12.949706,
+    "y": 13.700028,
+    "source_port_id": "source_port_26"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_27",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -12.000508,
+    "y": 13.700028,
+    "source_port_id": "source_port_27"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_28",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -11.050294,
+    "y": 13.700028,
+    "source_port_id": "source_port_28"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_29",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -11.050294,
+    "y": 16.299972,
+    "source_port_id": "source_port_29"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_30",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -12.949706,
+    "y": 16.299972,
+    "source_port_id": "source_port_30"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_31",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -11.825,
+    "y": 18,
+    "source_port_id": "source_port_31"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_32",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -10.175,
+    "y": 18,
+    "source_port_id": "source_port_32"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_33",
+    "pcb_component_id": "pcb_component_6",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.825,
+    "y": 20,
+    "source_port_id": "source_port_33"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_34",
+    "pcb_component_id": "pcb_component_6",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.825,
+    "y": 20,
+    "source_port_id": "source_port_34"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_35",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.15,
+    "y": 17.905,
+    "source_port_id": "source_port_35"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_36",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.15,
+    "y": 16.635,
+    "source_port_id": "source_port_36"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_37",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.15,
+    "y": 15.365,
+    "source_port_id": "source_port_37"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_38",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -7.15,
+    "y": 14.095,
+    "source_port_id": "source_port_38"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_39",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.85,
+    "y": 14.095,
+    "source_port_id": "source_port_39"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_40",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.85,
+    "y": 15.365,
+    "source_port_id": "source_port_40"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_41",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.85,
+    "y": 16.635,
+    "source_port_id": "source_port_41"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_42",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.85,
+    "y": 17.905,
+    "source_port_id": "source_port_42"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_43",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 6.424932,
+    "source_port_id": "source_port_43"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_44",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 6.07492,
+    "source_port_id": "source_port_44"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_45",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 5.724908,
+    "source_port_id": "source_port_45"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_46",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 5.374896,
+    "source_port_id": "source_port_46"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_47",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 5.024884,
+    "source_port_id": "source_port_47"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_48",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 4.674872000000001,
+    "source_port_id": "source_port_48"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_49",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 4.325114,
+    "source_port_id": "source_port_49"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_50",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 3.975102,
+    "source_port_id": "source_port_50"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_51",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 3.62509,
+    "source_port_id": "source_port_51"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_52",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 3.275078,
+    "source_port_id": "source_port_52"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_53",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 2.925066,
+    "source_port_id": "source_port_53"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_54",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 2.5750539999999997,
+    "source_port_id": "source_port_54"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_55",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 2.225042,
+    "source_port_id": "source_port_55"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_56",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 1.87503,
+    "source_port_id": "source_port_56"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_57",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 1.525018,
+    "source_port_id": "source_port_57"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_58",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 1.175006,
+    "source_port_id": "source_port_58"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_59",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 0.824994,
+    "source_port_id": "source_port_59"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_60",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 0.474982,
+    "source_port_id": "source_port_60"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_61",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": 0.12497000000000003,
+    "source_port_id": "source_port_61"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_62",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -0.22504199999999996,
+    "source_port_id": "source_port_62"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_63",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -0.575054,
+    "source_port_id": "source_port_63"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_64",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -0.9250659999999999,
+    "source_port_id": "source_port_64"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_65",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -1.2750780000000002,
+    "source_port_id": "source_port_65"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_66",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -1.6250900000000001,
+    "source_port_id": "source_port_66"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_67",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -1.9751020000000001,
+    "source_port_id": "source_port_67"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_68",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -2.325114,
+    "source_port_id": "source_port_68"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_69",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -2.674872,
+    "source_port_id": "source_port_69"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_70",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -3.024884,
+    "source_port_id": "source_port_70"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_71",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -3.3748959999999997,
+    "source_port_id": "source_port_71"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_72",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -3.724908,
+    "source_port_id": "source_port_72"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_73",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -4.07492,
+    "source_port_id": "source_port_73"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_74",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -6.057392,
+    "y": -4.424932,
+    "source_port_id": "source_port_74"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_75",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -5.424932,
+    "y": -5.057392,
+    "source_port_id": "source_port_75"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_76",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -5.07492,
+    "y": -5.057392,
+    "source_port_id": "source_port_76"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_77",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.724908,
+    "y": -5.057392,
+    "source_port_id": "source_port_77"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_78",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.374896,
+    "y": -5.057392,
+    "source_port_id": "source_port_78"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_79",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.024884,
+    "y": -5.057392,
+    "source_port_id": "source_port_79"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_80",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.674872,
+    "y": -5.057392,
+    "source_port_id": "source_port_80"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_81",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.325114,
+    "y": -5.057392,
+    "source_port_id": "source_port_81"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_82",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.975102,
+    "y": -5.057392,
+    "source_port_id": "source_port_82"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_83",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.62509,
+    "y": -5.057392,
+    "source_port_id": "source_port_83"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_84",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.275078,
+    "y": -5.057392,
+    "source_port_id": "source_port_84"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_85",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.925066,
+    "y": -5.057392,
+    "source_port_id": "source_port_85"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_86",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.575054,
+    "y": -5.057392,
+    "source_port_id": "source_port_86"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_87",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.225042,
+    "y": -5.057392,
+    "source_port_id": "source_port_87"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_88",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.87503,
+    "y": -5.057392,
+    "source_port_id": "source_port_88"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_89",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.525018,
+    "y": -5.057392,
+    "source_port_id": "source_port_89"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_90",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.175006,
+    "y": -5.057392,
+    "source_port_id": "source_port_90"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_91",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.175006,
+    "y": -5.057392,
+    "source_port_id": "source_port_91"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_92",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.525018,
+    "y": -5.057392,
+    "source_port_id": "source_port_92"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_93",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.87503,
+    "y": -5.057392,
+    "source_port_id": "source_port_93"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_94",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.225042,
+    "y": -5.057392,
+    "source_port_id": "source_port_94"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_95",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.575054,
+    "y": -5.057392,
+    "source_port_id": "source_port_95"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_96",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.925066,
+    "y": -5.057392,
+    "source_port_id": "source_port_96"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_97",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.275078,
+    "y": -5.057392,
+    "source_port_id": "source_port_97"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_98",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.62509,
+    "y": -5.057392,
+    "source_port_id": "source_port_98"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_99",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.975102,
+    "y": -5.057392,
+    "source_port_id": "source_port_99"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_100",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 3.325114,
+    "y": -5.057392,
+    "source_port_id": "source_port_100"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_101",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 3.674872,
+    "y": -5.057392,
+    "source_port_id": "source_port_101"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_102",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.024884,
+    "y": -5.057392,
+    "source_port_id": "source_port_102"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_103",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.374896,
+    "y": -5.057392,
+    "source_port_id": "source_port_103"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_104",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.724908,
+    "y": -5.057392,
+    "source_port_id": "source_port_104"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_105",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.07492,
+    "y": -5.057392,
+    "source_port_id": "source_port_105"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_106",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.424932,
+    "y": -5.057392,
+    "source_port_id": "source_port_106"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_107",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -4.424932,
+    "source_port_id": "source_port_107"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_108",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -4.07492,
+    "source_port_id": "source_port_108"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_109",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -3.724908,
+    "source_port_id": "source_port_109"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_110",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -3.3748959999999997,
+    "source_port_id": "source_port_110"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_111",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -3.024884,
+    "source_port_id": "source_port_111"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_112",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -2.674872,
+    "source_port_id": "source_port_112"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_113",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -2.325114,
+    "source_port_id": "source_port_113"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_114",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -1.9751020000000001,
+    "source_port_id": "source_port_114"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_115",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -1.6250900000000001,
+    "source_port_id": "source_port_115"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_116",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -1.2750780000000002,
+    "source_port_id": "source_port_116"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_117",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -0.9250659999999999,
+    "source_port_id": "source_port_117"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_118",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -0.575054,
+    "source_port_id": "source_port_118"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_119",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": -0.22504199999999996,
+    "source_port_id": "source_port_119"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_120",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 0.12497000000000003,
+    "source_port_id": "source_port_120"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_121",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 0.474982,
+    "source_port_id": "source_port_121"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_122",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 0.824994,
+    "source_port_id": "source_port_122"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_123",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 1.175006,
+    "source_port_id": "source_port_123"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_124",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 1.525018,
+    "source_port_id": "source_port_124"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_125",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 1.87503,
+    "source_port_id": "source_port_125"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_126",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 2.225042,
+    "source_port_id": "source_port_126"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_127",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 2.5750539999999997,
+    "source_port_id": "source_port_127"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_128",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 2.925066,
+    "source_port_id": "source_port_128"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_129",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 3.275078,
+    "source_port_id": "source_port_129"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_130",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 3.62509,
+    "source_port_id": "source_port_130"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_131",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 3.975102,
+    "source_port_id": "source_port_131"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_132",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 4.325114,
+    "source_port_id": "source_port_132"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_133",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 4.674872000000001,
+    "source_port_id": "source_port_133"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_134",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 5.024884,
+    "source_port_id": "source_port_134"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_135",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 5.374896,
+    "source_port_id": "source_port_135"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_136",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 5.724908,
+    "source_port_id": "source_port_136"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_137",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 6.07492,
+    "source_port_id": "source_port_137"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_138",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 6.057392,
+    "y": 6.424932,
+    "source_port_id": "source_port_138"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_139",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.424932,
+    "y": 7.057392,
+    "source_port_id": "source_port_139"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_140",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.07492,
+    "y": 7.057392,
+    "source_port_id": "source_port_140"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_141",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.724908,
+    "y": 7.057392,
+    "source_port_id": "source_port_141"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_142",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.374896,
+    "y": 7.057392,
+    "source_port_id": "source_port_142"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_143",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.024884,
+    "y": 7.057392,
+    "source_port_id": "source_port_143"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_144",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 3.674872,
+    "y": 7.057392,
+    "source_port_id": "source_port_144"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_145",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 3.325114,
+    "y": 7.057392,
+    "source_port_id": "source_port_145"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_146",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.975102,
+    "y": 7.057392,
+    "source_port_id": "source_port_146"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_147",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.62509,
+    "y": 7.057392,
+    "source_port_id": "source_port_147"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_148",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.275078,
+    "y": 7.057392,
+    "source_port_id": "source_port_148"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_149",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.925066,
+    "y": 7.057392,
+    "source_port_id": "source_port_149"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_150",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.575054,
+    "y": 7.057392,
+    "source_port_id": "source_port_150"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_151",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 1.225042,
+    "y": 7.057392,
+    "source_port_id": "source_port_151"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_152",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.87503,
+    "y": 7.057392,
+    "source_port_id": "source_port_152"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_153",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.525018,
+    "y": 7.057392,
+    "source_port_id": "source_port_153"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_154",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0.175006,
+    "y": 7.057392,
+    "source_port_id": "source_port_154"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_155",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.175006,
+    "y": 7.057392,
+    "source_port_id": "source_port_155"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_156",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.525018,
+    "y": 7.057392,
+    "source_port_id": "source_port_156"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_157",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -0.87503,
+    "y": 7.057392,
+    "source_port_id": "source_port_157"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_158",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.225042,
+    "y": 7.057392,
+    "source_port_id": "source_port_158"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_159",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.575054,
+    "y": 7.057392,
+    "source_port_id": "source_port_159"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_160",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -1.925066,
+    "y": 7.057392,
+    "source_port_id": "source_port_160"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_161",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.275078,
+    "y": 7.057392,
+    "source_port_id": "source_port_161"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_162",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.62509,
+    "y": 7.057392,
+    "source_port_id": "source_port_162"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_163",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -2.975102,
+    "y": 7.057392,
+    "source_port_id": "source_port_163"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_164",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.325114,
+    "y": 7.057392,
+    "source_port_id": "source_port_164"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_165",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -3.674872,
+    "y": 7.057392,
+    "source_port_id": "source_port_165"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_166",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.024884,
+    "y": 7.057392,
+    "source_port_id": "source_port_166"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_167",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.374896,
+    "y": 7.057392,
+    "source_port_id": "source_port_167"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_168",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -4.724908,
+    "y": 7.057392,
+    "source_port_id": "source_port_168"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_169",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -5.07492,
+    "y": 7.057392,
+    "source_port_id": "source_port_169"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_170",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -5.424932,
+    "y": 7.057392,
+    "source_port_id": "source_port_170"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_171",
+    "pcb_component_id": "pcb_component_8",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 0,
+    "y": 1,
+    "source_port_id": "source_port_171"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_172",
+    "pcb_component_id": "pcb_component_9",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.85,
+    "y": 1,
+    "source_port_id": "source_port_172"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_173",
+    "pcb_component_id": "pcb_component_9",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 10.15,
+    "y": 1,
+    "source_port_id": "source_port_173"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_174",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 8.49,
+    "y": -1,
+    "source_port_id": "source_port_174"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_175",
+    "pcb_component_id": "pcb_component_10",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 9.51,
+    "y": -1,
+    "source_port_id": "source_port_175"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_176",
+    "pcb_component_id": "pcb_component_11",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 11.49,
+    "y": 2.5,
+    "source_port_id": "source_port_176"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_177",
+    "pcb_component_id": "pcb_component_11",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 12.51,
+    "y": 2.5,
+    "source_port_id": "source_port_177"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_178",
+    "pcb_component_id": "pcb_component_12",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 2.175,
+    "y": -9,
+    "source_port_id": "source_port_178"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_179",
+    "pcb_component_id": "pcb_component_12",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 3.825,
+    "y": -9,
+    "source_port_id": "source_port_179"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_180",
+    "pcb_component_id": "pcb_component_13",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.850016999999999,
+    "y": -8.924945,
+    "source_port_id": "source_port_180"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_181",
+    "pcb_component_id": "pcb_component_13",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.850016999999999,
+    "y": -11.075055,
+    "source_port_id": "source_port_181"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_182",
+    "pcb_component_id": "pcb_component_13",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 12.149983,
+    "y": -8.924945,
+    "source_port_id": "source_port_182"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_183",
+    "pcb_component_id": "pcb_component_13",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 12.149983,
+    "y": -11.075055,
+    "source_port_id": "source_port_183"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_184",
+    "pcb_component_id": "pcb_component_14",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.850016999999999,
+    "y": -16.924945,
+    "source_port_id": "source_port_184"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_185",
+    "pcb_component_id": "pcb_component_14",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 7.850016999999999,
+    "y": -19.075055,
+    "source_port_id": "source_port_185"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_186",
+    "pcb_component_id": "pcb_component_14",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 12.149983,
+    "y": -16.924945,
+    "source_port_id": "source_port_186"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_187",
+    "pcb_component_id": "pcb_component_14",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 12.149983,
+    "y": -19.075055,
+    "source_port_id": "source_port_187"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_188",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 8.095,
+    "y": 5.469908,
+    "source_port_id": "source_port_188"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_189",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 9.365,
+    "y": 5.469908,
+    "source_port_id": "source_port_189"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_190",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 10.635,
+    "y": 5.469908,
+    "source_port_id": "source_port_190"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_191",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 11.905,
+    "y": 5.469908,
+    "source_port_id": "source_port_191"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_192",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 11.905,
+    "y": 12.530092,
+    "source_port_id": "source_port_192"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_193",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 10.635,
+    "y": 12.530092,
+    "source_port_id": "source_port_193"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_194",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 9.365,
+    "y": 12.530092,
+    "source_port_id": "source_port_194"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_195",
+    "pcb_component_id": "pcb_component_15",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 8.095,
+    "y": 12.530092,
+    "source_port_id": "source_port_195"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_196",
+    "pcb_component_id": "pcb_component_16",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 4.49,
+    "y": 14,
+    "source_port_id": "source_port_196"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_197",
+    "pcb_component_id": "pcb_component_16",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 5.51,
+    "y": 14,
+    "source_port_id": "source_port_197"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_198",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.5,
+    "y": -11.43,
+    "source_port_id": "source_port_198"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_199",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.5,
+    "y": -8.89,
+    "source_port_id": "source_port_199"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_200",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.5,
+    "y": -6.35,
+    "source_port_id": "source_port_200"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_201",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.5,
+    "y": -3.8099999999999996,
+    "source_port_id": "source_port_201"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_202",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.5,
+    "y": -1.2699999999999996,
+    "source_port_id": "source_port_202"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_203",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.5,
+    "y": 1.2699999999999996,
+    "source_port_id": "source_port_203"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_204",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.5,
+    "y": 3.8100000000000005,
+    "source_port_id": "source_port_204"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_205",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.5,
+    "y": 6.350000000000001,
+    "source_port_id": "source_port_205"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_206",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.5,
+    "y": 8.89,
+    "source_port_id": "source_port_206"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_207",
+    "pcb_component_id": "pcb_component_17",
+    "layers": [
+      "top",
+      "bottom",
+      "inner1",
+      "inner2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": -20.5,
+    "y": 11.43,
+    "source_port_id": "source_port_207"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_208",
+    "pcb_component_id": "pcb_component_18",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 11.175,
+    "y": -5,
+    "source_port_id": "source_port_208"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_209",
+    "pcb_component_id": "pcb_component_18",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 12.825,
+    "y": -5,
+    "source_port_id": "source_port_209"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_210",
+    "pcb_component_id": "pcb_component_19",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 11.175,
+    "y": -3,
+    "source_port_id": "source_port_210"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_211",
+    "pcb_component_id": "pcb_component_19",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "x": 12.825,
+    "y": -3,
+    "source_port_id": "source_port_211"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_0",
+    "position": {
+      "x": 0,
+      "y": -28.425043549999998,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_0",
+    "source_component_id": "source_component_0",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C165948.obj?uuid=617b05f9bba7410b96c001093d8189e4&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C165948.step?uuid=617b05f9bba7410b96c001093d8189e4&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0,
+      "y": -2.7500289000000517,
+      "z": 0.000010999999999872223
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_1",
+    "position": {
+      "x": -6,
+      "y": -21,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_1",
+    "source_component_id": "source_component_1",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_2",
+    "position": {
+      "x": -3,
+      "y": -21,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_2",
+    "source_component_id": "source_component_2",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_3",
+    "position": {
+      "x": 5,
+      "y": -20,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_3",
+    "source_component_id": "source_component_3",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C7519.obj?uuid=229b69761e2c45dba6a83d8866dec72d&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C7519.step?uuid=229b69761e2c45dba6a83d8866dec72d&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -0.000012700000070253736,
+      "y": 0.000012700000070253736,
+      "z": -0.048939
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_4",
+    "position": {
+      "x": -12,
+      "y": 15,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_4",
+    "source_component_id": "source_component_4",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C51118.obj?uuid=6d166d1d6c064b99aa79465714e989c1&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C51118.step?uuid=6d166d1d6c064b99aa79465714e989c1&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -0.000012700000070253736,
+      "y": 0,
+      "z": -0.15
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_5",
+    "position": {
+      "x": -11,
+      "y": 18,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_5",
+    "source_component_id": "source_component_5",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "cap0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_6",
+    "position": {
+      "x": 0,
+      "y": 20,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_6",
+    "source_component_id": "source_component_6",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "cap0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_7",
+    "position": {
+      "x": -5,
+      "y": 16,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_7",
+    "source_component_id": "source_component_7",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "soic8"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_8",
+    "position": {
+      "x": 0,
+      "y": 1,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_8",
+    "source_component_id": "source_component_8",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C5272606.obj?uuid=c1bbd866bce7425ca9a8837b53ffc2ad&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C5272606.step?uuid=c1bbd866bce7425ca9a8837b53ffc2ad&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0.00012700000002041634,
+      "y": 0,
+      "z": -0.02
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_9",
+    "position": {
+      "x": 9,
+      "y": 1,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_9",
+    "source_component_id": "source_component_9",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "show_as_bounding_box": true
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_10",
+    "position": {
+      "x": 9,
+      "y": -1,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_10",
+    "source_component_id": "source_component_10",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "cap0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_11",
+    "position": {
+      "x": 12,
+      "y": 2.5,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_11",
+    "source_component_id": "source_component_11",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "cap0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_12",
+    "position": {
+      "x": 3,
+      "y": -9,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_12",
+    "source_component_id": "source_component_12",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_13",
+    "position": {
+      "x": 10,
+      "y": -10,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_13",
+    "source_component_id": "source_component_13",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C55200589.obj?uuid=859fa7849d62453abedc7c971d7b8777&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C55200589.step?uuid=859fa7849d62453abedc7c971d7b8777&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -0.00005080000005364127,
+      "y": -0.00005079999993995443,
+      "z": -1.7
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_14",
+    "position": {
+      "x": 10,
+      "y": -18,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_14",
+    "source_component_id": "source_component_14",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C55200589.obj?uuid=859fa7849d62453abedc7c971d7b8777&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C55200589.step?uuid=859fa7849d62453abedc7c971d7b8777&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": -0.00005080000005364127,
+      "y": -0.00005079999993995443,
+      "z": -1.7
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_15",
+    "position": {
+      "x": 10,
+      "y": 9,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_15",
+    "source_component_id": "source_component_15",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C97521.obj?uuid=4652e19b90fa4dbb8662aa4cba61a532&cachebust_origin=",
+    "model_step_url": "https://modelcdn.tscircuit.com/easyeda_models/assets/C97521.step?uuid=4652e19b90fa4dbb8662aa4cba61a532&cachebust_origin=",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "model_origin_position": {
+      "x": 0.000012700000070253736,
+      "y": -0.000012699999956566899,
+      "z": -0.069425
+    }
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_16",
+    "position": {
+      "x": 5,
+      "y": 14,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_16",
+    "source_component_id": "source_component_16",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "cap0402"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_17",
+    "position": {
+      "x": -20.5,
+      "y": 0,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_17",
+    "source_component_id": "source_component_17",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "pinrow10_p2.54mm"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_18",
+    "position": {
+      "x": 12,
+      "y": -5,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_18",
+    "source_component_id": "source_component_18",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "0603_color(green)"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_19",
+    "position": {
+      "x": 12,
+      "y": -3,
+      "z": 0.8
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_19",
+    "source_component_id": "source_component_19",
+    "model_origin_alignment": "center_of_component_on_board_surface",
+    "anchor_alignment": "center_of_component_on_board_surface",
+    "footprinter_string": "res0603"
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_QmxKQierEb",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<led#342 name=\".D2\" /> footprint \"0603\" does not match supplier footprint jlcpcb:C965799 (copper IoU 0.7966).",
+    "source_component_id": "source_component_18",
+    "pcb_component_id": "pcb_component_18",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C965799",
+    "footprint_copper_intersection_over_union": 0.7966
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_aei9zxnWOR",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<pinheader#309 name=\".J_DEBUG\" /> footprint \"pinrow10_p2.54mm\" does not match supplier footprint jlcpcb:C492422 (copper IoU 0.2577).",
+    "source_component_id": "source_component_17",
+    "pcb_component_id": "pcb_component_17",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C492422",
+    "footprint_copper_intersection_over_union": 0.2577
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_0sXCLx2oyi",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<capacitor#261 name=\".C4\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C1547 (copper IoU 0.7249).",
+    "source_component_id": "source_component_11",
+    "pcb_component_id": "pcb_component_11",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C1547",
+    "footprint_copper_intersection_over_union": 0.7249
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_3D9iuf1Oeo",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<capacitor#297 name=\".C5\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C1525 (copper IoU 0.7249).",
+    "source_component_id": "source_component_16",
+    "pcb_component_id": "pcb_component_16",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C1525",
+    "footprint_copper_intersection_over_union": 0.7249
+  },
+  {
+    "type": "supplier_footprint_mismatch_warning",
+    "supplier_footprint_mismatch_warning_id": "supplier_footprint_mismatch_warning_JUpcsyCkRq",
+    "warning_type": "supplier_footprint_mismatch_warning",
+    "message": "<capacitor#249 name=\".C3\" /> footprint \"0402\" does not match supplier footprint jlcpcb:C1547 (copper IoU 0.7249).",
+    "source_component_id": "source_component_10",
+    "pcb_component_id": "pcb_component_10",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "supplier_name": "jlcpcb",
+    "supplier_part_number": "C1547",
+    "footprint_copper_intersection_over_union": 0.7249
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_29_0",
+    "connection_name": "source_net_29",
+    "connectsTo": [
+      "pcb_port_209",
+      "pcb_port_210"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 12.825,
+        "y": -5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_209"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.825,
+        "y": -4.649999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.175,
+        "y": -3,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_210"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_117"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_28_0",
+    "connection_name": "source_net_28",
+    "connectsTo": [
+      "pcb_port_184",
+      "pcb_port_186"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 7.850016999999999,
+        "y": -16.924945,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_184"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.850054999999999,
+        "y": -16.924945,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.149983,
+        "y": -16.924945,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_186"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_92"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_27_0",
+    "connection_name": "source_net_27",
+    "connectsTo": [
+      "pcb_port_107",
+      "pcb_port_202"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": -4.424932,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_107"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.124,
+        "y": -4.49154,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.124,
+        "y": -5.144031427179763,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.4040314271797625,
+        "y": -5.864,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.227,
+        "y": -5.864,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 5.227,
+        "y": -5.864,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 5.227,
+        "y": -5.864,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.225503753267349,
+        "y": -5.8654962467326515,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.607,
+        "y": -7.484,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.091,
+        "y": -7.484,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 0.091,
+        "y": -7.484,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 0.091,
+        "y": -7.484,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.058254117929726616,
+        "y": -7.516745882070273,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.058254117929726616,
+        "y": -7.537007534231745,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.116,
+        "y": -9.711261652161472,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.116,
+        "y": -12.885,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -2.116,
+        "y": -12.885,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -2.116,
+        "y": -12.885,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.149939122001078,
+        "y": -12.918939122001078,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.3252466175967736,
+        "y": -12.918939122001078,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.851060877998922,
+        "y": -12.918939122001078,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.5,
+        "y": -1.2699999999999996,
+        "width": 0.15,
+        "layer": "inner1",
+        "end_pcb_port_id": "pcb_port_202"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_79"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_26_0",
+    "connection_name": "source_net_26",
+    "connectsTo": [
+      "pcb_port_169",
+      "pcb_port_203"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -5.07492,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_169"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.108858009916706,
+        "y": 7.023141990083294,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.108838373561923,
+        "y": 6.68111330412598,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.194560058180466,
+        "y": 6.588164043601875,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.198145335307799,
+        "y": 6.476806151823466,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.198145335307799,
+        "y": 6.356644246444037,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.110956252692245,
+        "y": 6.262162287707934,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.754428211478295,
+        "y": 5.911070853104997,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.007,
+        "y": 5.912,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -4.007,
+        "y": 5.912,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -4.007,
+        "y": 5.912,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.027496943864279,
+        "y": 5.93249694386428,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.844951224557307,
+        "y": 5.93249694386428,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.971328056854495,
+        "y": 6.058873776161468,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.018454280693027,
+        "y": 6.106,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.463062840589549,
+        "y": 6.120851700925059,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": -7.463062840589549,
+        "y": 6.120851700925059,
+        "from_layer": "bottom",
+        "to_layer": "inner2",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -7.463062840589549,
+        "y": 6.120851700925059,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.51908965511878,
+        "y": 6.03691034488122,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.51908965511878,
+        "y": 5.905391147742909,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.51908965511878,
+        "y": 4.905691304115271,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.154780959234051,
+        "y": 1.2699999999999996,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.5,
+        "y": 1.2699999999999996,
+        "width": 0.15,
+        "layer": "bottom",
+        "end_pcb_port_id": "pcb_port_203"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_78"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_25_0",
+    "connection_name": "source_net_25",
+    "connectsTo": [
+      "pcb_port_168",
+      "pcb_port_201"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -4.724908,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_168"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.725,
+        "y": 6.505,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.798429772749198,
+        "y": 6.431580060293706,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -4.798429772749198,
+        "y": 6.431580060293706,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -4.798429772749198,
+        "y": 6.431580060293706,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.821204533547293,
+        "y": 6.408795466452706,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.912322531155049,
+        "y": 6.408795466452706,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.572117997607756,
+        "y": 5.749,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.122937159410451,
+        "y": 5.73414829907494,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -7.122937159410451,
+        "y": 5.73414829907494,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -7.122937159410451,
+        "y": 5.73414829907494,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.1770248324409245,
+        "y": 5.748491687075312,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.791508312924688,
+        "y": 5.748491687075312,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.593,
+        "y": 4.947,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -8.593,
+        "y": 4.947,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -8.593,
+        "y": 4.947,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.59585406944095,
+        "y": 4.94414593055905,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.925,
+        "y": -1.385,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.418,
+        "y": -1.385,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -16.418,
+        "y": -1.385,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -16.418,
+        "y": -1.385,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.423413319628768,
+        "y": -1.3904133196287691,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.502321197964918,
+        "y": -1.3904133196287691,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -18.92190787833615,
+        "y": -3.8099999999999996,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.5,
+        "y": -3.8099999999999996,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_201"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_77"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_24_0",
+    "connection_name": "source_net_24",
+    "connectsTo": [
+      "pcb_port_167",
+      "pcb_port_200"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -4.374896,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_167"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.375,
+        "y": 7.427319155760899,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.466205719703531,
+        "y": 7.51852487546443,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.560680844239101,
+        "y": 7.613,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.676841189033132,
+        "y": 7.613,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.8208934101789405,
+        "y": 7.613,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.249027476159642,
+        "y": 7.184865934019299,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.965134065980703,
+        "y": 7.184865934019298,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.5,
+        "y": -6.35,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_200"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_76"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_23_0",
+    "connection_name": "source_net_23",
+    "connectsTo": [
+      "pcb_port_164",
+      "pcb_port_204"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -3.325114,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_164"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.325,
+        "y": 7.49357483812398,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.7165000342081487,
+        "y": 7.885074872332128,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.424925127667873,
+        "y": 7.885074872332128,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.5,
+        "y": 3.8100000000000005,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_204"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_75"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_22_0",
+    "connection_name": "source_net_22",
+    "connectsTo": [
+      "pcb_port_163",
+      "pcb_port_205"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -2.975102,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_163"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.1325146763590155,
+        "y": 6.190502020358885,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.423143064097615,
+        "y": 6.456992493509692,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.4981355576073074,
+        "y": 6.382,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.275,
+        "y": 6.382,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -4.275,
+        "y": 6.382,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -4.275,
+        "y": 6.382,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.3289195608875275,
+        "y": 6.3280804391124725,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.330264431148187,
+        "y": 6.3280804391124725,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.26481910552344,
+        "y": 5.39352576473722,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.396279069639117,
+        "y": 5.39352576473722,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.3527533049019,
+        "y": 6.350000000000001,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.5,
+        "y": 6.350000000000001,
+        "width": 0.15,
+        "layer": "inner1",
+        "end_pcb_port_id": "pcb_port_205"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_74"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_21_0",
+    "connection_name": "source_net_21",
+    "connectsTo": [
+      "pcb_port_90",
+      "pcb_port_193"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.175006,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_90"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.194,
+        "y": -5.0760000000000005,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.18570980894279004,
+        "y": -5.802002374252999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -0.18570980894279004,
+        "y": -5.802002374252999,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -0.18570980894279004,
+        "y": -5.802002374252999,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.11381209386901547,
+        "y": -5.8821879061309845,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.11381209386901547,
+        "y": -6.010396978709069,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.125790927421915,
+        "y": -9.25,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.7141293752054554,
+        "y": -9.25,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.253,
+        "y": -1.7111293752054557,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.253,
+        "y": 7.827,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 11.253,
+        "y": 7.827,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 11.253,
+        "y": 7.827,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.248079509530063,
+        "y": 7.831920490469937,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.248079509530063,
+        "y": 8.034134204246962,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.635,
+        "y": 8.647213713777026,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.635,
+        "y": 12.530092,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_193"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_73"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_20_0",
+    "connection_name": "source_net_20",
+    "connectsTo": [
+      "pcb_port_89",
+      "pcb_port_188"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.525018,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_89"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.5274005149649729,
+        "y": -7.627999312970547,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.718,
+        "y": -7.821,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -0.718,
+        "y": -7.821,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -0.718,
+        "y": -7.821,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.6777198947456604,
+        "y": -7.861280105254339,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.5147684571633988,
+        "y": -7.861280105254339,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.02726997972948,
+        "y": -7.861280105254339,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.858648246488535,
+        "y": -8.692658372013394,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.858648246488535,
+        "y": 3.007648246488535,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.484,
+        "y": 4.633,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 7.484,
+        "y": 4.633,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 7.484,
+        "y": 4.633,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.529377082642687,
+        "y": 4.678377082642687,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.591944533980964,
+        "y": 4.678377082642687,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.095,
+        "y": 5.181432548661723,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.095,
+        "y": 5.469908,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_188"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_72"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_19_0",
+    "connection_name": "source_net_19",
+    "connectsTo": [
+      "pcb_port_86",
+      "pcb_port_190"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -1.575054,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_86"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.575,
+        "y": -5.551,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.318,
+        "y": -5.808,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -1.318,
+        "y": -5.808,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -1.318,
+        "y": -5.808,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.2424040174459747,
+        "y": -5.883595982554025,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.2424040174459747,
+        "y": -5.937186434292734,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.2424040174459747,
+        "y": -7.795087302526974,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.7904481153965022,
+        "y": -8.247043204576446,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.864569947505899,
+        "y": -8.247043204576446,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.1665267429294524,
+        "y": -9.549,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.971766612912225,
+        "y": -9.549,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.10865276620372,
+        "y": -9.412113846708504,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.53,
+        "y": -2.990766612912225,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.53,
+        "y": 4.676,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 12.53,
+        "y": 4.676,
+        "from_layer": "inner1",
+        "to_layer": "inner2",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 12.53,
+        "y": 4.676,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.414238260970627,
+        "y": 4.560238260970629,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.408384115480484,
+        "y": 4.560238260970629,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.948145854509853,
+        "y": 4.1,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.6,
+        "y": 4.1,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 10.6,
+        "y": 4.1,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 10.6,
+        "y": 4.1,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.621624966285406,
+        "y": 4.121624966285406,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.621624966285406,
+        "y": 4.22552375588185,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.635,
+        "y": 4.238898789596444,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.635,
+        "y": 5.469908,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_190"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_71"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_18_0",
+    "connection_name": "source_net_18",
+    "connectsTo": [
+      "pcb_port_84",
+      "pcb_port_189"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -2.275078,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_84"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.275,
+        "y": -6.071,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.391,
+        "y": -6.187,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -2.391,
+        "y": -6.187,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -2.391,
+        "y": -6.187,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.3651171885942412,
+        "y": -6.1611171885942415,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.2972823045221005,
+        "y": -6.1611171885942415,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.1483994931163424,
+        "y": -6.31,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.885,
+        "y": -6.31,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 0.885,
+        "y": -6.31,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 0.885,
+        "y": -6.31,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.9331119024557659,
+        "y": -6.358111902455765,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.9331119024557659,
+        "y": -6.370503059479471,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.9331119024557659,
+        "y": -6.897633892190246,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.0883020025077261,
+        "y": -7.052823992242207,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.409,
+        "y": -7.37352198973448,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.4126961556992705,
+        "y": -9.413303787845697,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 1.4126961556992705,
+        "y": -9.413303787845697,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 1.4126961556992705,
+        "y": -9.413303787845697,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.7639797446342078,
+        "y": -9.062020255365791,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.137462015240336,
+        "y": -9.062020255365791,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.137462015240336,
+        "y": -7.372216192000615,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.304717647438553,
+        "y": -2.204960559802399,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.304717647438553,
+        "y": 2.3982823525614476,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.788,
+        "y": 3.915,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 9.788,
+        "y": 3.915,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 9.788,
+        "y": 3.915,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.626748409145668,
+        "y": 4.076251590854333,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.621496897061672,
+        "y": 4.076251590854333,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.365,
+        "y": 4.332748487916004,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.365,
+        "y": 5.469908,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_189"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_70"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_17_0",
+    "connection_name": "source_net_17",
+    "connectsTo": [
+      "pcb_port_83",
+      "pcb_port_192"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -2.62509,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_83"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.625,
+        "y": -5.566,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.785,
+        "y": -5.726,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -2.785,
+        "y": -5.726,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -2.785,
+        "y": -5.726,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.780054492852588,
+        "y": -5.730945507147412,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.642895400839573,
+        "y": -5.730945507147412,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.596854157475955,
+        "y": -5.77698675051103,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.1629456596823537,
+        "y": -5.77698675051103,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.1777158600164519,
+        "y": -8.117648270209836,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.11526661927749,
+        "y": -8.117648270209836,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.398926495981918,
+        "y": -8.117648270209836,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.892366539066002,
+        "y": -2.624208227125752,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.892366539066002,
+        "y": 9.787633460933998,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.665,
+        "y": 10.015,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 12.665,
+        "y": 10.015,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 12.665,
+        "y": 10.015,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.630759110391944,
+        "y": 10.049240889608056,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.630759110391944,
+        "y": 10.080940843020077,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.905,
+        "y": 10.806699953412021,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.905,
+        "y": 12.530092,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_192"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_69"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_16_0",
+    "connection_name": "source_net_16",
+    "connectsTo": [
+      "pcb_port_81",
+      "pcb_port_194"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -3.325114,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_81"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.325,
+        "y": -8.639999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.584,
+        "y": -8.899,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -3.584,
+        "y": -8.899,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -3.584,
+        "y": -8.899,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.5329955523711285,
+        "y": -8.95000444762887,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.4625995781986467,
+        "y": -8.95000444762887,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.9991652563158762,
+        "y": -10.413438769511641,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.179357295588911,
+        "y": -10.413438769511641,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.34697835681914,
+        "y": -3.245817708281413,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.34697835681914,
+        "y": 2.906641588303048,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.547,
+        "y": 4.706619945122187,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.547,
+        "y": 7.41,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 10.547,
+        "y": 7.41,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 10.547,
+        "y": 7.41,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.522461617533587,
+        "y": 7.434538382466414,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.522461617533587,
+        "y": 7.509628109528818,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.365,
+        "y": 8.667089727062404,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.365,
+        "y": 12.530092,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_194"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_68"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_15_mst0_0",
+    "connection_name": "source_net_15",
+    "connectsTo": [
+      "pcb_port_173",
+      "pcb_port_176"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 10.15,
+        "y": 1,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_173"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.15,
+        "y": 1.1600000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.49,
+        "y": 2.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_176"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_81"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_15_mst1_0",
+    "connection_name": "source_net_15",
+    "connectsTo": [
+      "pcb_port_111",
+      "pcb_port_173"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": -3.024884,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_111"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.075000000000001,
+        "y": -3.025,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.15,
+        "y": -2.95,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 8.15,
+        "y": -2.95,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 8.15,
+        "y": -2.95,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.220347570167668,
+        "y": -2.8796524298323325,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.220347570167668,
+        "y": -2.8577196813945744,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.901,
+        "y": -0.17706725156224268,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.901,
+        "y": 0.035,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 10.901,
+        "y": 0.035,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 10.901,
+        "y": 0.035,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.88319389835663,
+        "y": 0.0528061016433691,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.804096734170932,
+        "y": 0.0528061016433691,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.15,
+        "y": 0.7069028358143002,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.15,
+        "y": 1,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_173"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_55"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_14_mst0_0",
+    "connection_name": "source_net_14",
+    "connectsTo": [
+      "pcb_port_172",
+      "pcb_port_174"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 7.85,
+        "y": 1,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_172"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.85,
+        "y": -0.35999999999999943,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.49,
+        "y": -1,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_174"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_80"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_14_mst1_0",
+    "connection_name": "source_net_14",
+    "connectsTo": [
+      "pcb_port_110",
+      "pcb_port_174"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": -3.3748959999999997,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_110"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.061459408585337,
+        "y": -3.3705405914146627,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.289594762442043,
+        "y": -3.3705405914146627,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.49,
+        "y": -3.1701353538567054,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.49,
+        "y": -1,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_174"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_54"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_13_mst0_0",
+    "connection_name": "source_net_13",
+    "connectsTo": [
+      "pcb_port_179",
+      "pcb_port_180"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 3.825,
+        "y": -9,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_179"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.775,
+        "y": -9,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.850016999999999,
+        "y": -8.924945,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_180"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_87"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_13_mst1_0",
+    "connection_name": "source_net_13",
+    "connectsTo": [
+      "pcb_port_180",
+      "pcb_port_182"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 7.850016999999999,
+        "y": -8.924945,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_180"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.850055000000001,
+        "y": -8.924945,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.149983,
+        "y": -8.924945,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_182"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_88"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_13_mst2_0",
+    "connection_name": "source_net_13",
+    "connectsTo": [
+      "pcb_port_108",
+      "pcb_port_180"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": -4.07492,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_108"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.127821295607965,
+        "y": -4.136926099999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.275835563638362,
+        "y": -4.136221335021198,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.827821615719677,
+        "y": -4.145765865387438,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.071,
+        "y": -4.389,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 8.071,
+        "y": -4.389,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 8.071,
+        "y": -4.389,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.129789324095118,
+        "y": -4.447789324095118,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.129789324095118,
+        "y": -4.57497954580034,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.253047692453945,
+        "y": -4.698237914159168,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.253047692453945,
+        "y": -6.772854210653878,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 8.253047692453945,
+        "y": -6.772854210653878,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 8.253047692453945,
+        "y": -6.772854210653878,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.190772619768484,
+        "y": -6.710579137968417,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.190772619768484,
+        "y": -6.696467763391489,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.850016999999999,
+        "y": -7.037223383159974,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.850016999999999,
+        "y": -8.924945,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_180"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_52"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_11_0",
+    "connection_name": "source_net_11",
+    "connectsTo": [
+      "pcb_port_40",
+      "pcb_port_157"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -2.85,
+        "y": 15.365,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_40"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.8711846503210883,
+        "y": 13.393819096333448,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.87503,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_157"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_37"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_10_mst0_0",
+    "connection_name": "source_net_10",
+    "connectsTo": [
+      "pcb_port_109",
+      "pcb_port_113"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": -3.724908,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_109"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.707929258833503,
+        "y": -3.724908,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.534896378705549,
+        "y": -3.5669169245837486,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.534862899401798,
+        "y": -2.332716378969474,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.557590891176163,
+        "y": -2.325,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.057,
+        "y": -2.325,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": -2.325114,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_113"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_53"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_10_mst1_0",
+    "connection_name": "source_net_10",
+    "connectsTo": [
+      "pcb_port_39",
+      "pcb_port_113"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -2.85,
+        "y": 14.095,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_39"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.2242522103719953,
+        "y": 14.095,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.1365014124047903,
+        "y": 14.007249202032796,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.976750797967205,
+        "y": 14.007249202032796,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.9727558071037046,
+        "y": 14.011237557326373,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -1.9727558071037046,
+        "y": 14.011237557326373,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -1.9727558071037046,
+        "y": 14.011237557326373,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.584456003826181,
+        "y": 5.46754399617382,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.5844560038261815,
+        "y": -0.9387521903364288,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.5844560038261815,
+        "y": -0.9984560038261809,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.654536747997392,
+        "y": -1.0367638421325986,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 6.654536747997392,
+        "y": -1.0367638421325986,
+        "from_layer": "inner2",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 6.654536747997392,
+        "y": -1.0367638421325986,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.583032016258869,
+        "y": -1.011,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.533659709813401,
+        "y": -2.060372306445468,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.530627693554532,
+        "y": -2.060372306445468,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.421,
+        "y": -2.17,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 5.421,
+        "y": -2.17,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 5.421,
+        "y": -2.17,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.5760000000000005,
+        "y": -2.325,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": -2.325114,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_113"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_36"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_9_mst0_0",
+    "connection_name": "source_net_9",
+    "connectsTo": [
+      "pcb_port_91",
+      "pcb_port_92"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 0.175006,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_91"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.525018,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_92"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_47"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_9_mst1_0",
+    "connection_name": "source_net_9",
+    "connectsTo": [
+      "pcb_port_92",
+      "pcb_port_95"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 0.525018,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_92"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.5134653669644674,
+        "y": -4.715933678144608,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.8925945345783985,
+        "y": -4.347925929414487,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.2925397989341654,
+        "y": -4.354,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.538056105839926,
+        "y": -4.599516306905761,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.538056105839926,
+        "y": -5.0200561058399265,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.575054,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_95"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_48"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_9_mst2_0",
+    "connection_name": "source_net_9",
+    "connectsTo": [
+      "pcb_port_95",
+      "pcb_port_98"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 1.575054,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_95"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.575054,
+        "y": -4.688078814719047,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.8441832646535106,
+        "y": -4.418949550065536,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.4085759942578058,
+        "y": -4.418949550065536,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.501484043101165,
+        "y": -4.511857598908895,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.625,
+        "y": -4.63537355580773,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.62509,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_98"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_49"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_9_mst3_0",
+    "connection_name": "source_net_9",
+    "connectsTo": [
+      "pcb_port_145",
+      "pcb_port_138"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": 6.424932,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_138"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.276071400989891,
+        "y": 6.424932,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.767954833176629,
+        "y": 5.916815432186738,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.114361046235823,
+        "y": 5.916815432186738,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.367757553721184,
+        "y": 6.663418924701377,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.367757553721184,
+        "y": 7.014242446278816,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.325114,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_145"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_61"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_9_mst4_0",
+    "connection_name": "source_net_9",
+    "connectsTo": [
+      "pcb_port_98",
+      "pcb_port_112"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 2.62509,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_98"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.62509,
+        "y": -5.96500879555585,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.867127521523759,
+        "y": -6.207046317079609,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.867127521523759,
+        "y": -6.24112752152376,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.917,
+        "y": -6.291,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 2.917,
+        "y": -6.291,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 2.917,
+        "y": -6.291,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.9510000000000005,
+        "y": -6.291,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.9859098086063955,
+        "y": -7.325909808606395,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.01,
+        "y": -7.35,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 5.01,
+        "y": -7.35,
+        "from_layer": "bottom",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 5.01,
+        "y": -7.35,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.642221286872156,
+        "y": -5.717778713127843,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.642221286872156,
+        "y": -2.684778713127843,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.7,
+        "y": -2.627,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 6.7,
+        "y": -2.627,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 6.7,
+        "y": -2.627,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.105,
+        "y": -2.627,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": -2.674872,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_112"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_50"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_9_mst5_0",
+    "connection_name": "source_net_9",
+    "connectsTo": [
+      "pcb_port_112",
+      "pcb_port_124"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": -2.674872,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_112"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.105,
+        "y": -2.627,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.565654605935945,
+        "y": -2.627,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.037850362953503,
+        "y": -2.1548042429824417,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.052997090940606,
+        "y": -0.9505061146128468,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.621695420492878,
+        "y": -0.5297186862428257,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.611781752568532,
+        "y": 0.6352941321378657,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.847788537361654,
+        "y": -0.19378072763422668,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.531787349297701,
+        "y": 1.5564534804130958,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.3073800067110835,
+        "y": 1.5250164634827834,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.307378470193867,
+        "y": 1.525018,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": 1.525018,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_124"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_56"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_9_mst6_0",
+    "connection_name": "source_net_9",
+    "connectsTo": [
+      "pcb_port_158",
+      "pcb_port_145"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 3.325114,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_145"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.265406007041602,
+        "y": 6.989391652257485,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.26190927927515,
+        "y": 6.58584204217732,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.981411359912423,
+        "y": 5.309888960652137,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.05569786886733441,
+        "y": 5.309888960652137,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.225042,
+        "y": 6.5906288295194715,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.225042,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_158"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_63"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_9_mst7_0",
+    "connection_name": "source_net_9",
+    "connectsTo": [
+      "pcb_port_124",
+      "pcb_port_138"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": 1.525018,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_124"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.295956748746703,
+        "y": 1.525018,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.306811114422956,
+        "y": 1.530385525985269,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.526546138669257,
+        "y": 1.6265041080829004,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.633260911586176,
+        "y": 1.8366380676702656,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.630894368491744,
+        "y": 1.8437435571948635,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.630894368491744,
+        "y": 6.212558920128674,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.566353237851275,
+        "y": 6.2771000507691435,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.418453288620419,
+        "y": 6.425,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": 6.424932,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_138"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_59"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_9_mst8_0",
+    "connection_name": "source_net_9",
+    "connectsTo": [
+      "pcb_port_52",
+      "pcb_port_66"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -6.057392,
+        "y": 3.275078,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_52"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.575948145700185,
+        "y": 3.275078,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.314651422608188,
+        "y": 1.5363747230919973,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.314651422608188,
+        "y": 0.133110169221494,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.556541253386694,
+        "y": -1.625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.057,
+        "y": -1.625,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.057392,
+        "y": -1.6250900000000001,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_66"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_38"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_9_mst9_0",
+    "connection_name": "source_net_9",
+    "connectsTo": [
+      "pcb_port_52",
+      "pcb_port_158"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -6.057392,
+        "y": 3.275078,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_52"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.631455769502734,
+        "y": 3.275,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.506208283601517,
+        "y": 3.4002474859012173,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.364918952740668,
+        "y": 5.541536816762067,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.3935356992469137,
+        "y": 5.541416320266648,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.2239695813990716,
+        "y": 6.7090782953333825,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.225042,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_158"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_38"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_9_mst10_0",
+    "connection_name": "source_net_9",
+    "connectsTo": [
+      "pcb_port_38",
+      "pcb_port_158"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -7.15,
+        "y": 14.095,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_38"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.15,
+        "y": 12.194433685010704,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.87189183557314,
+        "y": 9.472541849437565,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.87189183557314,
+        "y": 9.46810816442686,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.947,
+        "y": 9.393,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -9.947,
+        "y": 9.393,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -9.947,
+        "y": 9.393,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.947,
+        "y": 7.077263376550944,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.049695031149946,
+        "y": 5.179958407700891,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.049695031149946,
+        "y": 5.173695031149946,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.936,
+        "y": 5.06,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -7.936,
+        "y": 5.06,
+        "from_layer": "bottom",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -7.936,
+        "y": 5.06,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.627397603212813,
+        "y": 5.06,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.3522903321004245,
+        "y": 4.784892728887611,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.31510727111239,
+        "y": 4.784892728887611,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.275,
+        "y": 4.825,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -5.275,
+        "y": 4.825,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -5.275,
+        "y": 4.825,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.082564095951219,
+        "y": 4.825,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.3110038162024347,
+        "y": 6.596560279748784,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.225,
+        "y": 6.682564095951219,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.225042,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_158"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_35"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst0_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_55",
+      "pcb_port_61"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -6.057392,
+        "y": 2.225042,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_55"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.100274386588318,
+        "y": 2.181725613411682,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.409291314626832,
+        "y": 2.181725613411682,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.417623615643584,
+        "y": 2.165337438426127,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.481273561207185,
+        "y": 2.2383942111639916,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.672484745423473,
+        "y": 1.8008592047185856,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.579574051674505,
+        "y": 1.7330339764266216,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.583011783297733,
+        "y": 0.5399077083255986,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.670118218346611,
+        "y": 0.5882066919730972,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.5056120204057795,
+        "y": 0.14135158574431486,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.30612998782208,
+        "y": 0.12837510299188304,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.302724884830196,
+        "y": 0.12497000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.057392,
+        "y": 0.12497000000000003,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_61"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_39"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst1_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_150",
+      "pcb_port_143"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 4.024884,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_143"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.9880120225482147,
+        "y": 7.0939879774517856,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.9880120225482147,
+        "y": 7.540773918654914,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.689785941203128,
+        "y": 7.839,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.9722266838279439,
+        "y": 7.839,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.575054,
+        "y": 7.4418273161720565,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.575054,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_150"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_62"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst2_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_123",
+      "pcb_port_130"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": 1.175006,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_123"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.715870517530003,
+        "y": 1.164075663398109,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.074087506720713,
+        "y": 1.8224433976479992,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.0767672530511225,
+        "y": 3.035294691999676,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.589333120902369,
+        "y": 3.560056175262195,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.980059409228538,
+        "y": 3.5689200275028123,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": 3.62509,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_130"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_58"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst3_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_61",
+      "pcb_port_70"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -6.057392,
+        "y": 0.12497000000000003,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_61"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.678462268697716,
+        "y": 0.12497000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.9979149000000005,
+        "y": -0.5555773686977152,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.9979149000000005,
+        "y": -2.465631797029127,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.557283102970874,
+        "y": -3.025,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.057,
+        "y": -3.025,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.057392,
+        "y": -3.024884,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_70"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_40"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst4_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_196",
+      "pcb_port_195"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 8.095,
+        "y": 12.530092,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_195"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.960000000000001,
+        "y": 12.53,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.49,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_196"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_102"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst5_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_143",
+      "pcb_port_130"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": 3.62509,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_130"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.53591,
+        "y": 3.62509,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.021509638040155,
+        "y": 4.1394903619598455,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.982,
+        "y": 4.179,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 4.982,
+        "y": 4.179,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 4.982,
+        "y": 4.179,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.982,
+        "y": 5.902,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.611363526861651,
+        "y": 6.272636473138349,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.602,
+        "y": 6.282,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 4.602,
+        "y": 6.282,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 4.602,
+        "y": 6.282,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.543187828076457,
+        "y": 6.282,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.409565546781992,
+        "y": 6.415622281294465,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.329709468294714,
+        "y": 6.446126906307279,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.9863824402400496,
+        "y": 6.707015735472956,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.0129052002875385,
+        "y": 6.715246069550116,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.0129052002875385,
+        "y": 7.0449052002875385,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.024884,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_143"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_60"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst6_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_178",
+      "pcb_port_103"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 4.374896,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_103"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.375,
+        "y": -6.8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.175,
+        "y": -9,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_178"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_51"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst7_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_70",
+      "pcb_port_85"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -6.057392,
+        "y": -3.024884,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_70"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.98010070945252,
+        "y": -3.0852101975337605,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.4695294515609643,
+        "y": -3.10169920288857,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.925066,
+        "y": -4.646353702939298,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.925066,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_85"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_45"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst8_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_85",
+      "pcb_port_178"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -1.925066,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_85"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.925,
+        "y": -6.888,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.041,
+        "y": -7.004,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -2.041,
+        "y": -7.004,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -2.041,
+        "y": -7.004,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.0199110805494738,
+        "y": -7.025088919450526,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.7908221610989483,
+        "y": -6.796,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.383,
+        "y": -6.796,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 1.383,
+        "y": -6.796,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 1.383,
+        "y": -6.796,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.4016102984742753,
+        "y": -6.814610298474276,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.4016102984742753,
+        "y": -6.820448466542511,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.175,
+        "y": -7.593838168068236,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.175,
+        "y": -9,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_178"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_46"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst9_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_30",
+      "pcb_port_37"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -12.949706,
+        "y": 16.299972,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_30"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.25,
+        "y": 16.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.6,
+        "y": 16.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -13.6,
+        "y": 16.6,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -13.6,
+        "y": 16.6,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -13.553419992182647,
+        "y": 16.646580007817356,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.64087477121987,
+        "y": 17.559125228780132,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.684305858396707,
+        "y": 17.559125228780132,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.583,
+        "y": 16.457819370383426,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.583,
+        "y": 16.058,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": -8.583,
+        "y": 16.058,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -8.583,
+        "y": 16.058,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.649544143268804,
+        "y": 15.991455856731196,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.649544143268804,
+        "y": 15.952459111829121,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.062085031439683,
+        "y": 15.365,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.15,
+        "y": 15.365,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_37"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_27"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst10_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_103",
+      "pcb_port_123"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 4.374896,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_103"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.375,
+        "y": -5.673,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.241,
+        "y": -5.807,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 4.241,
+        "y": -5.807,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 4.241,
+        "y": -5.807,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.329588233216131,
+        "y": -5.895588233216132,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.329588233216131,
+        "y": -5.959703568628744,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.784707827290285,
+        "y": -4.50458397455459,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.902045042042148,
+        "y": -4.50458397455459,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.902045042042148,
+        "y": 0.6229549579578524,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.325,
+        "y": 1.2,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": 5.325,
+        "y": 1.2,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 5.325,
+        "y": 1.2,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.340146961130751,
+        "y": 1.1848530388692495,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.56157586103194,
+        "y": 1.1848530388692495,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.57142289990119,
+        "y": 1.175006,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.057392,
+        "y": 1.175006,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_123"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_51"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst11_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_103",
+      "pcb_port_208"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 4.374896,
+        "y": -5.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_103"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.375,
+        "y": -6.234593580195901,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.009716354954014,
+        "y": -6.869309935149915,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.879026290103929,
+        "y": -5,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.175,
+        "y": -5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_208"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_51"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst12_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_143",
+      "pcb_port_195"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 4.024884,
+        "y": 7.057392,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_143"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.025,
+        "y": 8.460092,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.095,
+        "y": 12.530092,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_195"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_62"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst13_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_37",
+      "pcb_port_33"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.825,
+        "y": 20,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_33"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.5150000000000006,
+        "y": 20,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.15,
+        "y": 15.365,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_37"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_30"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst14_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_33",
+      "pcb_port_196"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.825,
+        "y": 20,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_33"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.49,
+        "y": 14.684999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.49,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_196"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_30"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_8_mst15_0",
+    "connection_name": "source_net_8",
+    "connectsTo": [
+      "pcb_port_199",
+      "pcb_port_70"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -6.057392,
+        "y": -3.024884,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_70"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.068865143423931,
+        "y": -3.0131348565760687,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.287428540549496,
+        "y": -3.0131348565760687,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.290543887464266,
+        "y": -3.002509327438331,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.549282180724553,
+        "y": -3.1487252914899,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.652362743394765,
+        "y": -3.3523627433947656,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.190000000000001,
+        "y": -8.89,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.5,
+        "y": -8.89,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_199"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_45"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_7_0",
+    "connection_name": "source_net_7",
+    "connectsTo": [
+      "pcb_port_23",
+      "pcb_port_69"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 5.94996,
+        "y": -18.850904,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_23"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.949921602823158,
+        "y": -14.424198381654733,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.1216010459561443,
+        "y": -9.603115802829523,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.8116133151876527,
+        "y": -9.285813299665545,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.8116133151876527,
+        "y": -8.730249241687016,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.8116133151876527,
+        "y": -8.726613315187652,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.706,
+        "y": -8.621,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 0.706,
+        "y": -8.621,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 0.706,
+        "y": -8.621,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.4691270482580383,
+        "y": -8.384127048258039,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.942872951741961,
+        "y": -8.384127048258039,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.957,
+        "y": -8.37,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -4.957,
+        "y": -8.37,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -4.957,
+        "y": -8.37,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.957,
+        "y": -6.717947178703612,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.934706444068308,
+        "y": -4.740240734635304,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.934706444068308,
+        "y": -4.737293555931692,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.061,
+        "y": -4.611,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -7.061,
+        "y": -4.611,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -7.061,
+        "y": -4.611,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.061,
+        "y": -2.665552943834108,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.033249397989438,
+        "y": -2.6378023418235466,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.955598755097435,
+        "y": -2.560151698931543,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -6.955598755097435,
+        "y": -2.560151698931543,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -6.955598755097435,
+        "y": -2.560151698931543,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.840750454028979,
+        "y": -2.675,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.057392,
+        "y": -2.674872,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_69"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_21"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_6_0",
+    "connection_name": "source_net_6",
+    "connectsTo": [
+      "pcb_port_25",
+      "pcb_port_68"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 4.05004,
+        "y": -18.850904,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_25"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.05004,
+        "y": -18.25919731328632,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.493090111769921,
+        "y": -15.702247425056244,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.4842474250562445,
+        "y": -15.702247425056244,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.398,
+        "y": -15.616,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 1.398,
+        "y": -15.616,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 1.398,
+        "y": -15.616,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.074877360236079,
+        "y": -11.14312263976392,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.074877360236079,
+        "y": -8.469777399558318,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.601202632173102,
+        "y": -5.943452127621295,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.601202632173102,
+        "y": -2.2626318032357755,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.487631803235775,
+        "y": -2.2626318032357755,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.474823179706449,
+        "y": -2.2569165171180843,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": -5.474823179706449,
+        "y": -2.2569165171180843,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -5.474823179706449,
+        "y": -2.2569165171180843,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.981834379068343,
+        "y": -2.2695863776967395,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.057392,
+        "y": -2.325114,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_68"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_19"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_5_mst0_0",
+    "connection_name": "source_net_5",
+    "connectsTo": [
+      "pcb_port_26",
+      "pcb_port_28"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -12.949706,
+        "y": 13.700028,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_26"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.842715915573756,
+        "y": 13.807284084426243,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.842715915573756,
+        "y": 14.155238939599426,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.134137687418827,
+        "y": 14.863817167754355,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.861772022927537,
+        "y": 14.863817167754355,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.050294,
+        "y": 14.052339144826817,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.050294,
+        "y": 13.700028,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_28"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_24"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_5_mst1_0",
+    "connection_name": "source_net_5",
+    "connectsTo": [
+      "pcb_port_31",
+      "pcb_port_28"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -11.050294,
+        "y": 13.700028,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_28"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.050294,
+        "y": 15.168538699810352,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.672489427624976,
+        "y": 15.544662172942427,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.549572154503656,
+        "y": 15.64770658143719,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.547490630076904,
+        "y": 16.131860758134856,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.549142522751717,
+        "y": 16.453207065708987,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.546116721445165,
+        "y": 16.9083258855203,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.677926568639277,
+        "y": 17.095437654588753,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.680750654316821,
+        "y": 17.042258639473467,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.866463861894564,
+        "y": 17.042777621844653,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.825,
+        "y": 18,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_31"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_25"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_5_mst2_0",
+    "connection_name": "source_net_5",
+    "connectsTo": [
+      "pcb_port_31",
+      "pcb_port_35"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -11.825,
+        "y": 18,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_31"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.118097249836868,
+        "y": 18.70690275016313,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.95190275016313,
+        "y": 18.70690275016313,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.15,
+        "y": 17.905,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_35"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_28"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_5_mst3_0",
+    "connection_name": "source_net_5",
+    "connectsTo": [
+      "pcb_port_15",
+      "pcb_port_14"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 2.4001603,
+        "y": -25.8258552,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_14"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.4,
+        "y": -24.982,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.57,
+        "y": -24.152,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 1.57,
+        "y": -24.152,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 1.57,
+        "y": -24.152,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.5090345332551447,
+        "y": -24.212965466744855,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.5090345332551447,
+        "y": -24.353476634851447,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.9224888318934088,
+        "y": -26.785,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.776,
+        "y": -26.785,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": -1.776,
+        "y": -26.785,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -1.776,
+        "y": -26.785,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.877941963889054,
+        "y": -26.886941963889054,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.9437124728042814,
+        "y": -26.886941963889054,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.3999571,
+        "y": -26.430697336693335,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.3999571,
+        "y": -25.8260203,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_15"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_8"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_5_mst4_0",
+    "connection_name": "source_net_5",
+    "connectsTo": [
+      "pcb_port_14",
+      "pcb_port_24"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 2.4001603,
+        "y": -25.8258552,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_14"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.4,
+        "y": -25.071,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.179161786755304,
+        "y": -24.284161333971262,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 3.179161786755304,
+        "y": -24.284161333971262,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 3.179161786755304,
+        "y": -24.284161333971262,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.1970053294036815,
+        "y": -24.27399467059632,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.1970053294036815,
+        "y": -24.16038459973888,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.1470643393174225,
+        "y": -23.21032558982514,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.1470643393174225,
+        "y": -20.2981615865449,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 4.1470643393174225,
+        "y": -20.2981615865449,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 4.1470643393174225,
+        "y": -20.2981615865449,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.153907401863205,
+        "y": -20.291318523999117,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.153907401863205,
+        "y": -20.250239126301864,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5,
+        "y": -19.404146528165068,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5,
+        "y": -18.850904,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_24"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_8"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_5_mst5_0",
+    "connection_name": "source_net_5",
+    "connectsTo": [
+      "pcb_port_206",
+      "pcb_port_26"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -12.949706,
+        "y": 13.700028,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_26"
+      },
+      {
+        "route_type": "wire",
+        "x": -15.690000000000001,
+        "y": 13.7,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.5,
+        "y": 8.89,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_206"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_24"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_5_mst6_0",
+    "connection_name": "source_net_5",
+    "connectsTo": [
+      "pcb_port_28",
+      "pcb_port_24"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 5,
+        "y": -18.850904,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_24"
+      },
+      {
+        "route_type": "wire",
+        "x": 5,
+        "y": -16.133706660227123,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.9110105212898096,
+        "y": -12.044717181516933,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.8907171815169327,
+        "y": -12.044717181516933,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.771,
+        "y": -11.925,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 0.771,
+        "y": -11.925,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 0.771,
+        "y": -11.925,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.892178322777884,
+        "y": -11.925,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.841893174888565,
+        "y": -7.97528514788932,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.841893174888565,
+        "y": 8.334338351301096,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.458193846230579,
+        "y": 12.95063902264311,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.458193846230579,
+        "y": 12.952193846230578,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.486,
+        "y": 12.98,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -10.486,
+        "y": 12.98,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -10.486,
+        "y": 12.98,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.486,
+        "y": 13.136,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -11.050294,
+        "y": 13.700028,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_28"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_23"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst0_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_3",
+      "pcb_port_12"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -3.1999554999999997,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_12"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.5567620000000018,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.325112,
+        "y": -26.5943068,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_3"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_6"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst1_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_13",
+      "pcb_port_0"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 3.2000063,
+        "y": -25.8258552,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_13"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.556660400000001,
+        "y": -25.8258552,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.325112,
+        "y": -26.5943068,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_0"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_7"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst2_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_17",
+      "pcb_port_19"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -5.175,
+        "y": -21,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_17"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.410877008059852,
+        "y": -20.235877008059852,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.9917383528669794,
+        "y": -20.235877008059852,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.939122991940148,
+        "y": -20.235877008059852,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.175,
+        "y": -21,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_19"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_15"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst3_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_191",
+      "pcb_port_177"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 12.51,
+        "y": 2.5,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_177"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.905,
+        "y": 3.1050000000000004,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.905,
+        "y": 5.469908,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_191"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_85"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst4_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_32",
+      "pcb_port_36"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -10.175,
+        "y": 18,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_32"
+      },
+      {
+        "route_type": "wire",
+        "x": -8.514999999999999,
+        "y": 18,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.15,
+        "y": 16.635,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_36"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_29"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst5_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_21",
+      "pcb_port_185"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 5,
+        "y": -21.149096,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_21"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.385918008334948,
+        "y": -20.763081991665054,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.385918008334948,
+        "y": -20.368614354135914,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.556457645864084,
+        "y": -20.368614354135914,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.850016999999999,
+        "y": -19.075055,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_185"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_22"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst6_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_175",
+      "pcb_port_211"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 9.51,
+        "y": -1,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_175"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.825,
+        "y": -1,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.825,
+        "y": -3,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_211"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_83"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst7_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_3",
+      "pcb_port_2"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -4.325112,
+        "y": -26.5943068,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_3"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.325112,
+        "y": -26.594112000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -4.325112,
+        "y": -30.774130800000002,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_2"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_12"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst8_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_1",
+      "pcb_port_0"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 4.325112,
+        "y": -30.774130800000002,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_1"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.325112,
+        "y": -26.594112000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.325112,
+        "y": -26.5943068,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_0"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_10"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst9_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_181",
+      "pcb_port_183"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 7.850016999999999,
+        "y": -11.075055,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_181"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.850055000000001,
+        "y": -11.075055,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.149983,
+        "y": -11.075055,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_183"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_90"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst10_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_185",
+      "pcb_port_187"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 7.850016999999999,
+        "y": -19.075055,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_185"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.850054999999999,
+        "y": -19.075055,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.149983,
+        "y": -19.075055,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_187"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_94"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst11_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_175",
+      "pcb_port_177"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 9.51,
+        "y": -1,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_175"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.611425406002425,
+        "y": -0.8985745939975748,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.46765609063389,
+        "y": -0.8985745939975748,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.51,
+        "y": 1.1437693153685355,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.51,
+        "y": 2.5,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_177"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_83"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst12_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_27",
+      "pcb_port_32"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -12.000508,
+        "y": 13.700028,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_27"
+      },
+      {
+        "route_type": "wire",
+        "x": -12,
+        "y": 13.700999999999999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12,
+        "y": 14.5,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -12,
+        "y": 14.5,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -12,
+        "y": 14.5,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -12,
+        "y": 14.421635789423414,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.821635789423413,
+        "y": 16.6,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.297,
+        "y": 16.6,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "via",
+        "x": -9.297,
+        "y": 16.6,
+        "from_layer": "top",
+        "to_layer": "inner2",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -9.297,
+        "y": 16.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -9.337248756373148,
+        "y": 16.6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.175,
+        "y": 17.437751243626856,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -10.175,
+        "y": 18,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_32"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_26"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst13_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_12",
+      "pcb_port_19"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -3.1999554999999997,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_12"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.2,
+        "y": -25.271,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.397,
+        "y": -24.468,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -2.397,
+        "y": -24.468,
+        "from_layer": "bottom",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -2.397,
+        "y": -24.468,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.3978484807402576,
+        "y": -24.467151519259744,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.3978484807402576,
+        "y": -24.466486232750285,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.2,
+        "y": -24.268637752010026,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.2,
+        "y": -21.8,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -2.2,
+        "y": -21.8,
+        "from_layer": "top",
+        "to_layer": "bottom",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -2.2,
+        "y": -21.8,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.2478669343905433,
+        "y": -21.752133065609456,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.2478669343905433,
+        "y": -21.719633918568444,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.175,
+        "y": -21.6467669841779,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.175,
+        "y": -21,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_19"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_6"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst14_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_13",
+      "pcb_port_21"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 3.2000063,
+        "y": -25.8258552,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_13"
+      },
+      {
+        "route_type": "wire",
+        "x": 5,
+        "y": -24.026,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5,
+        "y": -21.149096,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_21"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_7"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst15_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_12",
+      "pcb_port_13"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -3.1999554999999997,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_12"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.444631963735702,
+        "y": -26.0706332637357,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.444631963735702,
+        "y": -27.474517235419356,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.3257535876653286,
+        "y": -27.59339561148973,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.414082138478911,
+        "y": -27.59339561148973,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.414082138478911,
+        "y": -26.03993103847891,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.2000063,
+        "y": -25.8258552,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_13"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_6"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst16_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_34",
+      "pcb_port_197"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 0.825,
+        "y": 20,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_34"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.51,
+        "y": 15.315000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.51,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_197"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_31"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst17_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_181",
+      "pcb_port_185"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 7.850016999999999,
+        "y": -11.075055,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_181"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.042465209436082,
+        "y": -11.88260679056392,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.042465209436082,
+        "y": -18.240265664386698,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.042465209436082,
+        "y": -18.267465209436082,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.850016999999999,
+        "y": -19.075055,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_185"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_90"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst18_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_183",
+      "pcb_port_211"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 12.149983,
+        "y": -11.075055,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_183"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.475282526962314,
+        "y": -9.749717473037686,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.475282526962314,
+        "y": -9.7025471991525,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 13.475282526962314,
+        "y": -3.6502825269623145,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 12.825,
+        "y": -3,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_211"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_91"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst19_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_36",
+      "pcb_port_34"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 0.825,
+        "y": 20,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_34"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.11810288365864927,
+        "y": 20.706897116341352,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.0781028836586497,
+        "y": 20.706897116341352,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -7.15,
+        "y": 16.635,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_36"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_31"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst20_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_207",
+      "pcb_port_27"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -12.000508,
+        "y": 13.700028,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_27"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.00900798817781,
+        "y": 13.691992011822189,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.00900798817781,
+        "y": 13.455651746226915,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -12.857659734404725,
+        "y": 12.607,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.799,
+        "y": 12.607,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -14.799,
+        "y": 12.607,
+        "from_layer": "inner2",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -14.799,
+        "y": 12.607,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.904343324792157,
+        "y": 12.501656675207842,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -14.943985802220645,
+        "y": 12.501656675207842,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.015642477428486,
+        "y": 11.43,
+        "width": 0.15,
+        "layer": "inner2"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.5,
+        "y": 11.43,
+        "width": 0.15,
+        "layer": "inner2",
+        "end_pcb_port_id": "pcb_port_207"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_26"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst21_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_171",
+      "pcb_port_175"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 0,
+        "y": 1,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_171"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.022055777980324,
+        "y": 1,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.127709993176991,
+        "y": -1.1056542151966666,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.269654215196667,
+        "y": -1.1056542151966666,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.291,
+        "y": -1.127,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 5.291,
+        "y": -1.127,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 5.291,
+        "y": -1.127,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.133507500684254,
+        "y": 0.7155075006842535,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.455477603131174,
+        "y": 0.7155075006842536,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.455477603131174,
+        "y": 0.6275223968688257,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.857736660903111,
+        "y": 0.2252633390968883,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.923,
+        "y": 0.16,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 8.923,
+        "y": 0.16,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 8.923,
+        "y": 0.16,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.923,
+        "y": -0.41300000000000026,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.51,
+        "y": -1,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_175"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_67"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst22_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_197",
+      "pcb_port_191"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 11.905,
+        "y": 5.469908,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_191"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.905,
+        "y": 5.47,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 11.905,
+        "y": 6.572157313883012,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.037,
+        "y": 8.44015731388301,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10.046936143176366,
+        "y": 13.556302447532113,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.59385007894633,
+        "y": 14.010467526337099,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.51,
+        "y": 14,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_197"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_103"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst23_0",
+    "connection_name": "source_net_4",
+    "connectsTo": [
+      "pcb_port_198",
+      "pcb_port_17"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -5.175,
+        "y": -21,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_17"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.382,
+        "y": -21.207,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.382,
+        "y": -21.952,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": -5.382,
+        "y": -21.952,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": -5.382,
+        "y": -21.952,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.398117347548693,
+        "y": -21.968117347548695,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -5.398117347548693,
+        "y": -22.047754159436643,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -16.015871506985334,
+        "y": -11.43,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": -20.5,
+        "y": -11.43,
+        "width": 0.15,
+        "layer": "inner1",
+        "end_pcb_port_id": "pcb_port_198"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_15"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst0_0",
+    "connection_name": "source_net_3",
+    "connectsTo": [
+      "pcb_port_7",
+      "pcb_port_9"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.249936,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_7"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.25,
+        "y": -25.826,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.25,
+        "y": -26.83482002026997,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.06551597812816112,
+        "y": -27.15033599839813,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.3263111700506713,
+        "y": -27.15033599839813,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.750062,
+        "y": -26.726585168448803,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.750062,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_9"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_4"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst1_0",
+    "connection_name": "source_net_3",
+    "connectsTo": [
+      "pcb_port_9",
+      "pcb_port_22"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 0.750062,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_9"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.750062,
+        "y": -26.5759568,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.750062,
+        "y": -26.727062,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.8,
+        "y": -26.777,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 0.8,
+        "y": -26.777,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 0.8,
+        "y": -26.777,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.1643608365774685,
+        "y": -26.77836491541599,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.664833958327508,
+        "y": -23.28010800101202,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.662361165419905,
+        "y": -23.237297522872073,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.400561592734748,
+        "y": -21.49909709555723,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.5009029044427695,
+        "y": -21.49909709555723,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.6,
+        "y": -21.4,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 6.6,
+        "y": -21.4,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 6.6,
+        "y": -21.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.200999999999998,
+        "y": -21.4,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.94996,
+        "y": -21.149096,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_22"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_5"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst0_0",
+    "connection_name": "source_net_2",
+    "connectsTo": [
+      "pcb_port_6",
+      "pcb_port_8"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -0.750062,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_6"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.750062,
+        "y": -25.17593876633509,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.5750803336649084,
+        "y": -24.985959930932616,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.17483980790811093,
+        "y": -24.985959930932616,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.17483980790811093,
+        "y": -25.75083980790811,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.249936,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_8"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_mst1_0",
+    "connection_name": "source_net_2",
+    "connectsTo": [
+      "pcb_port_8",
+      "pcb_port_20"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 0.249936,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_8"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.249936,
+        "y": -24.891276255765728,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.2038933819718178,
+        "y": -24.845233637737547,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.2038933819718178,
+        "y": -24.78010661802818,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.206,
+        "y": -24.778,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 0.206,
+        "y": -24.778,
+        "from_layer": "top",
+        "to_layer": "inner1",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 0.206,
+        "y": -24.778,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.206,
+        "y": -23.66384707634645,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.3013671616485758,
+        "y": -23.568479914697875,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.3013671616485758,
+        "y": -23.447632838351424,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.385,
+        "y": -23.364,
+        "width": 0.15,
+        "layer": "inner1"
+      },
+      {
+        "route_type": "via",
+        "x": 0.385,
+        "y": -23.364,
+        "from_layer": "inner1",
+        "to_layer": "top",
+        "via_diameter": 0.3,
+        "via_hole_diameter": 0.2
+      },
+      {
+        "route_type": "wire",
+        "x": 0.385,
+        "y": -23.364,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.835,
+        "y": -23.364,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.05004,
+        "y": -21.149096,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_20"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_3"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_0",
+    "connection_name": "source_net_1",
+    "connectsTo": [
+      "pcb_port_11",
+      "pcb_port_18"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 1.75006,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_11"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.75006,
+        "y": -25.241242584598865,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.7493660693446054,
+        "y": -24.24054865394347,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.5844513460565297,
+        "y": -24.24054865394347,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.825,
+        "y": -21,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_18"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_0",
+    "connection_name": "source_net_0",
+    "connectsTo": [
+      "pcb_port_5",
+      "pcb_port_16"
+    ],
+    "route": [
+      {
+        "route_type": "wire",
+        "x": -1.249934,
+        "y": -25.8259568,
+        "width": 0.15,
+        "layer": "top",
+        "start_pcb_port_id": "pcb_port_5"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.25,
+        "y": -24.55289717000675,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.8133930498151556,
+        "y": -23.989504120191597,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -3.835495879808403,
+        "y": -23.989504120191597,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -6.825,
+        "y": -21,
+        "width": 0.15,
+        "layer": "top",
+        "end_pcb_port_id": "pcb_port_16"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_0",
+    "source_trace_id": "source_trace_0"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_0",
+    "pcb_trace_id": "source_net_27_0",
+    "x": 5.227,
+    "y": -5.864,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_1",
+    "pcb_trace_id": "source_net_27_0",
+    "x": 0.091,
+    "y": -7.484,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_2",
+    "pcb_trace_id": "source_net_27_0",
+    "x": -2.116,
+    "y": -12.885,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net27"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_3",
+    "pcb_trace_id": "source_net_26_0",
+    "x": -4.007,
+    "y": 5.912,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_4",
+    "pcb_trace_id": "source_net_26_0",
+    "x": -7.463062840589549,
+    "y": 6.120851700925059,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "inner2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net26"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_5",
+    "pcb_trace_id": "source_net_25_0",
+    "x": -4.798429772749198,
+    "y": 6.431580060293706,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_6",
+    "pcb_trace_id": "source_net_25_0",
+    "x": -7.122937159410451,
+    "y": 5.73414829907494,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_7",
+    "pcb_trace_id": "source_net_25_0",
+    "x": -8.593,
+    "y": 4.947,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_8",
+    "pcb_trace_id": "source_net_25_0",
+    "x": -16.418,
+    "y": -1.385,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net25"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_9",
+    "pcb_trace_id": "source_net_22_0",
+    "x": -4.275,
+    "y": 6.382,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net22"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_10",
+    "pcb_trace_id": "source_net_21_0",
+    "x": -0.18570980894279004,
+    "y": -5.802002374252999,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_11",
+    "pcb_trace_id": "source_net_21_0",
+    "x": 11.253,
+    "y": 7.827,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net21"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_12",
+    "pcb_trace_id": "source_net_20_0",
+    "x": -0.718,
+    "y": -7.821,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_13",
+    "pcb_trace_id": "source_net_20_0",
+    "x": 7.484,
+    "y": 4.633,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net20"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_14",
+    "pcb_trace_id": "source_net_19_0",
+    "x": -1.318,
+    "y": -5.808,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_15",
+    "pcb_trace_id": "source_net_19_0",
+    "x": 12.53,
+    "y": 4.676,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "inner2"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "inner2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_16",
+    "pcb_trace_id": "source_net_19_0",
+    "x": 10.6,
+    "y": 4.1,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net19"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_17",
+    "pcb_trace_id": "source_net_18_0",
+    "x": -2.391,
+    "y": -6.187,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net18"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_18",
+    "pcb_trace_id": "source_net_18_0",
+    "x": 0.885,
+    "y": -6.31,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net18"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_19",
+    "pcb_trace_id": "source_net_18_0",
+    "x": 1.4126961556992705,
+    "y": -9.413303787845697,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net18"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_20",
+    "pcb_trace_id": "source_net_18_0",
+    "x": 9.788,
+    "y": 3.915,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net18"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_21",
+    "pcb_trace_id": "source_net_17_0",
+    "x": -2.785,
+    "y": -5.726,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_22",
+    "pcb_trace_id": "source_net_17_0",
+    "x": 12.665,
+    "y": 10.015,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net17"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_23",
+    "pcb_trace_id": "source_net_16_0",
+    "x": -3.584,
+    "y": -8.899,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_24",
+    "pcb_trace_id": "source_net_16_0",
+    "x": 10.547,
+    "y": 7.41,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net16"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_25",
+    "pcb_trace_id": "source_net_15_mst1_0",
+    "x": 8.15,
+    "y": -2.95,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_26",
+    "pcb_trace_id": "source_net_15_mst1_0",
+    "x": 10.901,
+    "y": 0.035,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net15"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_27",
+    "pcb_trace_id": "source_net_13_mst2_0",
+    "x": 8.071,
+    "y": -4.389,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_28",
+    "pcb_trace_id": "source_net_13_mst2_0",
+    "x": 8.253047692453945,
+    "y": -6.772854210653878,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net13"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_29",
+    "pcb_trace_id": "source_net_10_mst1_0",
+    "x": -1.9727558071037046,
+    "y": 14.011237557326373,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_30",
+    "pcb_trace_id": "source_net_10_mst1_0",
+    "x": 6.654536747997392,
+    "y": -1.0367638421325986,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner2",
+      "inner1"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_31",
+    "pcb_trace_id": "source_net_10_mst1_0",
+    "x": 5.421,
+    "y": -2.17,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net10"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_32",
+    "pcb_trace_id": "source_net_9_mst4_0",
+    "x": 2.917,
+    "y": -6.291,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_33",
+    "pcb_trace_id": "source_net_9_mst4_0",
+    "x": 5.01,
+    "y": -7.35,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_34",
+    "pcb_trace_id": "source_net_9_mst4_0",
+    "x": 6.7,
+    "y": -2.627,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_35",
+    "pcb_trace_id": "source_net_9_mst10_0",
+    "x": -9.947,
+    "y": 9.393,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_36",
+    "pcb_trace_id": "source_net_9_mst10_0",
+    "x": -7.936,
+    "y": 5.06,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_37",
+    "pcb_trace_id": "source_net_9_mst10_0",
+    "x": -5.275,
+    "y": 4.825,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net9"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_38",
+    "pcb_trace_id": "source_net_8_mst5_0",
+    "x": 4.982,
+    "y": 4.179,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_39",
+    "pcb_trace_id": "source_net_8_mst5_0",
+    "x": 4.602,
+    "y": 6.282,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_40",
+    "pcb_trace_id": "source_net_8_mst8_0",
+    "x": -2.041,
+    "y": -7.004,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_41",
+    "pcb_trace_id": "source_net_8_mst8_0",
+    "x": 1.383,
+    "y": -6.796,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_42",
+    "pcb_trace_id": "source_net_8_mst9_0",
+    "x": -13.6,
+    "y": 16.6,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_43",
+    "pcb_trace_id": "source_net_8_mst9_0",
+    "x": -8.583,
+    "y": 16.058,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_44",
+    "pcb_trace_id": "source_net_8_mst10_0",
+    "x": 4.241,
+    "y": -5.807,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_45",
+    "pcb_trace_id": "source_net_8_mst10_0",
+    "x": 5.325,
+    "y": 1.2,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net8"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_46",
+    "pcb_trace_id": "source_net_7_0",
+    "x": 0.706,
+    "y": -8.621,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_47",
+    "pcb_trace_id": "source_net_7_0",
+    "x": -4.957,
+    "y": -8.37,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_48",
+    "pcb_trace_id": "source_net_7_0",
+    "x": -7.061,
+    "y": -4.611,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_49",
+    "pcb_trace_id": "source_net_7_0",
+    "x": -6.955598755097435,
+    "y": -2.560151698931543,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net7"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_50",
+    "pcb_trace_id": "source_net_6_0",
+    "x": 1.398,
+    "y": -15.616,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_51",
+    "pcb_trace_id": "source_net_6_0",
+    "x": -5.474823179706449,
+    "y": -2.2569165171180843,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net6"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_52",
+    "pcb_trace_id": "source_net_5_mst3_0",
+    "x": 1.57,
+    "y": -24.152,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_53",
+    "pcb_trace_id": "source_net_5_mst3_0",
+    "x": -1.776,
+    "y": -26.785,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_54",
+    "pcb_trace_id": "source_net_5_mst4_0",
+    "x": 3.179161786755304,
+    "y": -24.284161333971262,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_55",
+    "pcb_trace_id": "source_net_5_mst4_0",
+    "x": 4.1470643393174225,
+    "y": -20.2981615865449,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_56",
+    "pcb_trace_id": "source_net_5_mst6_0",
+    "x": 0.771,
+    "y": -11.925,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_57",
+    "pcb_trace_id": "source_net_5_mst6_0",
+    "x": -10.486,
+    "y": 12.98,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net5"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_58",
+    "pcb_trace_id": "source_net_4_mst12_0",
+    "x": -12,
+    "y": 14.5,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_59",
+    "pcb_trace_id": "source_net_4_mst12_0",
+    "x": -9.297,
+    "y": 16.6,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner2",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_60",
+    "pcb_trace_id": "source_net_4_mst13_0",
+    "x": -2.397,
+    "y": -24.468,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "bottom",
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_61",
+    "pcb_trace_id": "source_net_4_mst13_0",
+    "x": -2.2,
+    "y": -21.8,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_62",
+    "pcb_trace_id": "source_net_4_mst20_0",
+    "x": -14.799,
+    "y": 12.607,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner2",
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner2",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_63",
+    "pcb_trace_id": "source_net_4_mst21_0",
+    "x": 5.291,
+    "y": -1.127,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_64",
+    "pcb_trace_id": "source_net_4_mst21_0",
+    "x": 8.923,
+    "y": 0.16,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_65",
+    "pcb_trace_id": "source_net_4_mst23_0",
+    "x": -5.382,
+    "y": -21.952,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net4"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_66",
+    "pcb_trace_id": "source_net_3_mst1_0",
+    "x": 0.8,
+    "y": -26.777,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_67",
+    "pcb_trace_id": "source_net_3_mst1_0",
+    "x": 6.6,
+    "y": -21.4,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net3"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_68",
+    "pcb_trace_id": "source_net_2_mst1_0",
+    "x": 0.206,
+    "y": -24.778,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "top",
+      "inner1"
+    ],
+    "from_layer": "top",
+    "to_layer": "inner1",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_69",
+    "pcb_trace_id": "source_net_2_mst1_0",
+    "x": 0.385,
+    "y": -23.364,
+    "hole_diameter": 0.2,
+    "outer_diameter": 0.3,
+    "layers": [
+      "inner1",
+      "top"
+    ],
+    "from_layer": "inner1",
+    "to_layer": "top",
+    "subcircuit_id": "subcircuit_source_group_0",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuitsubcircuit_source_group_0_connectivity_net2"
+  },
+  {
+    "type": "pcb_trace_too_long_warning",
+    "pcb_trace_too_long_warning_id": "pcb_trace_too_long_warning_0",
+    "warning_type": "pcb_trace_too_long_warning",
+    "message": "PCB trace is 10.77mm long, exceeding the 10mm maximum",
+    "pcb_trace_id": "source_net_15_mst1_0",
+    "source_trace_id": "source_trace_55",
+    "source_net_id": "source_net_15",
+    "actual_trace_length": 10.770583961977932,
+    "maximum_trace_length": 10,
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_0",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on D1 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_3",
+    "source_port_ids": [
+      "source_port_20",
+      "source_port_21",
+      "source_port_22",
+      "source_port_23",
+      "source_port_24",
+      "source_port_25"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_1",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on U2 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_4",
+    "source_port_ids": [
+      "source_port_26",
+      "source_port_27",
+      "source_port_28",
+      "source_port_29",
+      "source_port_30"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_2",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on U3 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_7",
+    "source_port_ids": [
+      "source_port_35",
+      "source_port_36",
+      "source_port_37",
+      "source_port_38",
+      "source_port_39",
+      "source_port_40",
+      "source_port_41",
+      "source_port_42"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_3",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on U1 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_8",
+    "source_port_ids": [
+      "source_port_43",
+      "source_port_44",
+      "source_port_45",
+      "source_port_46",
+      "source_port_47",
+      "source_port_48",
+      "source_port_49",
+      "source_port_50",
+      "source_port_51",
+      "source_port_52",
+      "source_port_53",
+      "source_port_54",
+      "source_port_55",
+      "source_port_56",
+      "source_port_57",
+      "source_port_58",
+      "source_port_59",
+      "source_port_60",
+      "source_port_61",
+      "source_port_62",
+      "source_port_63",
+      "source_port_64",
+      "source_port_65",
+      "source_port_66",
+      "source_port_67",
+      "source_port_68",
+      "source_port_69",
+      "source_port_70",
+      "source_port_71",
+      "source_port_72",
+      "source_port_73",
+      "source_port_74",
+      "source_port_75",
+      "source_port_76",
+      "source_port_77",
+      "source_port_78",
+      "source_port_79",
+      "source_port_80",
+      "source_port_81",
+      "source_port_82",
+      "source_port_83",
+      "source_port_84",
+      "source_port_85",
+      "source_port_86",
+      "source_port_87",
+      "source_port_88",
+      "source_port_89",
+      "source_port_90",
+      "source_port_91",
+      "source_port_92",
+      "source_port_93",
+      "source_port_94",
+      "source_port_95",
+      "source_port_96",
+      "source_port_97",
+      "source_port_98",
+      "source_port_99",
+      "source_port_100",
+      "source_port_101",
+      "source_port_102",
+      "source_port_103",
+      "source_port_104",
+      "source_port_105",
+      "source_port_106",
+      "source_port_107",
+      "source_port_108",
+      "source_port_109",
+      "source_port_110",
+      "source_port_111",
+      "source_port_112",
+      "source_port_113",
+      "source_port_114",
+      "source_port_115",
+      "source_port_116",
+      "source_port_117",
+      "source_port_118",
+      "source_port_119",
+      "source_port_120",
+      "source_port_121",
+      "source_port_122",
+      "source_port_123",
+      "source_port_124",
+      "source_port_125",
+      "source_port_126",
+      "source_port_127",
+      "source_port_128",
+      "source_port_129",
+      "source_port_130",
+      "source_port_131",
+      "source_port_132",
+      "source_port_133",
+      "source_port_134",
+      "source_port_135",
+      "source_port_136",
+      "source_port_137",
+      "source_port_138",
+      "source_port_139",
+      "source_port_140",
+      "source_port_141",
+      "source_port_142",
+      "source_port_143",
+      "source_port_144",
+      "source_port_145",
+      "source_port_146",
+      "source_port_147",
+      "source_port_148",
+      "source_port_149",
+      "source_port_150",
+      "source_port_151",
+      "source_port_152",
+      "source_port_153",
+      "source_port_154",
+      "source_port_155",
+      "source_port_156",
+      "source_port_157",
+      "source_port_158",
+      "source_port_159",
+      "source_port_160",
+      "source_port_161",
+      "source_port_162",
+      "source_port_163",
+      "source_port_164",
+      "source_port_165",
+      "source_port_166",
+      "source_port_167",
+      "source_port_168",
+      "source_port_169",
+      "source_port_170",
+      "source_port_171"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_4",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on SW1 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_13",
+    "source_port_ids": [
+      "source_port_180",
+      "source_port_181",
+      "source_port_182",
+      "source_port_183"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_component_pins_underspecified_warning",
+    "source_component_pins_underspecified_warning_id": "source_component_pins_underspecified_warning_5",
+    "warning_type": "source_component_pins_underspecified_warning",
+    "message": "All pins on SW2 are underspecified (no pinAttributes set)",
+    "source_component_id": "source_component_14",
+    "source_port_ids": [
+      "source_port_184",
+      "source_port_185",
+      "source_port_186",
+      "source_port_187"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_0",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "J1 has no pin with requires_power=true",
+    "source_component_id": "source_component_0",
+    "source_port_ids": [
+      "source_port_0",
+      "source_port_1",
+      "source_port_2",
+      "source_port_3",
+      "source_port_4",
+      "source_port_5",
+      "source_port_6",
+      "source_port_7",
+      "source_port_8",
+      "source_port_9",
+      "source_port_10",
+      "source_port_11",
+      "source_port_12",
+      "source_port_13",
+      "source_port_14",
+      "source_port_15"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_1",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "D1 has no pin with requires_power=true",
+    "source_component_id": "source_component_3",
+    "source_port_ids": [
+      "source_port_20",
+      "source_port_21",
+      "source_port_22",
+      "source_port_23",
+      "source_port_24",
+      "source_port_25"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_2",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "U2 has no pin with requires_power=true",
+    "source_component_id": "source_component_4",
+    "source_port_ids": [
+      "source_port_26",
+      "source_port_27",
+      "source_port_28",
+      "source_port_29",
+      "source_port_30"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_3",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "U3 has no pin with requires_power=true",
+    "source_component_id": "source_component_7",
+    "source_port_ids": [
+      "source_port_35",
+      "source_port_36",
+      "source_port_37",
+      "source_port_38",
+      "source_port_39",
+      "source_port_40",
+      "source_port_41",
+      "source_port_42"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_4",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "U1 has no pin with requires_power=true",
+    "source_component_id": "source_component_8",
+    "source_port_ids": [
+      "source_port_43",
+      "source_port_44",
+      "source_port_45",
+      "source_port_46",
+      "source_port_47",
+      "source_port_48",
+      "source_port_49",
+      "source_port_50",
+      "source_port_51",
+      "source_port_52",
+      "source_port_53",
+      "source_port_54",
+      "source_port_55",
+      "source_port_56",
+      "source_port_57",
+      "source_port_58",
+      "source_port_59",
+      "source_port_60",
+      "source_port_61",
+      "source_port_62",
+      "source_port_63",
+      "source_port_64",
+      "source_port_65",
+      "source_port_66",
+      "source_port_67",
+      "source_port_68",
+      "source_port_69",
+      "source_port_70",
+      "source_port_71",
+      "source_port_72",
+      "source_port_73",
+      "source_port_74",
+      "source_port_75",
+      "source_port_76",
+      "source_port_77",
+      "source_port_78",
+      "source_port_79",
+      "source_port_80",
+      "source_port_81",
+      "source_port_82",
+      "source_port_83",
+      "source_port_84",
+      "source_port_85",
+      "source_port_86",
+      "source_port_87",
+      "source_port_88",
+      "source_port_89",
+      "source_port_90",
+      "source_port_91",
+      "source_port_92",
+      "source_port_93",
+      "source_port_94",
+      "source_port_95",
+      "source_port_96",
+      "source_port_97",
+      "source_port_98",
+      "source_port_99",
+      "source_port_100",
+      "source_port_101",
+      "source_port_102",
+      "source_port_103",
+      "source_port_104",
+      "source_port_105",
+      "source_port_106",
+      "source_port_107",
+      "source_port_108",
+      "source_port_109",
+      "source_port_110",
+      "source_port_111",
+      "source_port_112",
+      "source_port_113",
+      "source_port_114",
+      "source_port_115",
+      "source_port_116",
+      "source_port_117",
+      "source_port_118",
+      "source_port_119",
+      "source_port_120",
+      "source_port_121",
+      "source_port_122",
+      "source_port_123",
+      "source_port_124",
+      "source_port_125",
+      "source_port_126",
+      "source_port_127",
+      "source_port_128",
+      "source_port_129",
+      "source_port_130",
+      "source_port_131",
+      "source_port_132",
+      "source_port_133",
+      "source_port_134",
+      "source_port_135",
+      "source_port_136",
+      "source_port_137",
+      "source_port_138",
+      "source_port_139",
+      "source_port_140",
+      "source_port_141",
+      "source_port_142",
+      "source_port_143",
+      "source_port_144",
+      "source_port_145",
+      "source_port_146",
+      "source_port_147",
+      "source_port_148",
+      "source_port_149",
+      "source_port_150",
+      "source_port_151",
+      "source_port_152",
+      "source_port_153",
+      "source_port_154",
+      "source_port_155",
+      "source_port_156",
+      "source_port_157",
+      "source_port_158",
+      "source_port_159",
+      "source_port_160",
+      "source_port_161",
+      "source_port_162",
+      "source_port_163",
+      "source_port_164",
+      "source_port_165",
+      "source_port_166",
+      "source_port_167",
+      "source_port_168",
+      "source_port_169",
+      "source_port_170",
+      "source_port_171"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_5",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "SW1 has no pin with requires_power=true",
+    "source_component_id": "source_component_13",
+    "source_port_ids": [
+      "source_port_180",
+      "source_port_181",
+      "source_port_182",
+      "source_port_183"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_power_pin_defined_warning",
+    "source_no_power_pin_defined_warning_id": "source_no_power_pin_defined_warning_6",
+    "warning_type": "source_no_power_pin_defined_warning",
+    "message": "SW2 has no pin with requires_power=true",
+    "source_component_id": "source_component_14",
+    "source_port_ids": [
+      "source_port_184",
+      "source_port_185",
+      "source_port_186",
+      "source_port_187"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_0",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "J1 has no pin with requires_ground=true",
+    "source_component_id": "source_component_0",
+    "source_port_ids": [
+      "source_port_0",
+      "source_port_1",
+      "source_port_2",
+      "source_port_3",
+      "source_port_4",
+      "source_port_5",
+      "source_port_6",
+      "source_port_7",
+      "source_port_8",
+      "source_port_9",
+      "source_port_10",
+      "source_port_11",
+      "source_port_12",
+      "source_port_13",
+      "source_port_14",
+      "source_port_15"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_1",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "D1 has no pin with requires_ground=true",
+    "source_component_id": "source_component_3",
+    "source_port_ids": [
+      "source_port_20",
+      "source_port_21",
+      "source_port_22",
+      "source_port_23",
+      "source_port_24",
+      "source_port_25"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_2",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "U2 has no pin with requires_ground=true",
+    "source_component_id": "source_component_4",
+    "source_port_ids": [
+      "source_port_26",
+      "source_port_27",
+      "source_port_28",
+      "source_port_29",
+      "source_port_30"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_3",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "U3 has no pin with requires_ground=true",
+    "source_component_id": "source_component_7",
+    "source_port_ids": [
+      "source_port_35",
+      "source_port_36",
+      "source_port_37",
+      "source_port_38",
+      "source_port_39",
+      "source_port_40",
+      "source_port_41",
+      "source_port_42"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_4",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "U1 has no pin with requires_ground=true",
+    "source_component_id": "source_component_8",
+    "source_port_ids": [
+      "source_port_43",
+      "source_port_44",
+      "source_port_45",
+      "source_port_46",
+      "source_port_47",
+      "source_port_48",
+      "source_port_49",
+      "source_port_50",
+      "source_port_51",
+      "source_port_52",
+      "source_port_53",
+      "source_port_54",
+      "source_port_55",
+      "source_port_56",
+      "source_port_57",
+      "source_port_58",
+      "source_port_59",
+      "source_port_60",
+      "source_port_61",
+      "source_port_62",
+      "source_port_63",
+      "source_port_64",
+      "source_port_65",
+      "source_port_66",
+      "source_port_67",
+      "source_port_68",
+      "source_port_69",
+      "source_port_70",
+      "source_port_71",
+      "source_port_72",
+      "source_port_73",
+      "source_port_74",
+      "source_port_75",
+      "source_port_76",
+      "source_port_77",
+      "source_port_78",
+      "source_port_79",
+      "source_port_80",
+      "source_port_81",
+      "source_port_82",
+      "source_port_83",
+      "source_port_84",
+      "source_port_85",
+      "source_port_86",
+      "source_port_87",
+      "source_port_88",
+      "source_port_89",
+      "source_port_90",
+      "source_port_91",
+      "source_port_92",
+      "source_port_93",
+      "source_port_94",
+      "source_port_95",
+      "source_port_96",
+      "source_port_97",
+      "source_port_98",
+      "source_port_99",
+      "source_port_100",
+      "source_port_101",
+      "source_port_102",
+      "source_port_103",
+      "source_port_104",
+      "source_port_105",
+      "source_port_106",
+      "source_port_107",
+      "source_port_108",
+      "source_port_109",
+      "source_port_110",
+      "source_port_111",
+      "source_port_112",
+      "source_port_113",
+      "source_port_114",
+      "source_port_115",
+      "source_port_116",
+      "source_port_117",
+      "source_port_118",
+      "source_port_119",
+      "source_port_120",
+      "source_port_121",
+      "source_port_122",
+      "source_port_123",
+      "source_port_124",
+      "source_port_125",
+      "source_port_126",
+      "source_port_127",
+      "source_port_128",
+      "source_port_129",
+      "source_port_130",
+      "source_port_131",
+      "source_port_132",
+      "source_port_133",
+      "source_port_134",
+      "source_port_135",
+      "source_port_136",
+      "source_port_137",
+      "source_port_138",
+      "source_port_139",
+      "source_port_140",
+      "source_port_141",
+      "source_port_142",
+      "source_port_143",
+      "source_port_144",
+      "source_port_145",
+      "source_port_146",
+      "source_port_147",
+      "source_port_148",
+      "source_port_149",
+      "source_port_150",
+      "source_port_151",
+      "source_port_152",
+      "source_port_153",
+      "source_port_154",
+      "source_port_155",
+      "source_port_156",
+      "source_port_157",
+      "source_port_158",
+      "source_port_159",
+      "source_port_160",
+      "source_port_161",
+      "source_port_162",
+      "source_port_163",
+      "source_port_164",
+      "source_port_165",
+      "source_port_166",
+      "source_port_167",
+      "source_port_168",
+      "source_port_169",
+      "source_port_170",
+      "source_port_171"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_5",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "SW1 has no pin with requires_ground=true",
+    "source_component_id": "source_component_13",
+    "source_port_ids": [
+      "source_port_180",
+      "source_port_181",
+      "source_port_182",
+      "source_port_183"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_no_ground_pin_defined_warning",
+    "source_no_ground_pin_defined_warning_id": "source_no_ground_pin_defined_warning_6",
+    "warning_type": "source_no_ground_pin_defined_warning",
+    "message": "SW2 has no pin with requires_ground=true",
+    "source_component_id": "source_component_14",
+    "source_port_ids": [
+      "source_port_184",
+      "source_port_185",
+      "source_port_186",
+      "source_port_187"
+    ],
+    "subcircuit_id": "subcircuit_source_group_0"
+  },
+  {
+    "type": "source_project_metadata",
+    "source_filesystem_md5_hash": "e5cfb24deb698ea5cb93e1d2dd233b1f"
+  }
+]


### PR DESCRIPTION
### Motivation
- the benchmark website needs a real large-pin-count circuit to track schematic port rendering performance.

### Before
- core had no RV1106G2 benchmark fixture or integration test for its render phase timings.

### After
- the supplied RV1106G2 Circuit JSON is registered in the benchmark website and records all 64 render phases.
- a focused test verifies the fixture produces `SchematicPortRender` timing; the baseline preview measures about 800 ms for that phase.