### PR TITLE
fix: report source_component_misconfigured_error on empty connections target

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -2198,6 +2198,19 @@ export class NormalComponent<
       for (const [pinName, target] of Object.entries(props.connections)) {
         const targets = Array.isArray(target) ? target : [target]
         for (const targetPath of targets) {
+          const targetStr =
+            typeof targetPath === "string" ? targetPath.trim() : ""
+          if (!targetStr) {
+            this.root?.db.source_component_misconfigured_error.insert({
+              type: "source_component_misconfigured_error",
+              error_type: "source_component_misconfigured_error",
+              message: `<${this.componentName} name=".${this.name}" /> has an empty connections target for pin "${pinName}". Provide a selector such as ".R1 > .pin1" or "net.VCC", or remove the entry.`,
+              source_component_ids: this.source_component_id
+                ? [this.source_component_id]
+                : [],
+            })
+            continue
+          }
           this.add(
             new Trace({
               from: `.${this.name} > .${pinName}`,

--- a/tests/components/normal-components/connections-empty-string.test.tsx
+++ b/tests/components/normal-components/connections-empty-string.test.tsx
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("Empty string in connections records source_component_misconfigured_error and renders valid sibling connections", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <capacitor
+        name="C1"
+        capacitance="1uF"
+        footprint="0402"
+        connections={{ pin1: "", pin2: ".R1 > .pin1" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const misconfiguredErrors = circuitJson.filter(
+    (item: any) => item.type === "source_component_misconfigured_error",
+  )
+
+  expect(misconfiguredErrors).toHaveLength(1)
+  expect(misconfiguredErrors[0].message).toContain(
+    'has an empty connections target for pin "pin1"',
+  )
+
+  const traces = circuitJson.filter((item: any) => item.type === "source_trace")
+  expect(traces.length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
Fixes #2865

## Summary
- Safely check for empty or whitespace-only target strings in `_createTracesFromConnectionsProp()` (`NormalComponent.ts`).
- Inserts a clear `source_component_misconfigured_error` into `circuit.db` rather than letting empty selectors reach `css-what` and throw a raw parser error that crashes the entire render.
- Added unit test in `tests/components/normal-components/connections-empty-string.test.tsx` verifying the error is logged and valid sibling connections/traces still render.

## Verification
```bash
bun test tests/components/normal-components/connections-empty-string.test.tsx
# 1 pass, 0 fail
```

/claim #2865

### 💰 Payout Details
- **USDC (Solana)**: `6UvBhyhY6ayeoJEGZxK4bDoFAHd9yeRDTVusnoDGdgQ5`
- **USDT (TRON / TRC20)**: `TYcNrMSoY36q8WrsFSZyB26Rkj25EFgQsX`
