### PR TITLE
fix: apply nominalTraceWidth from <net> and nested <group>

### DIFF
--- a/lib/components/primitive-components/Trace/Trace.ts
+++ b/lib/components/primitive-components/Trace/Trace.ts
@@ -91,6 +91,59 @@ export class Trace
     return this._parsedProps.thickness ?? this._parsedProps.width
   }
 
+  /**
+   * Get the widest nominalTraceWidth of the nets this trace connects to, e.g.
+   * <net name="VBUS" nominalTraceWidth="0.5mm" /> makes every trace on VBUS
+   * 0.5mm wide unless the trace sets its own thickness.
+   */
+  _getNominalTraceWidthFromConnectedNets(): number | undefined {
+    let nominalTraceWidth: number | undefined
+    for (const selector of this.getTracePathNetSelectors()) {
+      // _resolveNet is used instead of _findConnectedNets to avoid emitting a
+      // render error for unresolvable selectors during pcb rendering
+      const net = this._resolveNet(selector)
+      const netTraceWidth = net?._parsedProps.nominalTraceWidth
+      if (netTraceWidth === undefined) continue
+      nominalTraceWidth = Math.max(nominalTraceWidth ?? 0, netTraceWidth)
+    }
+    return nominalTraceWidth
+  }
+
+  /**
+   * Get the nominalTraceWidth/defaultTraceWidth of the closest ancestor group,
+   * e.g. <group nominalTraceWidth="0.4mm"> makes every trace inside the group
+   * 0.4mm wide. The enclosing subcircuit is not considered here because its
+   * value is applied to the whole SimpleRouteJson by Group._runLocalAutorouting.
+   */
+  _getNominalTraceWidthFromParentGroups(): number | undefined {
+    let ancestor = this.parent
+    while (ancestor && !ancestor.isSubcircuit) {
+      if (ancestor.isGroup) {
+        const groupProps = ancestor._parsedProps as {
+          defaultTraceWidth?: number
+          nominalTraceWidth?: number
+        }
+        const groupTraceWidth =
+          groupProps.defaultTraceWidth ?? groupProps.nominalTraceWidth
+        if (groupTraceWidth !== undefined) return groupTraceWidth
+      }
+      ancestor = ancestor.parent
+    }
+    return undefined
+  }
+
+  /**
+   * Get the width this trace should be routed at, falling back from the trace's
+   * own thickness to the nets it connects to, then to the groups it's inside of
+   */
+  _getEffectiveTraceThickness(): number | undefined {
+    return (
+      this._getExplicitTraceThickness() ??
+      this._getNominalTraceWidthFromConnectedNets() ??
+      this._getNominalTraceWidthFromParentGroups()
+    )
+  }
+
   _getSchematicNetLabelText(): string | undefined {
     return (
       this._parsedProps.schDisplayLabel ??
@@ -319,7 +372,7 @@ export class Trace
         ),
       max_via_count: props.maxViaCount,
       display_name: props.displayName ?? displayName,
-      min_trace_thickness: this._getExplicitTraceThickness(),
+      min_trace_thickness: this._getEffectiveTraceThickness(),
     })
 
     this.source_trace_id = trace.source_trace_id

--- a/lib/components/primitive-components/Trace/Trace_doInitialPcbManualTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialPcbManualTraceRender.ts
@@ -116,7 +116,7 @@ export function Trace_doInitialPcbManualTraceRender(trace: Trace) {
   }
 
   const width =
-    trace._getExplicitTraceThickness() ??
+    trace._getEffectiveTraceThickness() ??
     trace.getSubcircuit()._parsedProps.minTraceWidth ??
     jlcMinTolerances.min_trace_width!
 

