### PR TITLE
Reproduce reused copper-pour bounds between breakouts

### DIFF
--- a/tests/breakout/__snapshots__/active-breakout-copper-pour-bounds-autorouting-srj.snap.svg
+++ b/tests/breakout/__snapshots__/active-breakout-copper-pour-bounds-autorouting-srj.snap.svg
@@ -1,0 +1,505 @@
+<svg width="1616" height="2592" viewBox="0 0 1616 2592" xmlns="http://www.w3.org/2000/svg" data-testid="active-breakout-copper-pour-bounds-autorouting-srj-autorouting-srj-stack">
+  <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <rect x="0" y="0" width="800" height="36" fill="#121212" />
+  <text
+    x="400"
+    y="23"
+    fill="#f4f4f4"
+    font-family="Arial, sans-serif"
+    font-size="18"
+    font-weight="700"
+    text-anchor="middle"
+  >AUTOROUTING PHASE 1 START: 2 CONNECTIONS, 0 TRACES</text>
+  </g>
+  <g transform="translate(0, 36) scale(1, 1) translate(0, 0)">
+    <rect width="100%" height="100%" fill="#fff"/><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_1" data-x="-10.4" data-y="-0.4" x="39.99999999999994" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_0" data-x="-9.6" data-y="-0.4" x="67.2340425531915" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-10.4" data-y="0.4" x="39.99999999999994" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-9.6" data-y="0.4" x="67.2340425531915" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_1" data-x="9.6" data-y="-0.4" x="720.8510638297871" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_0" data-x="10.4" data-y="-0.4" x="748.0851063829787" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="9.6" data-y="0.4" x="720.8510638297871" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="10.4" data-y="0.4" x="748.0851063829787" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-0.51" data-y="7" x="373.44680851063833" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="0.51" data-y="7" x="408.17021276595744" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_0
+breakout:pcb_breakout_point_0
+top" data-x="-9.6" data-y="-0.4" cx="73.19148936170217" cy="428.4255319148936" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_0
+breakout:pcb_breakout_point_0
+bottom" data-x="-6.0001" data-y="-0.575" cx="195.7412765957447" cy="434.3829787234043" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_1
+breakout:pcb_breakout_point_1
+top" data-x="-10.4" data-y="-0.4" cx="45.95744680851061" cy="428.4255319148936" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_1
+breakout:pcb_breakout_point_1
+top" data-x="-6.0001" data-y="-0.22500000000000003" cx="195.7412765957447" cy="422.468085106383" r="3" fill="hsl(170, 100%, 50%)"/></g><g id="crosshair__stack1" style="display: none"><line id="crosshair-h__stack1" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '800');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '600');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":34.04255319148936,"c":0,"e":400,"b":0,"d":-34.04255319148936,"f":414.8085106382979};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script>
+  </g>
+  </g>
+  <g transform="translate(816, 0) scale(1, 1) translate(0, 0)">
+    <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <rect x="0" y="0" width="800" height="36" fill="#121212" />
+  <text
+    x="400"
+    y="23"
+    fill="#f4f4f4"
+    font-family="Arial, sans-serif"
+    font-size="18"
+    font-weight="700"
+    text-anchor="middle"
+  >AUTOROUTING PHASE 1 END: 2 CONNECTIONS, 2 TRACES</text>
+  </g>
+  <g transform="translate(0, 36) scale(1, 1) translate(0, 0)">
+    <rect width="100%" height="100%" fill="#fff"/><g><polyline data-points="-10.4,-0.4 -6.0001,-0.22500000000000003" data-type="line" data-label="" points="45.95744680851061,428.4255319148936 195.7412765957447,422.468085106383" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_1" data-x="-10.4" data-y="-0.4" x="39.99999999999994" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_0" data-x="-9.6" data-y="-0.4" x="67.2340425531915" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-10.4" data-y="0.4" x="39.99999999999994" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-9.6" data-y="0.4" x="67.2340425531915" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_1" data-x="9.6" data-y="-0.4" x="720.8510638297871" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_0" data-x="10.4" data-y="-0.4" x="748.0851063829787" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="9.6" data-y="0.4" x="720.8510638297871" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="10.4" data-y="0.4" x="748.0851063829787" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-0.51" data-y="7" x="373.44680851063833" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="0.51" data-y="7" x="408.17021276595744" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_0
+breakout:pcb_breakout_point_0
+top" data-x="-9.6" data-y="-0.4" cx="73.19148936170217" cy="428.4255319148936" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_0
+breakout:pcb_breakout_point_0
+bottom" data-x="-6.0001" data-y="-0.575" cx="195.7412765957447" cy="434.3829787234043" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_1
+breakout:pcb_breakout_point_1
+top" data-x="-10.4" data-y="-0.4" cx="45.95744680851061" cy="428.4255319148936" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_1
+breakout:pcb_breakout_point_1
+top" data-x="-6.0001" data-y="-0.22500000000000003" cx="195.7412765957447" cy="422.468085106383" r="3" fill="hsl(170, 100%, 50%)"/></g><g id="crosshair__stack1__stack1" style="display: none"><line id="crosshair-h__stack1__stack1" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack1" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack1" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '800');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '600');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":34.04255319148936,"c":0,"e":400,"b":0,"d":-34.04255319148936,"f":414.8085106382979};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script>
+  </g>
+  </g>
+  </g>
+  <g transform="translate(0, 652) scale(1, 1) translate(0, 0)">
+    <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <rect x="0" y="0" width="800" height="36" fill="#121212" />
+  <text
+    x="400"
+    y="23"
+    fill="#f4f4f4"
+    font-family="Arial, sans-serif"
+    font-size="18"
+    font-weight="700"
+    text-anchor="middle"
+  >AUTOROUTING PHASE 2 START: 2 CONNECTIONS, 2 TRACES</text>
+  </g>
+  <g transform="translate(0, 36) scale(1, 1) translate(0, 0)">
+    <rect width="100%" height="100%" fill="#fff"/><g><polyline data-points="-10.4,-0.4 -6.0001,-0.22500000000000003" data-type="line" data-label="" points="45.95744680851061,428.4255319148936 195.7412765957447,422.468085106383" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_3" data-x="-10.4" data-y="-0.4" x="39.99999999999994" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_2" data-x="-9.6" data-y="-0.4" x="67.2340425531915" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-10.4" data-y="0.4" x="39.99999999999994" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-9.6" data-y="0.4" x="67.2340425531915" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_3" data-x="9.6" data-y="-0.4" x="720.8510638297871" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_2" data-x="10.4" data-y="-0.4" x="748.0851063829787" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="9.6" data-y="0.4" x="720.8510638297871" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="10.4" data-y="0.4" x="748.0851063829787" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-0.51" data-y="7" x="373.44680851063833" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="0.51" data-y="7" x="408.17021276595744" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_2
+breakout:pcb_breakout_point_2
+top" data-x="10.4" data-y="-0.4" cx="754.0425531914893" cy="428.4255319148936" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_2
+breakout:pcb_breakout_point_2
+bottom" data-x="6.0001" data-y="-0.575" cx="604.2587234042553" cy="434.3829787234043" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_3
+breakout:pcb_breakout_point_3
+top" data-x="9.6" data-y="-0.4" cx="726.8085106382978" cy="428.4255319148936" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_3
+breakout:pcb_breakout_point_3
+top" data-x="6.0001" data-y="-0.22500000000000003" cx="604.2587234042553" cy="422.468085106383" r="3" fill="hsl(170, 100%, 50%)"/></g><g id="crosshair__stack1__stack1" style="display: none"><line id="crosshair-h__stack1__stack1" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack1" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack1" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '800');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '600');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":34.04255319148936,"c":0,"e":400,"b":0,"d":-34.04255319148936,"f":414.8085106382979};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script>
+  </g>
+  </g>
+  <g transform="translate(816, 0) scale(1, 1) translate(0, 0)">
+    <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <rect x="0" y="0" width="800" height="36" fill="#121212" />
+  <text
+    x="400"
+    y="23"
+    fill="#f4f4f4"
+    font-family="Arial, sans-serif"
+    font-size="18"
+    font-weight="700"
+    text-anchor="middle"
+  >AUTOROUTING PHASE 2 END: 2 CONNECTIONS, 4 TRACES</text>
+  </g>
+  <g transform="translate(0, 36) scale(1, 1) translate(0, 0)">
+    <rect width="100%" height="100%" fill="#fff"/><g><polyline data-points="-10.4,-0.4 -6.0001,-0.22500000000000003" data-type="line" data-label="" points="45.95744680851061,428.4255319148936 195.7412765957447,422.468085106383" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><polyline data-points="9.6,-0.4 6.0001,-0.22500000000000003" data-type="line" data-label="" points="726.8085106382978,428.4255319148936 604.2587234042553,422.468085106383" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_3" data-x="-10.4" data-y="-0.4" x="39.99999999999994" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_2" data-x="-9.6" data-y="-0.4" x="67.2340425531915" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-10.4" data-y="0.4" x="39.99999999999994" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-9.6" data-y="0.4" x="67.2340425531915" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_3" data-x="9.6" data-y="-0.4" x="720.8510638297871" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+breakout:pcb_breakout_point_2" data-x="10.4" data-y="-0.4" x="748.0851063829787" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="9.6" data-y="0.4" x="720.8510638297871" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="10.4" data-y="0.4" x="748.0851063829787" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-0.51" data-y="7" x="373.44680851063833" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="0.51" data-y="7" x="408.17021276595744" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_2
+breakout:pcb_breakout_point_2
+top" data-x="10.4" data-y="-0.4" cx="754.0425531914893" cy="428.4255319148936" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_2
+breakout:pcb_breakout_point_2
+bottom" data-x="6.0001" data-y="-0.575" cx="604.2587234042553" cy="434.3829787234043" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_3
+breakout:pcb_breakout_point_3
+top" data-x="9.6" data-y="-0.4" cx="726.8085106382978" cy="428.4255319148936" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="breakout:pcb_breakout_point_3
+breakout:pcb_breakout_point_3
+top" data-x="6.0001" data-y="-0.22500000000000003" cx="604.2587234042553" cy="422.468085106383" r="3" fill="hsl(170, 100%, 50%)"/></g><g id="crosshair__stack1__stack1__stack1" style="display: none"><line id="crosshair-h__stack1__stack1__stack1" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack1__stack1" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack1__stack1" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '800');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '600');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":34.04255319148936,"c":0,"e":400,"b":0,"d":-34.04255319148936,"f":414.8085106382979};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script>
+  </g>
+  </g>
+  </g>
+  <g transform="translate(0, 1304) scale(1, 1) translate(0, 0)">
+    <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <rect x="0" y="0" width="800" height="36" fill="#121212" />
+  <text
+    x="400"
+    y="23"
+    fill="#f4f4f4"
+    font-family="Arial, sans-serif"
+    font-size="18"
+    font-weight="700"
+    text-anchor="middle"
+  >AUTOROUTING PHASE 3 START: 2 CONNECTIONS, 4 TRACES</text>
+  </g>
+  <g transform="translate(0, 36) scale(1, 1) translate(0, 0)">
+    <rect width="100%" height="100%" fill="#fff"/><g><polyline data-points="-10.4,-0.4 -6.0001,-0.22500000000000003" data-type="line" data-label="" points="45.95744680851061,428.4255319148936 195.7412765957447,422.468085106383" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><polyline data-points="9.6,-0.4 6.0001,-0.22500000000000003" data-type="line" data-label="" points="726.8085106382978,428.4255319148936 604.2587234042553,422.468085106383" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><rect data-type="rect" data-label="top
+source_trace_0" data-x="-10.4" data-y="-0.4" x="39.99999999999994" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+source_trace_1" data-x="-9.6" data-y="-0.4" x="67.2340425531915" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-10.4" data-y="0.4" x="39.99999999999994" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-9.6" data-y="0.4" x="67.2340425531915" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+source_trace_0" data-x="9.6" data-y="-0.4" x="720.8510638297871" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+source_trace_1" data-x="10.4" data-y="-0.4" x="748.0851063829787" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="9.6" data-y="0.4" x="720.8510638297871" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="10.4" data-y="0.4" x="748.0851063829787" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-0.51" data-y="7" x="373.44680851063833" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="0.51" data-y="7" x="408.17021276595744" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><circle data-type="point" data-label="source_trace_0
+source_trace_0
+top" data-x="-6.0001" data-y="-0.22500000000000003" cx="195.7412765957447" cy="422.468085106383" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_0
+source_trace_0
+top" data-x="6.0001" data-y="-0.22500000000000003" cx="604.2587234042553" cy="422.468085106383" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_1
+source_trace_1
+bottom" data-x="-6.0001" data-y="-0.575" cx="195.7412765957447" cy="434.3829787234043" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_1
+source_trace_1
+bottom" data-x="6.0001" data-y="-0.575" cx="604.2587234042553" cy="434.3829787234043" r="3" fill="hsl(170, 100%, 50%)"/></g><g id="crosshair__stack1__stack2" style="display: none"><line id="crosshair-h__stack1__stack2" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack2" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack2" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '800');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '600');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":34.04255319148936,"c":0,"e":400,"b":0,"d":-34.04255319148936,"f":414.8085106382979};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script>
+  </g>
+  </g>
+  <g transform="translate(816, 0) scale(1, 1) translate(0, 0)">
+    <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <rect x="0" y="0" width="800" height="36" fill="#121212" />
+  <text
+    x="400"
+    y="23"
+    fill="#f4f4f4"
+    font-family="Arial, sans-serif"
+    font-size="18"
+    font-weight="700"
+    text-anchor="middle"
+  >AUTOROUTING PHASE 3 END: 2 CONNECTIONS, 6 TRACES</text>
+  </g>
+  <g transform="translate(0, 36) scale(1, 1) translate(0, 0)">
+    <rect width="100%" height="100%" fill="#fff"/><g><polyline data-points="-10.4,-0.4 -6.0001,-0.22500000000000003" data-type="line" data-label="" points="45.95744680851061,428.4255319148936 195.7412765957447,422.468085106383" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><polyline data-points="9.6,-0.4 6.0001,-0.22500000000000003" data-type="line" data-label="" points="726.8085106382978,428.4255319148936 604.2587234042553,422.468085106383" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><polyline data-points="-6.0001,-0.22500000000000003 6.0001,-0.22500000000000003" data-type="line" data-label="" points="195.7412765957447,422.468085106383 604.2587234042553,422.468085106383" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><polyline data-points="-6.0001,-0.575 6.0001,-0.575" data-type="line" data-label="" points="195.7412765957447,434.3829787234043 604.2587234042553,434.3829787234043" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="3.404255319148936" stroke-dasharray="0.2 0.2"/></g><g><rect data-type="rect" data-label="top
+source_trace_0" data-x="-10.4" data-y="-0.4" x="39.99999999999994" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+source_trace_1" data-x="-9.6" data-y="-0.4" x="67.2340425531915" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-10.4" data-y="0.4" x="39.99999999999994" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-9.6" data-y="0.4" x="67.2340425531915" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+source_trace_0" data-x="9.6" data-y="-0.4" x="720.8510638297871" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top
+source_trace_1" data-x="10.4" data-y="-0.4" x="748.0851063829787" y="422.468085106383" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="9.6" data-y="0.4" x="720.8510638297871" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="10.4" data-y="0.4" x="748.0851063829787" y="395.23404255319156" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-0.51" data-y="7" x="373.44680851063833" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="0.51" data-y="7" x="408.17021276595744" y="165.61702127659575" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><circle data-type="point" data-label="source_trace_0
+source_trace_0
+top" data-x="-6.0001" data-y="-0.22500000000000003" cx="195.7412765957447" cy="422.468085106383" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_0
+source_trace_0
+top" data-x="6.0001" data-y="-0.22500000000000003" cx="604.2587234042553" cy="422.468085106383" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_1
+source_trace_1
+bottom" data-x="-6.0001" data-y="-0.575" cx="195.7412765957447" cy="434.3829787234043" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_1
+source_trace_1
+bottom" data-x="6.0001" data-y="-0.575" cx="604.2587234042553" cy="434.3829787234043" r="3" fill="hsl(170, 100%, 50%)"/></g><g id="crosshair__stack1__stack1__stack2" style="display: none"><line id="crosshair-h__stack1__stack1__stack2" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack1__stack2" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack1__stack2" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '800');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '600');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":34.04255319148936,"c":0,"e":400,"b":0,"d":-34.04255319148936,"f":414.8085106382979};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script>
+  </g>
+  </g>
+  </g>
+  <g transform="translate(0, 1956) scale(1, 1) translate(0, 0)">
+    <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <rect x="0" y="0" width="800" height="36" fill="#121212" />
+  <text
+    x="400"
+    y="23"
+    fill="#f4f4f4"
+    font-family="Arial, sans-serif"
+    font-size="18"
+    font-weight="700"
+    text-anchor="middle"
+  >FULL ROUTED CIRCUIT: 0 CONNECTIONS, 6 TRACES</text>
+  </g>
+  <g transform="translate(0, 36) scale(1, 1) translate(0, 0)">
+    <rect width="100%" height="100%" fill="#fff"/><g><polyline data-points="-10.4,-0.4 -6.0001,-0.22500000000000003" data-type="line" data-label="" points="45.95744680851061,427.5744680851064 195.7412765957447,421.6170212765958" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><polyline data-points="6.0001,-0.22500000000000003 9.6,-0.4" data-type="line" data-label="" points="604.2587234042553,421.6170212765958 726.8085106382978,427.5744680851064" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><polyline data-points="-6.0001,-0.22500000000000003 6.0001,-0.22500000000000003" data-type="line" data-label="" points="195.7412765957447,421.6170212765958 604.2587234042553,421.6170212765958" fill="none" stroke="red" stroke-width="3.404255319148936"/></g><g><polyline data-points="-6.0001,-0.575 6.0001,-0.575" data-type="line" data-label="" points="195.7412765957447,433.53191489361706 604.2587234042553,433.53191489361706" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="3.404255319148936" stroke-dasharray="0.2 0.2"/></g><g><rect data-type="rect" data-label="top" data-x="-10.4" data-y="-0.4" x="39.99999999999994" y="421.6170212765958" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-9.6" data-y="-0.4" x="67.2340425531915" y="421.6170212765958" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-10.4" data-y="0.4" x="39.99999999999994" y="394.38297872340434" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-9.6" data-y="0.4" x="67.2340425531915" y="394.38297872340434" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="9.6" data-y="-0.4" x="720.8510638297871" y="421.6170212765958" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="10.4" data-y="-0.4" x="748.0851063829787" y="421.6170212765958" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="9.6" data-y="0.4" x="720.8510638297871" y="394.38297872340434" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="10.4" data-y="0.4" x="748.0851063829787" y="394.38297872340434" width="11.914893617021335" height="11.914893617021278" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="-0.51" data-y="7" x="373.44680851063833" y="164.76595744680853" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="top" data-x="0.51" data-y="7" x="408.17021276595744" y="164.76595744680853" width="18.38297872340428" height="21.787234042553223" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g><rect data-type="rect" data-label="bottom" data-x="0" data-y="-0.575" x="195.7412765957447" y="431.82978723404256" width="408.5174468085106" height="3.4042553191489446" fill="rgba(0,0,255,0.5)" stroke="black" stroke-width="0.029375000000000002"/></g><g id="crosshair__stack1__stack3" style="display: none"><line id="crosshair-h__stack1__stack3" y1="0" y2="600" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1__stack3" x1="0" x2="800" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1__stack3" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '800');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '600');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":34.04255319148936,"c":0,"e":400,"b":0,"d":-34.04255319148936,"f":413.95744680851067};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script>
+  </g>
+  </g>
+  <g transform="translate(816, 0) scale(1, 1) translate(0, 0)">
+    <rect width="800" height="636" fill="#fff" />
+  </g>
+  </g>
+</svg>

