### PR TITLE
Test fanout-solver #85 in Core

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "^0.0.49",
     "@tscircuit/create-fdm-enclosure": "0.0.4",
-    "@tscircuit/fanout-solver": "0.0.35",
+    "@tscircuit/fanout-solver": "github:tscircuit/fanout-solver#599f24d0a9d7b9270fddbaf2b46899e6cdef7b6f",
     "@tscircuit/footprinter": "^0.0.426",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/infer-cable-insertion-point": "^0.0.4",


### PR DESCRIPTION
## Summary

- replace Core's published `@tscircuit/fanout-solver@0.0.35` dependency with the exact head commit of tscircuit/fanout-solver#85
- pin commit `599f24d0a9d7b9270fddbaf2b46899e6cdef7b6f`
- make no Core source or test changes, so Core CI and snapshot artifacts measure only the solver dependency change

## Why this is needed

fanout-solver#85 preserves persistent `source_trace_id` metadata on emitted fanout copper. Core relies on that identity across fanout and global routing phases, so the solver's own tests are not enough to establish integration safety. Pinning the exact PR head lets Core's full type-check, test shards, smoke test, and snapshots show whether the new output shape fixes the handoff without changing existing routes.

The current #85 head declares solver version `0.0.33`, while Core main normally pins published `0.0.35`. This PR intentionally tests the exact requested PR head, but failures or snapshot changes must therefore be checked for branch drift as well as the identity change. #85 should be rebased onto current fanout-solver main before being treated as release-ready.

This is a temporary integration-test pin. After #85 is rebased, merged, and released, Core should return to an exact published version.

## Core CI result

✅ The exact #85 head passes Core type-check, smoke test, formatting, and all ten test shards. No Core snapshot regression was reported despite the older branch base noted above.

## Local verification

- `bunx tsc --noEmit`
- 31 focused fanout/breakout tests passed, including `tests/repros/repro-am62l-lpddr4-two-bus-fanout.test.tsx`
- `tests/breakout/breakout-insufficient-fanout-space-error.test.tsx` passed when rerun alone after timing out only while both large dependency suites were competing for local CPU
- `git diff --check`

Upstream solver PR: tscircuit/fanout-solver#85
