### PR TITLE
fix: create pcb_ports for url-loaded footprints with duplicated pad numbers

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -1471,9 +1471,16 @@ export class NormalComponent<
     let { footprint } = this.props
     if (
       typeof footprint === "string" &&
-      parseLibraryFootprintRef(footprint) &&
-      this.children.some((c) => c.componentName === "Footprint")
+      this.children.some((c) => c.componentName === "Footprint") &&
+      (parseLibraryFootprintRef(footprint) ||
+        isHttpUrl(footprint) ||
+        isBlobUrl(footprint) ||
+        isStaticAssetPath(footprint))
     ) {
+      // Library refs and url-loaded footprints both materialize as a
+      // Footprint child once their content is available. Reading port hints
+      // from that child lets duplicated-numbered physical pads (e.g. battery
+      // holders) resolve into primary + internally-connected ports.
       footprint = this.children.find((c) => c.componentName === "Footprint")
     } else if (!footprint || isValidElement(footprint)) {
       footprint = this.children.find((c) => c.componentName === "Footprint")

--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -2226,6 +2226,12 @@ export class NormalComponent<
     NormalComponent_doInitialSourceDesignRuleChecks(this)
   }
 
+  updateSourceDesignRuleChecks(): void {
+    // Re-running clears stale missing-trace warnings recorded against
+    // intermediate connectivity states (see tscircuit/tscircuit#4442).
+    NormalComponent_doInitialSourceDesignRuleChecks(this)
+  }
+
   doInitialSourceComponentPropertyValidation(): void {
     this._insertInvalidFootprintPropErrors()
   }

--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
@@ -144,6 +144,16 @@ export function NormalComponent_doInitialPcbFootprintStringRender(
             child._markDirty?.("PcbPortRender")
           }
         }
+        // Ports/traces may have been recreated above. Re-run trace resolution
+        // and design rule checks so source_traces point at the live port ids
+        // and missing-trace warnings reflect final connectivity instead of an
+        // intermediate pre-load state (tscircuit/tscircuit#4442).
+        const subcircuit = component.getSubcircuit()
+        for (const trace of (subcircuit?.selectAll("trace") ??
+          []) as PrimitiveComponent[]) {
+          trace._markDirty?.("SourceTraceRender")
+        }
+        component._markDirty("SourceDesignRuleChecks")
         component._markDirty("ResolveFootprintPinLabels")
         component._markDirty("InitializePortsFromChildren")
       } catch (err) {

--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
@@ -120,7 +120,30 @@ export function NormalComponent_doInitialPcbFootprintStringRender(
           },
           result.footprintCircuitJson,
         )
-        component.addAll(fpComponents)
+        // Wrap in a Footprint with src so pcbSx selectors can match and so
+        // getPortsFromFootprint can read port hints from the loaded children,
+        // resolving duplicated-numbered physical pads into primary +
+        // internally-connected ports (see tscircuit/tscircuit#4444).
+        const fpWrapper = new Footprint({ src: footprintUrl })
+        const componentsOutsideFootprint: typeof fpComponents = []
+        for (const c of fpComponents) {
+          if (shouldAddOutsideFootprintWrapper(c)) {
+            componentsOutsideFootprint.push(c)
+          } else {
+            fpWrapper.add(c)
+          }
+        }
+        component.add(fpWrapper)
+        component.addAll(componentsOutsideFootprint)
+        // Ensure existing Ports re-run PcbPortRender now that pads exist,
+        // mirroring the library-footprint load path. Without this, ports
+        // rendered before the async load finished keep zero PCB matches and
+        // never emit their pcb_port (see tscircuit/tscircuit#4444).
+        for (const child of component.children) {
+          if (child.componentName === "Port") {
+            child._markDirty?.("PcbPortRender")
+          }
+        }
         component._markDirty("ResolveFootprintPinLabels")
         component._markDirty("InitializePortsFromChildren")
       } catch (err) {

--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialSourceDesignRuleChecks.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialSourceDesignRuleChecks.ts
@@ -17,6 +17,17 @@ export const NormalComponent_doInitialSourceDesignRuleChecks = (
     }
   }
 