--- a/tests/breakout/active-breakout-copper-pour-bounds.test.tsx
+++ b/tests/breakout/active-breakout-copper-pour-bounds.test.tsx
@@ -1,0 +1,163 @@
+import { expect, test } from "bun:test"
+import type {
+  SimpleRouteJson,
+  SimplifiedPcbTrace,
+} from "lib/utils/autorouting/SimpleRouteJson"
+import { Fragment } from "react"
+import { createAutoroutingPhaseIoStack } from "tests/fixtures/create-autorouting-phase-io-stack"
+import { createBasicAutorouter } from "tests/fixtures/createBasicAutorouter"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const createBgaPads = () =>
+  Array.from({ length: 4 }, (_, padIndex) => {
+    const pinNumber = padIndex + 1
+    return (
+      <Fragment key={pinNumber}>
+        <smtpad
+          portHints={[`pin${pinNumber}`]}
+          pcbX={(padIndex % 2) * 0.8 - 0.4}
+          pcbY={Math.floor(padIndex / 2) * 0.8 - 0.4}
+          shape="circle"
+          radius="0.175mm"
+        />
+      </Fragment>
+    )
+  })
+
+const routeConnectionsDirectly = (
+  simpleRouteJson: SimpleRouteJson,
+  traceIdPrefix: string,
+): SimplifiedPcbTrace[] =>
+  simpleRouteJson.connections.map((connection, connectionIndex) => ({
+    type: "pcb_trace",
+    pcb_trace_id: `${traceIdPrefix}_${connectionIndex}`,
+    connection_name: connection.source_trace_id ?? connection.name,
+    route: connection.pointsToConnect.map((point) => ({
+      route_type: "wire",
+      x: point.x,
+      y: point.y,
+      width: connection.nominalTraceWidth ?? 0.1,
+      layer: point.layer,
+    })),
+  }))
+
+test("custom breakout phases use their active copper-pour bounds", async () => {
+  const { circuit } = getTestFixture({
+    platform: { placementDrcChecksDisabled: true },
+  })
+  const autoroutingPhaseIoStack = createAutoroutingPhaseIoStack(circuit)
+  const breakoutInputs = new Map<string, SimpleRouteJson>()
+  const createBreakoutAutorouter = (breakoutName: string) =>
+    createBasicAutorouter(async (simpleRouteJson) => {
+      breakoutInputs.set(breakoutName, structuredClone(simpleRouteJson))
+      return routeConnectionsDirectly(simpleRouteJson, breakoutName)
+    })
+  const globalAutorouter = createBasicAutorouter(async (simpleRouteJson) =>
+    routeConnectionsDirectly(simpleRouteJson, "global"),
+  )
+
+  circuit.add(
+    <board
+      width="50mm"
+      height="20mm"
+      layers={4}
+      minTraceWidth="0.1mm"
+      defaultTraceWidth="0.1mm"
+      autorouter={{ algorithmFn: globalAutorouter }}
+    >
+      <copperpour layer="inner1" connectsTo="net.GND" unbroken />
+      <copperpour layer="inner2" connectsTo="net.GND" unbroken />
+
+      <breakout
+        name="LEFT_BREAKOUT"
+        pcbX={-10}
+        width="8mm"
+        height="8mm"
+        autorouter={{ algorithmFn: createBreakoutAutorouter("left") }}
+      >
+        <chip name="U1" footprint={<footprint>{createBgaPads()}</footprint>} />
+      </breakout>
+
+      <breakout
+        name="RIGHT_BREAKOUT"
+        pcbX={10}
+        width="8mm"
+        height="8mm"
+        autorouter={{ algorithmFn: createBreakoutAutorouter("right") }}
+      >
+        <chip name="U2" footprint={<footprint>{createBgaPads()}</footprint>} />
+      </breakout>
+
+      <resistor
+        name="UNRELATED"
+        resistance="1k"
+        footprint="0402"
+        pcbX={0}
+        pcbY={7}
+      />
+      <trace name="DATA0" from="U1.pin1" to="U2.pin1" />
+      <trace name="DATA1" from="U1.pin2" to="U2.pin2" />
+      <bus name="DATA" connections={["DATA0", "DATA1"]} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.pcb_autorouting_error.list()).toEqual([])
+  const leftInput = breakoutInputs.get("left")
+  const rightInput = breakoutInputs.get("right")
+  expect(leftInput).toBeDefined()
+  expect(rightInput).toBeDefined()
+  const getCopperPourBounds = (simpleRouteJson: SimpleRouteJson | undefined) =>
+    simpleRouteJson?.obstacles
+      .filter((obstacle) => obstacle.isCopperPour)
+      .map((obstacle) => ({
+        center: obstacle.center,
+        width: obstacle.width,
+        height: obstacle.height,
+        layers: obstacle.layers,
+      }))
+  expect(getCopperPourBounds(leftInput)).toEqual([
+    {
+      center: { x: -10, y: 0 },
+      width: 8,
+      height: 8,
+      layers: ["inner1"],
+    },
+    {
+      center: { x: -10, y: 0 },
+      width: 8,
+      height: 8,
+      layers: ["inner2"],
+    },
+  ])
+  expect(getCopperPourBounds(rightInput)).toEqual([
+    {
+      center: { x: -10, y: 0 },
+      width: 8,
+      height: 8,
+      layers: ["inner1"],
+    },
+    {
+      center: { x: -10, y: 0 },
+      width: 8,
+      height: 8,
+      layers: ["inner2"],
+    },
+  ])
+  expect(
+    leftInput?.obstacles
+      .filter((obstacle) => !obstacle.isCopperPour)
+      .map((obstacle) => obstacle.obstacleId),
+  ).toEqual(
+    rightInput?.obstacles
+      .filter((obstacle) => !obstacle.isCopperPour)
+      .map((obstacle) => obstacle.obstacleId),
+  )
+  expect(rightInput?.traces).toHaveLength(2)
+  await expect(autoroutingPhaseIoStack).toMatchAutoroutingPhaseIoStackSnapshot(
+    import.meta.path,
+    "active-breakout-copper-pour-bounds-autorouting-srj",
+    circuit,
+  )
+})


