### PR TITLE
Test fanout-solver #90 in Core

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "^0.0.49",
     "@tscircuit/create-fdm-enclosure": "0.0.4",
-    "@tscircuit/fanout-solver": "0.0.35",
+    "@tscircuit/fanout-solver": "github:tscircuit/fanout-solver#5011b76e9c724c747037e0b47a94fde64dd04860",
     "@tscircuit/footprinter": "^0.0.426",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/infer-cable-insertion-point": "^0.0.4",


### PR DESCRIPTION
## Summary

- replace Core's published `@tscircuit/fanout-solver@0.0.35` dependency with the exact head commit of tscircuit/fanout-solver#90
- pin commit `5011b76e9c724c747037e0b47a94fde64dd04860`
- make no Core source or test changes, so Core CI and snapshot artifacts measure only the solver dependency change

## Why this is needed

fanout-solver#90 stops preloaded fanout traces from being returned again as newly emitted copper. The solver-level regression passes, but Core is the phased host that accumulates `fanoutTraces`, converts them into Circuit JSON, and exercises the wider breakout/fanout matrix. Pinning the exact PR head lets Core's full type-check, test shards, smoke test, and snapshots reveal integration regressions before the solver PR is merged or published.

This is a temporary integration-test pin. After #90 is merged and released, Core should return to an exact published version.

## Core CI result

✅ The exact #90 head passes Core type-check, smoke test, formatting, and all ten test shards. No Core snapshot regression was reported.

## Local verification

- `bunx tsc --noEmit`
- 31 focused fanout/breakout tests passed, including `tests/repros/repro-am62l-lpddr4-two-bus-fanout.test.tsx`
- `tests/breakout/breakout-insufficient-fanout-space-error.test.tsx` passed when rerun alone after timing out only while both large dependency suites were competing for local CPU
- `git diff --check`

Upstream solver PR: tscircuit/fanout-solver#90