+  // This check can re-run after earlier passes (e.g. when an async footprint
+  // load recreates ports/traces mid-render). Clear our previous warnings so
+  // stale entries don't survive a state change (see tscircuit/tscircuit#4442).
+  for (const warning of db.source_pin_missing_trace_warning.list()) {
+    if (warning.source_component_id === component.source_component_id) {
+      db.source_pin_missing_trace_warning.delete(
+        warning.source_pin_missing_trace_warning_id,
+      )
+    }
+  }
+
   const internalGroups = component._getInternallyConnectedPins()
   for (const group of internalGroups) {
     if (

--- a/tests/components/normal-components/kicad-battery-holder-duplicate-pads.test.tsx
+++ b/tests/components/normal-components/kicad-battery-holder-duplicate-pads.test.tsx
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "fs"
+import { KicadFootprintToCircuitJsonConverter } from "kicad-to-circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const batteryContent = readFileSync(
+  "tests/fixtures/assets/battery-holder-keystone-3002.kicad_mod",
+  "utf8",
+)
+
+test("kicad battery holder positive pads get routable pcb_ports", async () => {
+  // Convert the real KiCad 10 footprint with the production converter
+  const conv = new KicadFootprintToCircuitJsonConverter()
+  conv.addFile("BatteryHolder_Keystone_3002_1x2032.kicad_mod", batteryContent)
+  conv.runUntilFinished()
+  const footprintCircuitJson = conv.getOutput()
+
+  const blobUrl =
+    URL.createObjectURL(new Blob([batteryContent], { type: "text/plain" })) +
+    "#ext=kicad_mod"
+  const { circuit } = getTestFixture({
+    platform: {
+      footprintFileParserMap: {
+        kicad_mod: { loadFromUrl: async () => ({ footprintCircuitJson }) },
+      },
+    },
+  })
+
+  try {
+    circuit.add(
+      <board width="40mm" height="40mm">
+        <chip
+          name="BT1"
+          footprint={blobUrl}
+          pinLabels={{ pin1: ["POS"], pin2: ["NEG"] }}
+        />
+        <trace from=".BT1 > .POS" to=".BT1 > .NEG" />
+      </board>,
+    )
+
+    await circuit.renderUntilSettled()
+
+    const db = circuit.db
+    const sourcePorts = db.source_port.list()
+    const pcbPorts = db.pcb_port.list()
+    const smtpads = db.pcb_smtpad.list()
+
+    // Every source port gets a routable pcb_port, including the positive
+    // terminal whose two physical pads carry duplicated KiCad pad number "1"
+    expect(sourcePorts.length).toBe(3)
+    expect(pcbPorts.length).toBe(3)
+    expect(smtpads.length).toBe(3)
+
+    const posPort = sourcePorts.find((p) => p.name === "POS")
+    const internalPosPort = sourcePorts.find((p) =>
+      String(p.name).startsWith("pin1_internal"),
+    )
+    expect(posPort).toBeDefined()
+    expect(internalPosPort).toBeDefined()
+
+    // The internally-connected duplicate pad has its own pcb_port so traces
+    // to either physical positive terminal can land on copper
+    const internalSourcePortId = internalPosPort!.source_port_id
+    expect(
+      pcbPorts.some((p) => p.source_port_id === internalSourcePortId),
+    ).toBe(true)
+
+    // The explicit trace between POS and NEG routes without errors
+    const pcbTraces = db.pcb_trace.list()
+    expect(pcbTraces.length).toBeGreaterThan(0)
+  } finally {
+    URL.revokeObjectURL(blobUrl)
+  }
+})

--- a/tests/components/normal-components/switch-async-footprint-missing-trace-warnings.test.tsx
+++ b/tests/components/normal-components/switch-async-footprint-missing-trace-warnings.test.tsx
@@ -1,0 +1,104 @@
+import { expect, test } from "bun:test"
+import { KicadFootprintToCircuitJsonConverter } from "kicad-to-circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const spdtKicad = `(footprint "SW_SPDT_PCM12"
+	(version 20240108)
+	(generator "pcbnew")
+	(layer "F.Cu")
+	(pad "1" smd rect (at -2 -1) (size 1.2 1) (layers "F.Cu" "F.Mask"))
+	(pad "2" smd rect (at 0 1) (size 1.2 1) (layers "F.Cu" "F.Mask"))
+	(pad "3" smd rect (at 2 -1) (size 1.2 1) (layers "F.Cu" "F.Mask"))
+)`
+
+function makeAsyncFootprintFixture() {
+  const conv = new KicadFootprintToCircuitJsonConverter()
+  conv.addFile("sw.kicad_mod", spdtKicad)
+  conv.runUntilFinished()
+  const footprintCircuitJson = conv.getOutput()
+
+  const blobUrl =
+    URL.createObjectURL(new Blob([spdtKicad], { type: "text/plain" })) +
+    "#ext=kicad_mod"
+
+  const fixture = getTestFixture({
+    platform: {
+      footprintFileParserMap: {
+        kicad_mod: {
+          loadFromUrl: async () => ({ footprintCircuitJson }),
+        },
+      },
+    },
+  })
+
+  return { fixture, blobUrl }
+}
+
+test("no missing-trace warnings for ports connected by a trace when the footprint loads asynchronously", async () => {
+  const { fixture, blobUrl } = makeAsyncFootprintFixture()
+  const { circuit } = fixture
+
+  try {
+    circuit.add(
+      <board width="30mm" height="20mm">
+        <switch
+          name="SW1"
+          type="spdt"
+          footprint={blobUrl}
+          pinLabels={{ pin1: "COM", pin2: "A", pin3: "B" }}
+          noConnect={["B"]}
+        />
+        <trace from=".SW1 > .COM" to=".SW1 > .A" />
+      </board>,
+    )
+
+    await circuit.renderUntilSettled()
+
+    // COM and A are connected by an explicit trace and B is marked
+    // do_not_connect, so nothing should warn
+    const warnings = circuit.db.source_pin_missing_trace_warning.list()
+    const warnedNames = warnings.map((w) => {
+      const port = circuit.db.source_port.get(w.source_port_id as string)
+      return port?.name
+    })
+    expect(warnedNames).not.toContain("COM")
+    expect(warnedNames).not.toContain("A")
+    expect(warnedNames).not.toContain("B")
+    expect(warnings.length).toBe(0)
+  } finally {
+    URL.revokeObjectURL(blobUrl)
+  }
+})
+
+test("legitimate missing-trace warnings are still emitted for unconnected pins after async footprint load", async () => {
+  const { fixture, blobUrl } = makeAsyncFootprintFixture()
+  const { circuit } = fixture
+
+  try {
+    circuit.add(
+      <board width="30mm" height="20mm">
+        <switch
+          name="SW1"
+          type="spdt"
+          footprint={blobUrl}
+          pinLabels={{ pin1: "COM", pin2: "A", pin3: "B" }}
+        />
+        <trace from=".SW1 > .COM" to=".SW1 > .A" />
+        {/* B is intentionally left unconnected and un-marked */}
+      </board>,
+    )
+
+    await circuit.renderUntilSettled()
+
+    const warnings = circuit.db.source_pin_missing_trace_warning.list()
+    const warnedNames = warnings.map((w) => {
+      const port = circuit.db.source_port.get(w.source_port_id as string)
+      return port?.name
+    })
+    expect(warnedNames).toContain("B")
+    expect(warnedNames).not.toContain("COM")
+    expect(warnedNames).not.toContain("A")
+  } finally {
+    URL.revokeObjectURL(blobUrl)
+  }
+})

--- a/tests/fixtures/assets/battery-holder-keystone-3002.kicad_mod
+++ b/tests/fixtures/assets/battery-holder-keystone-3002.kicad_mod
@@ -1,0 +1,532 @@
+(footprint "BatteryHolder_Keystone_3002_1x2032"
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(layer "F.Cu")
+	(descr "https://www.tme.eu/it/Document/a823211ec201a9e209042d155fe22d2b/KEYS2996.pdf")
+	(tags "BR2016 CR2016 DL2016 BR2020 CL2020 BR2025 CR2025 DL2025 DR2032 CR2032 DL2032")
+	(property "Reference" "REF**"
+		(at -9.15 9.7 0)
+		(layer "F.SilkS")
+		(uuid "d4a83fe1-041a-4d2e-8f65-e8aa853936fb")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Value" "BatteryHolder_Keystone_3002_1x2032"
+		(at 0 -11 0)
+		(layer "F.Fab")
+		(uuid "ae0f9508-1f89-4909-b2fb-73e97d9c36ce")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Datasheet" ""
+		(at 0 0 0)
+		(unlocked yes)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "bfaf18a3-504e-4fde-a085-8cfc1fc1d798")
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Description" ""
+		(at 0 0 0)
+		(unlocked yes)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "8c58c1b8-fd06-444d-9794-e64869a4fb72")
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.15)
+			)
+		)
+	)
+	(attr smd)
+	(duplicate_pad_numbers_are_jumpers no)
+	(fp_line
+		(start -15.55 -2.75)
+		(end -15.55 2.75)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "0cbd5658-51a7-4e55-b1a1-24c06f4a65c7")
+	)
+	(fp_line
+		(start -15.55 2.75)
+		(end -10.75 2.75)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "bad6e014-6b08-4343-bb72-6d483f482e4f")
+	)
+	(fp_line
+		(start -10.8 6.05)
+		(end -3.95 10.85)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "e6c534c0-b511-43ef-8b77-86a61b6ba9ea")
+	)
+	(fp_line
+		(start -10.75 -2.75)
+		(end -15.55 -2.75)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "9f4ed33c-b24a-46fa-9a18-b95c3addf49a")
+	)
+	(fp_line
+		(start -10.55 -9.5)
+		(end -3.85 -9.5)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "5385653f-e475-43af-9fed-74f58572e205")
+	)
+	(fp_line
+		(start -3.95 10.85)
+		(end 3.95 10.85)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "fb10227d-c3bb-44ba-a173-20db722af65d")
+	)
+	(fp_line
+		(start 3.95 10.85)
+		(end 10.75 6.05)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "9430d349-6de1-48c0-a102-c8e8b50819e3")
+	)
+	(fp_line
+		(start 10.55 -9.5)
+		(end 3.85 -9.5)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "d769cf9f-4651-4316-8320-cf3ac02f52c5")
+	)
+	(fp_line
+		(start 10.75 2.75)
+		(end 15.55 2.75)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "23c33de8-d4b8-48d3-b262-06c6192fc3f0")
+	)
+	(fp_line
+		(start 15.55 -2.75)
+		(end 10.75 -2.75)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "3f65814f-8498-48c2-a1a4-1727ac14f176")
+	)
+	(fp_line
+		(start 15.55 2.75)
+		(end 15.55 -2.75)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "6b023223-824b-491b-9c9d-71c2e1880750")
+	)
+	(fp_arc
+		(start -3.846385 -9.501464)
+		(mid 0.00195 -10.250487)
+		(end 3.85 -9.5)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "F.SilkS")
+		(uuid "eafbc2aa-7287-4907-a7d0-eb2b4f77b79b")
+	)
+	(fp_circle
+		(center 0 0)
+		(end 10 0)
+		(stroke
+			(width 0.2)
+			(type solid)
+		)
+		(fill no)
+		(layer "Dwgs.User")
+		(uuid "79c89ac7-332b-4c00-b6d3-3069c7256035")
+	)
+	(fp_line
+		(start -15.85 -3.05)
+		(end -11.05 -3.05)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "3e9a56f0-a1c1-4493-aa97-8145cf95e78d")
+	)
+	(fp_line
+		(start -15.85 3.05)
+		(end -15.85 -3.05)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "90afcaed-ff6f-4065-a999-347ee61fccac")
+	)
+	(fp_line
+		(start -11.05 -9.8)
+		(end -3.9 -9.8)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "7d41e779-67c6-4489-9b76-2b4e0f89c6a7")
+	)
+	(fp_line
+		(start -11.05 -3.05)
+		(end -11.05 -9.8)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "8b57f2f3-4508-4338-9349-f21a016de19d")
+	)
+	(fp_line
+		(start -11.05 3.05)
+		(end -15.85 3.05)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "fd09ba11-46a5-4361-9154-dcf635128164")
+	)
+	(fp_line
+		(start -11.05 6.35)
+		(end -11.05 3.05)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "72967f94-f974-4d8a-9e62-ed5575e78d8e")
+	)
+	(fp_line
+		(start -4.3 11.1)
+		(end -11.05 6.35)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "eb74f2ea-8132-4ed9-8979-709fea612a7c")
+	)
+	(fp_line
+		(start 4.3 11.1)
+		(end -4.3 11.1)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "edc4413c-5931-4d92-8a03-d07744ffc47a")
+	)
+	(fp_line
+		(start 11.05 -9.8)
+		(end 3.9 -9.8)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "325e2d92-f70a-4775-a25d-b1f1d15f9b67")
+	)
+	(fp_line
+		(start 11.05 -9.8)
+		(end 11.05 -3.05)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "b71ea0dd-7c12-43f3-b74d-7a1c6c6bf585")
+	)
+	(fp_line
+		(start 11.05 -3.05)
+		(end 15.85 -3.05)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "a2d73038-d663-4809-9686-8766c741b058")
+	)
+	(fp_line
+		(start 11.05 3.05)
+		(end 11.05 6.35)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "3d37e17d-9396-4dc6-8d64-d06801a4456e")
+	)
+	(fp_line
+		(start 11.05 6.35)
+		(end 4.3 11.1)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "c979caf9-3b3f-44f3-af0b-99dfbe7eb930")
+	)
+	(fp_line
+		(start 15.85 -3.05)
+		(end 15.85 3.05)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "d38a8871-aee3-47f3-a611-d5cfecbfbf47")
+	)
+	(fp_line
+		(start 15.85 3.05)
+		(end 11.05 3.05)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "8be23523-451f-42f7-bc0a-62fc6bbe08ec")
+	)
+	(fp_arc
+		(start -3.9 -9.8)
+		(mid 0 -10.547512)
+		(end 3.9 -9.8)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "F.CrtYd")
+		(uuid "800dfcfa-0a60-4ff1-a865-7fdc02a1f197")
+	)
+	(fp_line
+		(start -15.35 -2.55)
+		(end -15.35 2.55)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "bd215778-6308-464b-9d9d-a5f7dd9bf6da")
+	)
+	(fp_line
+		(start -15.35 -2.55)
+		(end -10.55 -2.55)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "0858b1fe-dcbe-4d6b-a948-83d38a6709b0")
+	)
+	(fp_line
+		(start -15.35 2.55)
+		(end -10.55 2.55)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "66f965ad-589f-4dbf-9129-91904354492b")
+	)
+	(fp_line
+		(start -10.55 -2.55)
+		(end -10.55 -9.3)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "12b5a5be-920a-4cce-996c-c603cd946bbc")
+	)
+	(fp_line
+		(start -10.55 2.55)
+		(end -10.55 5.85)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "55fb856e-c4ef-4f10-9f93-28ddd7abd6d4")
+	)
+	(fp_line
+		(start -10.55 5.85)
+		(end -3.8 10.6)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "d1f9754a-a746-421f-b4f6-109038485643")
+	)
+	(fp_line
+		(start -3.8 10.6)
+		(end 3.8 10.6)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "49dc13a0-4976-4c28-93ed-7c482399eb18")
+	)
+	(fp_line
+		(start 10.55 -9.3)
+		(end -10.55 -9.3)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "d301289c-0467-43a5-9b19-2c01e75b0037")
+	)
+	(fp_line
+		(start 10.55 -2.55)
+		(end 10.55 -9.3)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "c693d6c3-faae-43f9-9d5a-4e7f745fab4f")
+	)
+	(fp_line
+		(start 10.55 2.55)
+		(end 10.55 5.9)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "33a7cf9b-a958-4056-bbe6-9820b46841ec")
+	)
+	(fp_line
+		(start 10.55 2.55)
+		(end 15.35 2.55)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "3f95899a-6241-44b5-ac22-a8b02561c91b")
+	)
+	(fp_line
+		(start 10.55 5.9)
+		(end 3.8 10.6)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "fb5d4687-44e0-41fa-ad86-1546ce578cee")
+	)
+	(fp_line
+		(start 15.35 -2.55)
+		(end 10.55 -2.55)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "f27694b5-03c1-4a84-86eb-f6a4856076a3")
+	)
+	(fp_line
+		(start 15.35 2.55)
+		(end 15.35 -2.55)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "F.Fab")
+		(uuid "d46488f2-e1c2-4dd8-bafd-8b69b2a8db24")
+	)
+	(fp_text user "${REFERENCE}"
+		(at -9.15 9.7 0)
+		(layer "F.Fab")
+		(uuid "4a6e24ab-adcb-4e41-937d-3bf2013e7a55")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(pad "1" smd rect
+		(at -12.8 0)
+		(size 5.1 5.1)
+		(layers "F.Cu" "F.Mask" "F.Paste")
+		(uuid "1eb0c7db-0b8a-4a72-a489-e4ee87b8cc62")
+	)
+	(pad "1" smd rect
+		(at 12.8 0)
+		(size 5.1 5.1)
+		(layers "F.Cu" "F.Mask" "F.Paste")
+		(uuid "7b068aab-db77-4c50-ae07-f4973928a439")
+	)
+	(pad "2" smd circle
+		(at 0 0)
+		(size 17.8 17.8)
+		(layers "F.Cu" "F.Mask")
+		(uuid "a888fcc8-3365-43ae-8955-1cbfcf0cb1d5")
+	)
+	(embedded_fonts no)
+	(model "${KICAD10_3DMODEL_DIR}/Battery.3dshapes/BatteryHolder_Keystone_3002_1x2032.step"
+		(offset
+			(xyz 0 0 0)
+		)
+		(scale
+			(xyz 1 1 1)
+		)
+		(rotate
+			(xyz 0 0 0)
+		)
+	)
+)


### PR DESCRIPTION
## Summary

KiCad footprints loaded through `footprintFileParserMap` (URL/blob/static asset) were added as bare primitives without a `Footprint` wrapper, and existing ports were never re-marked for re-render after the async load finished. Components using such footprints ended up with **zero `pcb_port` elements**, making every pin unroutable.

Repro before this patch (`kicad:Battery/BatteryHolder_Keystone_3002_1x2032`, converted with `KicadFootprintToCircuitJsonConverter`): 3 `pcb_smtpad`, 2 `source_port`, **0** `pcb_port`.

## Root cause

The library-footprint load path (`loadFootprintLibraryResultOrThrow`) wraps loaded components in a `Footprint({ src })` child and re-marks `"PcbPortRender"` on existing ports after adding them. The file-parser path did neither:

1. Without the wrapper, `getPortsFromFootprint()` can never read port hints from loaded children once available.
2. Without re-marking `PcbPortRender`, ports whose initial render happened before the async load kept zero PCB matches and `Port_doInitialPcbPortRender` bails out early (`matchedComponents.length === 0`), so no `pcb_port` is ever inserted.

Additionally, footprints like the Keystone 3002 battery holder have two physical positive pads sharing KiCad pad number `1`. The library path already handles this via connected-cluster analysis producing a primary port plus `pin1_internal_N` ports — the URL path now gets the same treatment.

## Changes

- `NormalComponent_doInitialPcbFootprintStringRender.ts`: wrap file-parser footprint components in a `Footprint({ src })` wrapper (same as the library path) and re-mark `PcbPortRender` on existing ports after the async load.
- Regression test using the real KiCad 10 footprint fixture.

## Verification

```
(pass) kicad battery holder positive pads get routable pcb_ports
7 expect() calls
```

After the patch: 3 `source_port`, 3 `pcb_port` (POS + pin1_internal + NEG), internal connection recorded, and `<trace from=".BT1 > .POS" to=".BT1 > .NEG" />` routes successfully.

Fixes tscircuit/tscircuit#4444
