### PR TITLE
Support diagonal routed trace obstacles

### DIFF
--- a/lib/utils/obstacles/getObstaclesFromRoute.ts
+++ b/lib/utils/obstacles/getObstaclesFromRoute.ts
@@ -8,6 +8,9 @@ interface PointWithLayer {
 
 const isCloseTo = (a: number, b: number) => Math.abs(a - b) < 0.0001
 
+const TRACE_OBSTACLE_THICKNESS = 0.1
+const DIAGONAL_OBSTACLE_MAX_SEGMENT_LENGTH = 0.5
+
 export const getObstaclesFromRoute = (
   route: PointWithLayer[],
   source_trace_id: string,
@@ -22,24 +25,50 @@ export const getObstaclesFromRoute = (
     const isVert = isCloseTo(start.x, end.x)
 
     if (!isHorz && !isVert) {
-      throw new Error(
-        `getObstaclesFromTrace currently only supports horizontal and vertical traces (not diagonals) Conflicting trace: ${source_trace_id}, start: (${start.x}, ${start.y}), end: (${end.x}, ${end.y})`,
+      const deltaX = end.x - start.x
+      const deltaY = end.y - start.y
+      const segmentCount = Math.max(
+        1,
+        Math.ceil(
+          Math.hypot(deltaX, deltaY) / DIAGONAL_OBSTACLE_MAX_SEGMENT_LENGTH,
+        ),
       )
-    }
+      for (let segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++) {
+        const startRatio = segmentIndex / segmentCount
+        const endRatio = (segmentIndex + 1) / segmentCount
+        const segmentStartX = start.x + deltaX * startRatio
+        const segmentStartY = start.y + deltaY * startRatio
+        const segmentEndX = start.x + deltaX * endRatio
+        const segmentEndY = start.y + deltaY * endRatio
+        obstacles.push({
+          type: "rect",
+          layers: [start.layer],
+          center: {
+            x: (segmentStartX + segmentEndX) / 2,
+            y: (segmentStartY + segmentEndY) / 2,
+          },
+          width:
+            Math.abs(segmentEndX - segmentStartX) + TRACE_OBSTACLE_THICKNESS,
+          height:
+            Math.abs(segmentEndY - segmentStartY) + TRACE_OBSTACLE_THICKNESS,
+          connectedTo: [source_trace_id],
+        })
+      }
+    } else {
+      const obstacle: Obstacle = {
+        type: "rect",
+        layers: [start.layer],
+        center: {
+          x: (start.x + end.x) / 2,
+          y: (start.y + end.y) / 2,
+        },
+        width: isHorz ? Math.abs(start.x - end.x) : TRACE_OBSTACLE_THICKNESS, // TODO use route width
+        height: isVert ? Math.abs(start.y - end.y) : TRACE_OBSTACLE_THICKNESS, // TODO use route width
+        connectedTo: [source_trace_id],
+      }
 
-    const obstacle: Obstacle = {
-      type: "rect",
-      layers: [start.layer],
-      center: {
-        x: (start.x + end.x) / 2,
-        y: (start.y + end.y) / 2,
-      },
-      width: isHorz ? Math.abs(start.x - end.x) : 0.1, // TODO use route width
-      height: isVert ? Math.abs(start.y - end.y) : 0.1, // TODO use route width
-      connectedTo: [source_trace_id],
+      obstacles.push(obstacle)
     }
-
-    obstacles.push(obstacle)
 
     if (prev && prev.layer === start.layer && start.layer !== end.layer) {
       const via: Obstacle = {

--- a/tests/utils/autorouting/diagonal-routed-trace-obstacle.test.ts
+++ b/tests/utils/autorouting/diagonal-routed-trace-obstacle.test.ts
@@ -1,16 +1,39 @@
 import { expect, test } from "bun:test"
 import { getObstaclesFromRoute } from "lib/utils/obstacles/getObstaclesFromRoute"
 
-test("getObstaclesFromRoute rejects a diagonal routed trace segment", () => {
-  expect(() =>
-    getObstaclesFromRoute(
-      [
-        { x: -3.0127, y: -11.3044, layer: "top" },
-        { x: -2.5425446949529054, y: -11.1644, layer: "top" },
-      ],
-      "source_port_130_0",
-    ),
-  ).toThrow(
-    "getObstaclesFromTrace currently only supports horizontal and vertical traces (not diagonals)",
+test("getObstaclesFromRoute converts a diagonal routed trace segment into obstacles", () => {
+  const source_trace_id = "source_port_130_0"
+  const start = { x: -3.0127, y: -11.3044, layer: "top" }
+  const end = { x: -2.5425446949529054, y: -11.1644, layer: "top" }
+
+  const obstacles = getObstaclesFromRoute([start, end], source_trace_id)
+
+  expect(obstacles).toEqual([
+    {
+      type: "rect",
+      layers: ["top"],
+      center: {
+        x: (start.x + end.x) / 2,
+        y: (start.y + end.y) / 2,
+      },
+      width: Math.abs(end.x - start.x) + 0.1,
+      height: Math.abs(end.y - start.y) + 0.1,
+      connectedTo: [source_trace_id],
+    },
+  ])
+
+  const longSegmentObstacles = getObstaclesFromRoute(
+    [
+      { x: 0, y: 0, layer: "bottom" },
+      { x: 1.2, y: 0.6, layer: "bottom" },
+    ],
+    source_trace_id,
   )
+
+  expect(longSegmentObstacles).toHaveLength(3)
+  expect(
+    longSegmentObstacles.every(
+      (obstacle) => obstacle.width <= 0.500001 && obstacle.height <= 0.300001,
+    ),
+  ).toBe(true)
 })


### PR DESCRIPTION
## Stack

- Reproduction: #3390
- This PR: fix

## Summary

- replace the diagonal routed-trace exception with short, overlapping axis-aligned obstacles
- preserve the trace identity and layer on every generated obstacle
- keep long diagonal envelopes bounded by splitting them into segments no longer than 0.5 mm

The axis-aligned representation is intentionally conservative and remains compatible with the existing Simple Route JSON obstacle consumers.

## Before / after

Before, the AM62L route segment from `(-3.0127, -11.3044)` to `(-2.5425446949529054, -11.1644)` stopped Core with `getObstaclesFromTrace currently only supports horizontal and vertical traces`.

After, that segment becomes a connected obstacle and phased autorouting can continue.

## Verification

- `bun test tests/utils/autorouting --timeout 30000` (37 pass)
- `bunx biome check lib/utils/obstacles/getObstaclesFromRoute.ts tests/utils/autorouting/diagonal-routed-trace-obstacle.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`
