### PR TITLE
Fix phased copper pour scope at SRJ origin

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -34,6 +34,7 @@ import { FanoutAutorouter } from "lib/utils/autorouting/FanoutAutorouter"
 import type { GenericLocalAutorouter } from "lib/utils/autorouting/GenericLocalAutorouter"
 import type {
   CircuitJsonMetadata,
+  PcbGroupId,
   SimpleRouteBounds,
   SimpleRouteJson,
   SimplifiedPcbTrace,
@@ -1073,15 +1074,51 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     const fanoutPourNetMap = hasFanoutStage
       ? Group_getFanoutPourNetMap(this, routingPhasePlans)
       : undefined
-    let { simpleRouteJson: baseSimpleRouteJson } =
-      getSimpleRouteJsonFromCircuitJson({
-        db,
-        minTraceWidth,
-        nominalTraceWidth,
-        subcircuit_id: this.subcircuit_id,
-        subcircuitComponent: this,
-        fanoutPourNetMap,
-      })
+    let copperPourRoutingPcbGroupIds: PcbGroupId[] | undefined
+    if (hasPhasedAutorouting) {
+      const uniqueRoutingPcbGroupIds = new Set<PcbGroupId>()
+      for (const routingPhasePlan of routingPhasePlans) {
+        if (routingPhasePlan.routingPcbGroupId) {
+          uniqueRoutingPcbGroupIds.add(routingPhasePlan.routingPcbGroupId)
+        }
+      }
+      copperPourRoutingPcbGroupIds = Array.from(uniqueRoutingPcbGroupIds)
+    }
+    const baseSimpleRouteJsonResult = getSimpleRouteJsonFromCircuitJson({
+      db,
+      minTraceWidth,
+      nominalTraceWidth,
+      subcircuit_id: this.subcircuit_id,
+      subcircuitComponent: this,
+      copperPourRoutingPcbGroupIds,
+      fanoutPourNetMap,
+    })
+    let { simpleRouteJson: baseSimpleRouteJson } = baseSimpleRouteJsonResult
+    const { precomputedCopperPourObstacles } = baseSimpleRouteJsonResult
+    if (hasPhasedAutorouting && !precomputedCopperPourObstacles) {
+      throw new Error(
+        "Phased autorouting is missing precomputed copper-pour obstacles",
+      )
+    }
+    const getCopperPourObstaclesForPhase = (
+      routingPhasePlan: RoutingPhasePlan,
+    ): SimpleRouteJson["obstacles"] => {
+      if (!precomputedCopperPourObstacles) return []
+      const routingPcbGroupId = routingPhasePlan.routingPcbGroupId
+      if (!routingPcbGroupId) {
+        return precomputedCopperPourObstacles.defaultScope
+      }
+      const copperPourObstacles =
+        precomputedCopperPourObstacles.byRoutingPcbGroupId.get(
+          routingPcbGroupId,
+        )
+      if (!copperPourObstacles) {
+        throw new Error(
+          `Copper-pour obstacles were not precomputed for PCB group "${routingPcbGroupId}"`,
+        )
+      }
+      return copperPourObstacles
+    }
     const outputTraces: SimplifiedPcbTrace[] = []
     const outputJumpers: Array<{
       jumper_footprint: string
@@ -1130,6 +1167,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     }
 
     let previousStageOutputSimpleRouteJson: SimpleRouteJson | undefined
+    let currentPhaseBaseSimpleRouteJson = baseSimpleRouteJson
 
     for (const {
       routingPhasePlan,
@@ -1141,6 +1179,16 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     } of routingStages) {
       if (!usesPreviousStageOutput) {
         previousStageOutputSimpleRouteJson = undefined
+        currentPhaseBaseSimpleRouteJson = baseSimpleRouteJson
+        if (hasPhasedAutorouting) {
+          const copperPourObstacles =
+            getCopperPourObstaclesForPhase(routingPhasePlan)
+          currentPhaseBaseSimpleRouteJson = {
+            ...baseSimpleRouteJson,
+            obstacles:
+              baseSimpleRouteJson.obstacles.concat(copperPourObstacles),
+          }
+        }
       }
       if (
         usesPreviousStageOutput &&
@@ -1151,7 +1199,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         )
       }
       let simpleRouteJson =
-        previousStageOutputSimpleRouteJson ?? baseSimpleRouteJson
+        previousStageOutputSimpleRouteJson ?? currentPhaseBaseSimpleRouteJson
       const isRegionReroutePhase = Boolean(
         routingPhasePlan.reroute && routingPhasePlan.region,
       )
@@ -1163,7 +1211,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       const isReroutePhase = isRegionReroutePhase || isConnectionReroutePhase
       const rerouteOriginalSrj = isRegionReroutePhase
         ? {
-            ...baseSimpleRouteJson,
+            ...currentPhaseBaseSimpleRouteJson,
             traces: [...existingRerouteSeedTraces, ...outputTraces],
           }
         : null
@@ -1182,7 +1230,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         ) as SimpleRouteJson
       } else if (!usesPreviousStageOutput && isConnectionReroutePhase) {
         const phaseInput = Group_filterSimpleRouteJsonForPhase(
-          baseSimpleRouteJson,
+          currentPhaseBaseSimpleRouteJson,
           routingPhasePlan,
         )
         // Preserve routed geometry as SRJ traces. The autorouter owns
@@ -1198,7 +1246,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         }
       } else if (!usesPreviousStageOutput && hasPhasedAutorouting) {
         const phaseInput = Group_filterSimpleRouteJsonForPhase(
-          baseSimpleRouteJson,
+          currentPhaseBaseSimpleRouteJson,
           routingPhasePlan,
         )
         // Preserve routed geometry as SRJ traces. The autorouter owns

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -17,6 +17,7 @@ import { DifferentialPair } from "lib/components/primitive-components/Differenti
 import type { ISubcircuit } from "lib/components/primitive-components/Group/Subcircuit/ISubcircuit"
 import { getViaSpanLayers } from "lib/utils/getViaSpanLayers"
 import { getObstaclesFromCircuitJson } from "../obstacles/getObstaclesFromCircuitJson"
+import type { Obstacle } from "../obstacles/types"
 import type {
   PcbGroupId,
   SimpleRouteConnection,
@@ -34,6 +35,11 @@ import {
 import { getDifferentialPairsForSimpleRouteJson } from "./getDifferentialPairsForSimpleRouteJson"
 import { getPreservedRoutedSubcircuitTraces } from "./getPreservedRoutedSubcircuitTraces"
 import { getUnbrokenCopperPourObstacles } from "./getUnbrokenCopperPourObstacles"
+
+export interface PrecomputedCopperPourObstacles {
+  defaultScope: Obstacle[]
+  byRoutingPcbGroupId: Map<PcbGroupId, Obstacle[]>
+}
 
 /**
  * This function can only be called in the PcbTraceRender phase or later
@@ -53,6 +59,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   minViaPadDiameter,
   nominalTraceWidth,
   subcircuitComponent,
+  copperPourRoutingPcbGroupIds,
   fanoutPourNetMap,
   ignoreExistingTopLevelPcbRouteState = false,
 }: {
@@ -73,6 +80,12 @@ export const getSimpleRouteJsonFromCircuitJson = ({
     pcb_group_id?: PcbGroupId | null
   }
   /**
+   * Precomputes fully enriched unbroken copper-pour obstacles for phased
+   * routing. When provided, the returned SRJ contains only invariant
+   * non-copper-pour obstacles.
+   */
+  copperPourRoutingPcbGroupIds?: PcbGroupId[]
+  /**
    * Copper plane intent used by fanout routing. Source-only traces whose nets
    * are mapped here become internal plane-terminated buses in SRJ.
    */
@@ -82,7 +95,11 @@ export const getSimpleRouteJsonFromCircuitJson = ({
    * Routed child-subcircuit traces and vias remain fixed routing geometry.
    */
   ignoreExistingTopLevelPcbRouteState?: boolean
-}): { simpleRouteJson: SimpleRouteJson; connMap: ConnectivityMap } => {
+}): {
+  simpleRouteJson: SimpleRouteJson
+  connMap: ConnectivityMap
+  precomputedCopperPourObstacles?: PrecomputedCopperPourObstacles
+} => {
   if (!db && circuitJson) {
     db = su(circuitJson)
   }
@@ -239,21 +256,60 @@ export const getSimpleRouteJsonFromCircuitJson = ({
     ),
     sharedConnMap,
   )
-  obstacles.push(
-    ...getUnbrokenCopperPourObstacles({
-      connMap: sharedConnMap,
-      subcircuitComponent,
-      board,
-      group: pcbGroup,
-    }),
-  )
+
+  let defaultCopperPourGroup = pcbGroup
+  if (subcircuitIsBoard) {
+    defaultCopperPourGroup = undefined
+  }
+  const defaultCopperPourObstacles = getUnbrokenCopperPourObstacles({
+    connMap: sharedConnMap,
+    subcircuitComponent,
+    board,
+    group: defaultCopperPourGroup,
+  })
+  let precomputedCopperPourObstacles: PrecomputedCopperPourObstacles | undefined
+  if (copperPourRoutingPcbGroupIds) {
+    const byRoutingPcbGroupId = new Map<PcbGroupId, Obstacle[]>()
+    const uniqueRoutingPcbGroupIds = new Set(copperPourRoutingPcbGroupIds)
+    for (const routingPcbGroupId of uniqueRoutingPcbGroupIds) {
+      const routingPcbGroup = db.pcb_group.get(routingPcbGroupId)
+      if (!routingPcbGroup) {
+        throw new Error(
+          `Could not precompute copper pours for missing PCB group "${routingPcbGroupId}"`,
+        )
+      }
+      const copperPourObstacles = getUnbrokenCopperPourObstacles({
+        connMap: sharedConnMap,
+        subcircuitComponent,
+        board,
+        group: routingPcbGroup,
+      })
+      byRoutingPcbGroupId.set(routingPcbGroupId, copperPourObstacles)
+    }
+    precomputedCopperPourObstacles = {
+      defaultScope: defaultCopperPourObstacles,
+      byRoutingPcbGroupId,
+    }
+  } else {
+    obstacles.push(...defaultCopperPourObstacles)
+  }
+
+  const obstacleCollections = [obstacles]
+  if (precomputedCopperPourObstacles) {
+    obstacleCollections.push(precomputedCopperPourObstacles.defaultScope)
+    for (const copperPourObstacles of precomputedCopperPourObstacles.byRoutingPcbGroupId.values()) {
+      obstacleCollections.push(copperPourObstacles)
+    }
+  }
 
   // Add every equivalent ID from the shared connectivity map to each obstacle.
-  for (const obstacle of obstacles) {
-    const additionalIds = obstacle.connectedTo.flatMap((id) =>
-      sharedConnMap.getIdsConnectedToNet(id),
-    )
-    obstacle.connectedTo.push(...additionalIds)
+  for (const obstacleCollection of obstacleCollections) {
+    for (const obstacle of obstacleCollection) {
+      const additionalIds = obstacle.connectedTo.flatMap((id) =>
+        sharedConnMap.getIdsConnectedToNet(id),
+      )
+      obstacle.connectedTo.push(...additionalIds)
+    }
   }
 
   // Build mapping from source_port_id to internal connection ID for interconnects
@@ -295,23 +351,31 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   }
 
   // Set offBoardConnectsTo and netIsAssignable for obstacles that are part of internal connections
-  for (const obstacle of obstacles) {
-    for (const connectedId of obstacle.connectedTo) {
-      const sourcePortId = pcbElementIdToSourcePortId.get(connectedId)
-      if (sourcePortId) {
-        const internalConnectionId =
-          sourcePortIdToInternalConnectionId.get(sourcePortId)
-        if (internalConnectionId) {
-          obstacle.offBoardConnectsTo = [internalConnectionId]
-          obstacle.netIsAssignable = true
-          break
+  for (const obstacleCollection of obstacleCollections) {
+    for (const obstacle of obstacleCollection) {
+      for (const connectedId of obstacle.connectedTo) {
+        const sourcePortId = pcbElementIdToSourcePortId.get(connectedId)
+        if (sourcePortId) {
+          const internalConnectionId =
+            sourcePortIdToInternalConnectionId.get(sourcePortId)
+          if (internalConnectionId) {
+            obstacle.offBoardConnectsTo = [internalConnectionId]
+            obstacle.netIsAssignable = true
+            break
+          }
         }
       }
     }
   }
 
   // Calculate bounds
-  const allPoints = obstacles
+  let obstaclesForBounds = obstacles
+  if (precomputedCopperPourObstacles) {
+    obstaclesForBounds = obstacles.concat(
+      precomputedCopperPourObstacles.defaultScope,
+    )
+  }
+  const allPoints = obstaclesForBounds
     .flatMap((o) => [
       {
         x: o.center.x - o.width / 2,
@@ -884,5 +948,6 @@ export const getSimpleRouteJsonFromCircuitJson = ({
       outline: board?.outline?.map((point) => ({ ...point })),
     },
     connMap: sharedConnMap,
+    precomputedCopperPourObstacles,
   }
 }


### PR DESCRIPTION
## Summary

- build one invariant SimpleRouteJson base for phased autorouting
- precompute fully enriched copper-pour obstacles for the board scope and each active breakout PCB group at the SRJ producer boundary
- attach the matching precomputed pours only when constructing the first input for a phase; follow-up stages keep their preceding transformed SRJ
- preserve connection endpoint synchronization, accumulated output traces, and the existing pure phase filter

This is a new origin-level implementation that supersedes the replacement-based approach proposed in #3389. It does not modify or close #3389.

## AM62L validation

Validated against the latest merged `simplified-am62l-computer/index.circuit.tsx` with this Core commit linked locally. Captures were taken byte-for-byte at the custom `algorithmFn` boundary. The natural SoC solver still reaches its existing solver-stage failure; a zero-trace diagnostic continuation was used only to reach the independent RAM phase.

- SoC: 33 connections, 988 obstacles (986 invariant + 2 pours), 3 buses, 8 layers, 0 prior traces; SHA256 `4ea12abe2d3f55ddc62e3d54ef48a810aa38fefb2dad7d9bc889036111afda2e`
- RAM: 33 connections, 988 obstacles (986 invariant + 2 pours), 3 buses, 8 layers, 0 prior traces; SHA256 `824cc9d1f3189b4624631bc7f8d83988d425376447061e82f53a2d629c0fc3e4`

Both captures are byte-identical to the reviewed golden inputs. SoC pours are centered at `(2, 1)` over `21.3 mm × 21.3 mm`; RAM pours are centered at `(29.675, 0.949083)` over `24.05 mm × 19.2 mm`, on `inner1` and `inner6`.

## Checks

- `bun run format`
- `bunx tsc --noEmit`
- `bun run build`
- focused existing breakout/copper-pour tests: 4 passed
- broad existing breakout, autorouting utility, and subcircuit suite: 107 passed, 3 skipped, 0 failed

No test files were added or changed.