### PR DESCRIPTION
## Summary

- add an exact two-breakout regression fixture for outline-less, unbroken copper pours
- record the Simple Route JSON received by each real custom breakout autorouter
- demonstrate that the second breakout incorrectly receives the first breakout's `8mm x 8mm` pour bounds
- assert that both phases otherwise retain the same non-pour obstacle scope and that the second phase retains the first phase's routed traces

## Why this repro is needed

A board subcircuit can contain several custom breakout routing groups. The board-level copper pours belong to every phase, but an outline-less pour must be represented using the bounds of the breakout that is currently routing. Core currently builds the board SRJ once, selecting the first matching PCB group, and both breakout phases reuse those pour obstacles. That gives the right-hand autorouter a false copper plane at the left-hand breakout and no copper plane where its real breakout sits.

The test uses the real phased-routing handoff rather than calling the SRJ utility in isolation, because the bug depends on how Core constructs and filters phase inputs. It intentionally leaves the failing coordinates in the repro commit. The stacked fix changes only the second breakout's expected center from `x = -10` to `x = 10`; the non-pour obstacle and prior-trace assertions stay unchanged.

This is a stacked, test-first alternative to #3389. #3389 currently performs its substitution only in the connection-reroute branch, which does not execute for this ordinary custom-breakout fixture.

## Test plan

- `bun test tests/breakout/active-breakout-copper-pour-bounds.test.tsx`

Stacked fix: base the follow-up PR on this branch.
