### PR TITLE
Forward schematic pin-label font size to Circuit JSON

### DIFF
--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -22,6 +22,8 @@ import { Port_isConnectedToPower } from "./Port_isConnectedToPower"
 import { Port_tryRenderGroupPcbPort } from "./Port_tryRenderGroupPcbPort"
 import { getSourcePortNetLabelText } from "lib/utils/schematic/getSourcePortNetLabelText"
 
+const SMALL_SCHEMATIC_PIN_LABEL_FONT_SIZE = 0.12
+
 export class Port extends PrimitiveComponent<typeof portProps> {
   source_port_id: string | null = null
   pcb_port_id: string | null = null
@@ -731,6 +733,12 @@ export class Port extends PrimitiveComponent<typeof portProps> {
         : undefined
     const sideOfComponent =
       explicitCustomSymbolSide ?? localPortInfo?.side ?? sideFromDirection
+    const displayPinLabelFontSize =
+      props.schPinLabelFontSize === "sm"
+        ? SMALL_SCHEMATIC_PIN_LABEL_FONT_SIZE
+        : props.schPinLabelFontSize === "default"
+          ? undefined
+          : props.schPinLabelFontSize
 
     const schematicPortInsertProps: Omit<SchematicPort, "schematic_port_id"> = {
       type: "schematic_port",
@@ -743,7 +751,7 @@ export class Port extends PrimitiveComponent<typeof portProps> {
       pin_number: props.pinNumber,
       true_ccw_index: localPortInfo?.trueIndex,
       display_pin_label: bestDisplayPinLabel,
-      display_pin_label_font_size: props.schPinLabelFontSize,
+      display_pin_label_font_size: displayPinLabelFontSize,
       is_connected: false,
       schematic_sheet_id: this._resolveSchematicSheetId(),
     }

--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -743,6 +743,7 @@ export class Port extends PrimitiveComponent<typeof portProps> {
       pin_number: props.pinNumber,
       true_ccw_index: localPortInfo?.trueIndex,
       display_pin_label: bestDisplayPinLabel,
+      display_pin_label_font_size: props.schPinLabelFontSize,
       is_connected: false,
       schematic_sheet_id: this._resolveSchematicSheetId(),
     }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "bun-match-svg": "0.0.12",
     "calculate-elbow": "^0.0.12",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.475",
+    "circuit-json": "^0.0.476",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.27",
     "circuit-json-to-gltf": "^0.0.118",
@@ -131,6 +131,6 @@
   "overrides": {
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/props": "^0.0.635",
-    "circuit-json": "^0.0.475"
+    "circuit-json": "^0.0.476"
   }
 }

--- a/tests/components/primitive-components/port-pin-label-font-size.test.tsx
+++ b/tests/components/primitive-components/port-pin-label-font-size.test.tsx
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("port forwards schematic pin-label font sizes to circuit json", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        symbol={
+          <symbol>
+            <port
+              name="SMALL"
+              schX={-1}
+              schY={0.5}
+              direction="left"
+              schPinLabelFontSize="sm"
+            />
+            <port
+              name="CUSTOM"
+              schX={-1}
+              schY={0}
+              direction="left"
+              schPinLabelFontSize="0.1mm"
+            />
+            <port name="UNCHANGED" schX={-1} schY={-0.5} direction="left" />
+          </symbol>
+        }
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const schematicPortsByLabel = new Map(
+    circuit.db.schematic_port
+      .list()
+      .map((port) => [port.display_pin_label, port]),
+  )
+
+  expect(schematicPortsByLabel.get("SMALL")?.display_pin_label_font_size).toBe(
+    "sm",
+  )
+  expect(schematicPortsByLabel.get("CUSTOM")?.display_pin_label_font_size).toBe(
+    0.1,
+  )
+  expect(
+    schematicPortsByLabel.get("UNCHANGED")?.display_pin_label_font_size,
+  ).toBeUndefined()
+})

--- a/tests/components/primitive-components/port-pin-label-font-size.test.tsx
+++ b/tests/components/primitive-components/port-pin-label-font-size.test.tsx
@@ -24,7 +24,14 @@ test("port forwards schematic pin-label font sizes to circuit json", () => {
               direction="left"
               schPinLabelFontSize="0.1mm"
             />
-            <port name="UNCHANGED" schX={-1} schY={-0.5} direction="left" />
+            <port
+              name="DEFAULT"
+              schX={-1}
+              schY={-0.5}
+              direction="left"
+              schPinLabelFontSize="default"
+            />
+            <port name="UNCHANGED" schX={-1} schY={-1} direction="left" />
           </symbol>
         }
       />
@@ -40,11 +47,14 @@ test("port forwards schematic pin-label font sizes to circuit json", () => {
   )
 
   expect(schematicPortsByLabel.get("SMALL")?.display_pin_label_font_size).toBe(
-    "sm",
+    0.12,
   )
   expect(schematicPortsByLabel.get("CUSTOM")?.display_pin_label_font_size).toBe(
     0.1,
   )
+  expect(
+    schematicPortsByLabel.get("DEFAULT")?.display_pin_label_font_size,
+  ).toBeUndefined()
   expect(
     schematicPortsByLabel.get("UNCHANGED")?.display_pin_label_font_size,
   ).toBeUndefined()


### PR DESCRIPTION
## Summary

Carries the optional per-port `schPinLabelFontSize` prop into `schematic_port.display_pin_label_font_size` as a precise numeric Circuit JSON value.

Core resolves:

- `"sm"` to `0.12`
- numeric distance inputs such as `"0.1mm"` (already normalized by props) to `0.1`
- `"default"` and omitted values to `undefined`, preserving the existing context-sensitive renderer default

## Dependencies

- Circuit JSON support: https://github.com/tscircuit/circuit-json/pull/723 (merged and released in `circuit-json@0.0.476`)
- Props contract: https://github.com/tscircuit/props/pull/810

## Scope

This PR only resolves the props-level input and writes the precise optional value into Circuit JSON. Renderer support belongs in a separate circuit-to-svg PR.

## Validation

- focused regression test passes
- full TypeScript check passes
- package build passes
- distribution smoke test passes
- changed files pass Biome formatting