--- a/lib/components/primitive-components/Trace/Trace_doInitialPcbTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialPcbTraceRender.ts
@@ -407,7 +407,7 @@ export function Trace_doInitialPcbTraceRender(trace: Trace) {
     const pcbPortB = "pcb_port_id" in b ? b.pcb_port_id : null
 
     const minTraceWidth =
-      trace._getExplicitTraceThickness() ??
+      trace._getEffectiveTraceThickness() ??
       trace.getSubcircuit()._parsedProps.minTraceWidth ??
       jlcMinTolerances.min_trace_width!
 

--- a/tests/features/net-and-group-nominal-trace-width-autorouting.test.tsx
+++ b/tests/features/net-and-group-nominal-trace-width-autorouting.test.tsx
@@ -1,0 +1,159 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const getWireWidths = (circuit: any): number[] =>
+  circuit.db.pcb_trace
+    .list()
+    .flatMap((t: any) =>
+      t.route
+        .filter((p: any) => p.route_type === "wire")
+        .map((p: any) => p.width),
+    )
+
+test("net nominalTraceWidth sets autorouted trace width", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <net name="VBUS" nominalTraceWidth="0.5mm" />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} pcbY={0} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={5} pcbY={0} />
+      <trace from=".R1 > .pin2" to="net.VBUS" />
+      <trace from=".R2 > .pin1" to="net.VBUS" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const widths = getWireWidths(circuit)
+  expect(widths.length).toBeGreaterThan(0)
+  for (const width of widths) {
+    expect(width).toBe(0.5)
+  }
+})
+
+test("explicit trace thickness takes precedence over net nominalTraceWidth", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <net name="VBUS" nominalTraceWidth="0.5mm" />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} pcbY={0} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={5} pcbY={0} />
+      <trace from=".R1 > .pin2" to="net.VBUS" thickness="0.2mm" />
+      <trace from=".R2 > .pin1" to="net.VBUS" thickness="0.2mm" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const widths = getWireWidths(circuit)
+  expect(widths.length).toBeGreaterThan(0)
+  for (const width of widths) {
+    expect(width).toBe(0.2)
+  }
+})
+
+test("group nominalTraceWidth sets autorouted trace width", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <group nominalTraceWidth="0.4mm">
+        <resistor
+          name="R1"
+          resistance="1k"
+          footprint="0402"
+          pcbX={-5}
+          pcbY={0}
+        />
+        <resistor
+          name="R2"
+          resistance="1k"
+          footprint="0402"
+          pcbX={5}
+          pcbY={0}
+        />
+        <trace from=".R1 > .pin2" to=".R2 > .pin1" />
+      </group>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const widths = getWireWidths(circuit)
+  expect(widths.length).toBeGreaterThan(0)
+  for (const width of widths) {
+    expect(width).toBe(0.4)
+  }
+})
+
+test("innermost group nominalTraceWidth wins over the board's", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" nominalTraceWidth="0.2mm">
+      <group nominalTraceWidth="0.4mm">
+        <resistor
+          name="R1"
+          resistance="1k"
+          footprint="0402"
+          pcbX={-5}
+          pcbY={0}
+        />
+        <resistor
+          name="R2"
+          resistance="1k"
+          footprint="0402"
+          pcbX={5}
+          pcbY={0}
+        />
+        <trace from=".R1 > .pin2" to=".R2 > .pin1" />
+      </group>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const widths = getWireWidths(circuit)
+  expect(widths.length).toBeGreaterThan(0)
+  for (const width of widths) {
+    expect(width).toBe(0.4)
+  }
+})
+
+test("net nominalTraceWidth wins over the enclosing group's", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <net name="VBUS" nominalTraceWidth="0.5mm" />
+      <group nominalTraceWidth="0.2mm">
+        <resistor
+          name="R1"
+          resistance="1k"
+          footprint="0402"
+          pcbX={-5}
+          pcbY={0}
+        />
+        <resistor
+          name="R2"
+          resistance="1k"
+          footprint="0402"
+          pcbX={5}
+          pcbY={0}
+        />
+        <trace from=".R1 > .pin2" to="net.VBUS" />
+        <trace from=".R2 > .pin1" to="net.VBUS" />
+      </group>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const widths = getWireWidths(circuit)
+  expect(widths.length).toBeGreaterThan(0)
+  for (const width of widths) {
+    expect(width).toBe(0.5)
+  }
+})


### PR DESCRIPTION
## Problem

`nominalTraceWidth` is declared in `@tscircuit/props` for both `netProps` and `baseGroupProps`, but core only read it off the subcircuit that runs autorouting (`Group._runLocalAutorouting`). Both of these are parsed and then silently dropped:

```tsx
<board width="20mm" height="20mm">
  {/* ignored — traces on VBUS still render at 0.15mm */}
  <net name="VBUS" nominalTraceWidth="0.5mm" />

  {/* ignored — group is not a subcircuit, so nothing reads its props */}
  <group nominalTraceWidth="0.4mm">
    <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
    <resistor name="R2" resistance="1k" footprint="0402" pcbX={5} />
    <trace from=".R1 > .pin2" to=".R2 > .pin1" />
  </group>
</board>
```

No error or warning is emitted. Setting `nominalTraceWidth` on `<board>`, or on a group that has the `subcircuit` prop set, already worked.

## Fix

A trace resolves its width by falling back through the things that can specify it:

1. the trace's own `thickness` / `width`
2. `nominalTraceWidth` of the nets it connects to (widest wins if it connects several)
3. `defaultTraceWidth` / `nominalTraceWidth` of the closest ancestor group
4. the subcircuit/board value — unchanged, still applied to the whole `SimpleRouteJson`

The resolved width is written to `source_trace.min_trace_thickness`, which `getSimpleRouteJsonFromCircuitJson` already reads for both direct-trace and net connections, so autorouted, manual, and per-trace-ijump routes all pick it up.

The ancestor walk stops before the enclosing subcircuit, since that value is already applied by `Group._runLocalAutorouting` — this keeps existing board-level behaviour identical.

## Tests

`tests/features/net-and-group-nominal-trace-width-autorouting.test.tsx` covers:

- `<net nominalTraceWidth>` sets the autorouted width
- explicit trace `thickness` beats net `nominalTraceWidth`
- non-subcircuit `<group nominalTraceWidth>` sets the autorouted width
- innermost group wins over the board's
- net wins over the enclosing group's

`bunx tsc --noEmit` is clean. `bun test tests/groups tests/subcircuits tests/drc tests/utils tests/breakout trace` passes apart from 4 tests that time out identically on unmodified `main` locally (`repro-bq25895-cross-net-trace-overlap`, `repro-rp2040-gamepad-trace-alignment`, `example35-minimize-trace-crossing`, `ground-net-label-preserves-solver-orientation`).
