### PR TITLE
feat: propagate blind and buried via board option

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -532,6 +532,7 @@ export class Board
 
       thickness: this.boardThickness,
       num_layers: this.allLayers.length,
+      allow_blind_and_buried_vias: props.allowBlindAndBuriedVias ?? false,
 
       width: computedWidth!,
       height: computedHeight!,

--- a/lib/utils/autorouting/SimpleRouteJson.ts
+++ b/lib/utils/autorouting/SimpleRouteJson.ts
@@ -145,6 +145,8 @@ export type SimpleRouteJson = Omit<
   | "buses"
 > & {
   layerCount: number
+  /** Whether the autorouter may generate blind and buried vias. */
+  allowBlindAndBuriedVias?: boolean
   minTraceWidth: number
   nominalTraceWidth?: number
   /** @deprecated Use `min_via_pad_diameter` / `minViaPadDiameter` instead. */

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -863,6 +863,9 @@ export const getSimpleRouteJsonFromCircuitJson = ({
           ? preservedRoutedSubcircuitTraces
           : undefined,
       layerCount: board?.num_layers ?? 2,
+      allowBlindAndBuriedVias: board
+        ? (board.allow_blind_and_buried_vias ?? false)
+        : undefined,
       minTraceWidth: Math.min(
         defaultTraceWidth,
         ...allConns.map((c) => c.width!),

--- a/tests/features/autorouter-board-allow-blind-and-buried-vias.test.tsx
+++ b/tests/features/autorouter-board-allow-blind-and-buried-vias.test.tsx
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("board can allow blind and buried autorouter vias", async () => {
+  const { circuit } = getTestFixture()
+  let autorouterInput: SimpleRouteJson | undefined
+
+  circuit.on("autorouting:start", ({ simpleRouteJson }) => {
+    autorouterInput = simpleRouteJson
+  })
+
+  circuit.add(
+    <board width="12mm" height="8mm" layers={4} allowBlindAndBuriedVias>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-3} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={3} />
+      <trace from=".R1 > .pin2" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.pcb_board.list()[0]?.allow_blind_and_buried_vias).toBe(true)
+  expect(autorouterInput?.allowBlindAndBuriedVias).toBe(true)
+})

--- a/tests/features/autorouter-board-blind-and-buried-vias-disabled-by-default.test.tsx
+++ b/tests/features/autorouter-board-blind-and-buried-vias-disabled-by-default.test.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("board disables blind and buried autorouter vias by default", async () => {
+  const { circuit } = getTestFixture()
+  let autorouterInput: SimpleRouteJson | undefined
+
+  circuit.on("autorouting:start", ({ simpleRouteJson }) => {
+    autorouterInput = simpleRouteJson
+  })
+
+  circuit.add(
+    <board width="12mm" height="8mm" layers={4}>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-3} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={3} />
+      <trace from=".R1 > .pin2" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.pcb_board.list()[0]?.allow_blind_and_buried_vias).toBe(
+    false,
+  )
+  expect(autorouterInput?.allowBlindAndBuriedVias).toBe(false)
+})

--- a/tests/footprint/footprint-library-map3.test.tsx
+++ b/tests/footprint/footprint-library-map3.test.tsx
@@ -38,6 +38,7 @@ test("footprint library map 3", async () => {
   expect(pcb_board).toMatchInlineSnapshot(`
     [
       {
+        "allow_blind_and_buried_vias": false,
         "center": {
           "x": 0,
           "y": 0,

--- a/tests/repros/repro-simple-route-json-45-degree.test.tsx
+++ b/tests/repros/repro-simple-route-json-45-degree.test.tsx
@@ -36,6 +36,7 @@ test("45 degree rects bug", () => {
   expect(simpleRouteJson).not.toHaveProperty("buses")
   expect(simpleRouteJson).toMatchInlineSnapshot(`
     {
+      "allowBlindAndBuriedVias": false,
       "bounds": {
         "maxX": 3.6970562748477143,
         "maxY": 3.6970562748477143,

--- a/tests/repros/repro158-pcb-group-size.test.tsx
+++ b/tests/repros/repro158-pcb-group-size.test.tsx
@@ -47,6 +47,7 @@ test("repro158: PCB group size", async () => {
   expect(pcb_boards).toMatchInlineSnapshot(`
     [
       {
+        "allow_blind_and_buried_vias": false,
         "center": {
           "x": -0.23499999999999943,
           "y": -0.28999999999999915,

--- a/tests/utils/autorouting/simple-route-json-omits-blind-and-buried-via-policy-without-board.test.ts
+++ b/tests/utils/autorouting/simple-route-json-omits-blind-and-buried-via-policy-without-board.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+
+test("simple route json omits blind and buried via policy without a board", () => {
+  const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
+    circuitJson: [],
+  })
+
+  expect(simpleRouteJson.allowBlindAndBuriedVias).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

- serialize `<board allowBlindAndBuriedVias>` to Circuit JSON as `allow_blind_and_buried_vias`
- always materialize `false` for an actual board unless it explicitly opts in
- translate the Circuit JSON field to Simple Route JSON as `allowBlindAndBuriedVias`
- preserve legacy standalone/group behavior by omitting the Simple Route JSON field when no `pcb_board` exists

## Cross-repository stack

- public board prop: [tscircuit/props#808](https://github.com/tscircuit/props/pull/808)
- Circuit JSON transport: [tscircuit/circuit-json#719](https://github.com/tscircuit/circuit-json/pull/719)
- autorouter enforcement: [tscircuit/tscircuit-autorouter#2200](https://github.com/tscircuit/tscircuit-autorouter/pull/2200)

This PR remains a draft until the props and Circuit JSON packages above are published. It was built and tested locally against their exact clean feature commits (`4365a56` and `97189da`).

## Contract

For board-backed routing, `false` requests full-stack newly generated vias and `true` permits blind and buried generated vias. Existing authored partial-depth vias are not rewritten. A boardless conversion omits the field so standalone callers retain the autorouter's legacy compatibility behavior.

## Validation

- all autorouting utility tests, the two board propagation tests, and all three affected inline snapshots — 42 pass, 0 fail, 4 snapshots, 126 assertions
- one test per newly added Core test file
- `bunx tsc --noEmit` against the exact local props/Circuit JSON builds
- `bun run build` against the exact local props/Circuit JSON builds
- `bun run format`
- `git diff --check`
