### PR TITLE
Reproduce diagonal routed trace obstacle crash

### DIFF
--- a/tests/utils/autorouting/diagonal-routed-trace-obstacle.test.ts
+++ b/tests/utils/autorouting/diagonal-routed-trace-obstacle.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { getObstaclesFromRoute } from "lib/utils/obstacles/getObstaclesFromRoute"
+
+test("getObstaclesFromRoute rejects a diagonal routed trace segment", () => {
+  expect(() =>
+    getObstaclesFromRoute(
+      [
+        { x: -3.0127, y: -11.3044, layer: "top" },
+        { x: -2.5425446949529054, y: -11.1644, layer: "top" },
+      ],
+      "source_port_130_0",
+    ),
+  ).toThrow(
+    "getObstaclesFromTrace currently only supports horizontal and vertical traces (not diagonals)",
+  )
+})


### PR DESCRIPTION
## Summary

- add a focused regression for the diagonal routed segment that stops the AM62L phased autorouter
- use the observed `source_port_130_0` identity and segment coordinates
- make no production-code or dependency changes

## Reproduction

`getObstaclesFromRoute` currently throws when an already-routed wire segment is neither horizontal nor vertical. Fanout output routinely contains short 45-degree or chamfered segments, so a parent or later routing scope cannot convert that copper into an obstacle.

The test records the current exception:

```text
getObstaclesFromTrace currently only supports horizontal and vertical traces (not diagonals)
```

## Expected behavior

Diagonal routed copper should become connected obstacle geometry on its physical layer without crashing routing.

## Stack

This is the reproduction-only PR. The fix will be proposed as a second PR based on this branch.

## Verification

- `bun test tests/utils/autorouting/diagonal-routed-trace-obstacle.test.ts --timeout 30000`
- `bunx biome check tests/utils/autorouting/diagonal-routed-trace-obstacle.test.ts`
- `git diff --check`
