### PR TITLE
chore: update capacity autorouter to 0.0.840

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@resvg/resvg-js": "^2.6.2",
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
-    "@tscircuit/capacity-autorouter": "^0.0.839",
+    "@tscircuit/capacity-autorouter": "^0.0.840",
     "@tscircuit/checks": "^0.0.169",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

- update `@tscircuit/capacity-autorouter` from `^0.0.839` to `^0.0.840`
- pick up the latest autorouter release and its length-matching solver update

## Validation

Run against commit `997ab6e5` in an isolated 0hmX box worktree:

- `bunx tsc --noEmit`
- `bun test tests/utils/autorouting tests/features/autorouter-cache-provider.test.ts tests/features/async-local-cache-engine-cache-provider.test.ts tests/features/autorouter-default.test.tsx tests/features/autorouter-min-via-dimensions.test.tsx tests/features/autorouter-version-beta-pipeline9.test.tsx` — 41 passed, 0 failed
- `bun run build`
- `bun run smoke-test:dist`
