### PR TITLE
Use active breakout bounds for copper pours

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -1208,6 +1208,34 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
           traces: [...(phaseInput.traces ?? []), ...outputTraces],
         }
       }
+      const activeCustomBreakoutRoutingGroupId =
+        routingPhasePlan.routingPcbGroupId
+      if (!usesPreviousStageOutput && activeCustomBreakoutRoutingGroupId) {
+        const activeGroupSimpleRouteJson = getSimpleRouteJsonFromCircuitJson({
+          db,
+          minTraceWidth,
+          nominalTraceWidth,
+          subcircuit_id: this.subcircuit_id,
+          subcircuitComponent: this,
+          routingPcbGroupId: activeCustomBreakoutRoutingGroupId,
+          fanoutPourNetMap,
+        }).simpleRouteJson
+        const activeGroupCopperPourObstacles =
+          activeGroupSimpleRouteJson.obstacles.filter(
+            (obstacle) => obstacle.isCopperPour,
+          )
+        const nonCopperPourObstacles = simpleRouteJson.obstacles.filter(
+          (obstacle) => !obstacle.isCopperPour,
+        )
+        // Only outline-less pours vary by active breakout. Preserve every other
+        // obstacle and all phase-local connections/traces exactly as selected.
+        simpleRouteJson = {
+          ...simpleRouteJson,
+          obstacles: nonCopperPourObstacles.concat(
+            activeGroupCopperPourObstacles,
+          ),
+        }
+      }
       simpleRouteJson = Group_applyDrcTolerancesToSimpleRouteJson(
         simpleRouteJson,
         routingPhasePlan.drcTolerances,

--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -4,6 +4,7 @@ import type {
   AnyCircuitElement,
   LayerRef,
   PcbBoard,
+  PcbGroup,
   PcbPort,
   PcbVia,
   SourcePort,
@@ -53,6 +54,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   minViaPadDiameter,
   nominalTraceWidth,
   subcircuitComponent,
+  routingPcbGroupId,
   fanoutPourNetMap,
   ignoreExistingTopLevelPcbRouteState = false,
 }: {
@@ -72,6 +74,11 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   subcircuitComponent?: Pick<ISubcircuit, "selectAll"> & {
     pcb_group_id?: PcbGroupId | null
   }
+  /**
+   * Selects the routing group used to bound outline-less copper pours. Other
+   * SRJ content retains its normal subcircuit-wide semantics.
+   */
+  routingPcbGroupId?: PcbGroupId
   /**
    * Copper plane intent used by fanout routing. Source-only traces whose nets
    * are mapped here become internal plane-terminated buses in SRJ.
@@ -138,12 +145,17 @@ export const getSimpleRouteJsonFromCircuitJson = ({
     if (!sourceComponent?.name) return undefined
     return `${sourceComponent.name}.${sourcePort.name}`
   }
-  const pcbGroup = subcircuit_id
-    ? db.pcb_group.getWhere({ subcircuit_id })
-    : undefined
-  const activeRoutingPcbGroupId =
-    subcircuitComponent?.pcb_group_id ??
-    (!subcircuitIsBoard ? pcbGroup?.pcb_group_id : undefined)
+  let pcbGroup: PcbGroup | undefined | null
+  if (routingPcbGroupId) {
+    pcbGroup = db.pcb_group.get(routingPcbGroupId)
+  } else if (subcircuit_id) {
+    pcbGroup = db.pcb_group.getWhere({ subcircuit_id })
+  }
+  let activeRoutingPcbGroupId =
+    routingPcbGroupId ?? subcircuitComponent?.pcb_group_id
+  if (activeRoutingPcbGroupId == null && !subcircuitIsBoard) {
+    activeRoutingPcbGroupId = pcbGroup?.pcb_group_id
+  }
 
   const sharedConnMap =
     getFullConnectivityMapFromCircuitJson(subcircuitElements)

--- a/tests/breakout/active-breakout-copper-pour-bounds.test.tsx
+++ b/tests/breakout/active-breakout-copper-pour-bounds.test.tsx
@@ -133,13 +133,13 @@ test("custom breakout phases use their active copper-pour bounds", async () => {
   ])
   expect(getCopperPourBounds(rightInput)).toEqual([
     {
-      center: { x: -10, y: 0 },
+      center: { x: 10, y: 0 },
       width: 8,
       height: 8,
       layers: ["inner1"],
     },
     {
-      center: { x: -10, y: 0 },
+      center: { x: 10, y: 0 },
       width: 8,
       height: 8,
       layers: ["inner2"],


### PR DESCRIPTION
## Summary

- let SRJ construction select the active routing PCB group explicitly
- replace only copper-pour obstacles at the shared custom-breakout phase boundary
- preserve the phase's existing non-pour obstacles, connections, and already-routed traces
- make the regression fixture expect the right breakout's pours at `x = 10` instead of the left breakout's `x = -10`

## Why this fix is needed

Outline-less unbroken pours are converted into rectangular routing obstacles. On a board with multiple custom breakouts, those rectangles must use the group being routed now; otherwise an autorouter can treat a sibling breakout as occupied copper while treating its own actual plane area as empty. That can make a route avoid a nonexistent obstacle or enter copper belonging to another net.

The phase-local correction belongs at Core's phased-routing handoff because the base SRJ deliberately remains board-wide and the active `routingPcbGroupId` is known only while a phase is being prepared. The substitution runs for every initial custom-breakout phase, not only connection-reroute phases. It regenerates the active group's pours and replaces just obstacles marked `isCopperPour`; all fixed component obstacles, phase connections, and prior routed traces remain exactly as selected by the existing phase filter.

This is a stacked, tested alternative to #3389. The competing PR's current placement inside `isConnectionReroutePhase` leaves ordinary custom breakout phases unfixed; the exact repro in the base PR exercises that missing path.

## Test plan

- `bun test tests/breakout/active-breakout-copper-pour-bounds.test.tsx`
- `bun test tests/utils/autorouting/simple-route-json-unbroken-copper-pour-obstacles.test.tsx tests/repros/repro-offset-board-copper-pour-bounds.test.tsx tests/subcircuits/subcircuit-exposed-nets-copper-pour01.test.tsx tests/subcircuits/subcircuit-exposed-nets-copper-pour02.test.tsx tests/breakout/custom-implicit-breakout-point-solver.test.tsx tests/breakout/active-breakout-copper-pour-bounds.test.tsx`
- `bunx biome check lib/components/primitive-components/Group/Group.ts lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts tests/breakout/active-breakout-copper-pour-bounds.test.tsx`

- `bunx tsc --noEmit` (GitHub Actions)
