### PR TITLE
Pin schematic-trace-solver PR #900 in core

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "url": "https://github.com/tscircuit/core"
   },
   "scripts": {
+    "postinstall": "bun run scripts/build-pinned-schematic-trace-solver.ts",
     "build": "tsup-node",
     "format": "biome format . --write",
     "measure-bundle": "howfat -r table .",
@@ -56,7 +57,8 @@
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
     "@tscircuit/props": "^0.0.637",
     "@tscircuit/schematic-match-adapt": "^0.0.18",
-    "@tscircuit/schematic-trace-solver": "^0.0.160",
+    "@tscircuit/schematic-trace-solver": "github:tscircuit/schematic-trace-solver#9da352208b6a7368f093cd6ed9532a7b66a85f38",
+    "@tscircuit/schematic-trace-solver-published": "npm:@tscircuit/schematic-trace-solver@0.0.162",
     "@tscircuit/solver-utils": "^0.0.16",
     "@tscircuit/soup-util": "^0.0.41",
     "@tscircuit/winding-breakout-point-solver": "github:tscircuit/winding-breakout-point-solver#202dbe9eb0088633b6fa094120dba6f2f41f8803",

--- a/scripts/build-pinned-schematic-trace-solver.ts
+++ b/scripts/build-pinned-schematic-trace-solver.ts
@@ -1,0 +1,60 @@
+import { cp, mkdtemp, rm, symlink } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const repositoryRoot = join(import.meta.dir, "..")
+const nodeModulesDirectory = join(repositoryRoot, "node_modules")
+const installedSolverDirectory = join(
+  nodeModulesDirectory,
+  "@tscircuit",
+  "schematic-trace-solver",
+)
+const publishedSolverDirectory = join(
+  nodeModulesDirectory,
+  "@tscircuit",
+  "schematic-trace-solver-published",
+)
+const buildDirectory = await mkdtemp(
+  join(tmpdir(), "core-pinned-schematic-trace-solver-"),
+)
+
+try {
+  await cp(installedSolverDirectory, buildDirectory, { recursive: true })
+  await symlink(
+    nodeModulesDirectory,
+    join(buildDirectory, "node_modules"),
+    "dir",
+  )
+
+  const buildProcess = Bun.spawn(
+    [
+      join(nodeModulesDirectory, ".bin", "tsup-node"),
+      "lib/index.ts",
+      "--format",
+      "esm",
+    ],
+    {
+      cwd: buildDirectory,
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  )
+  const exitCode = await buildProcess.exited
+
+  if (exitCode !== 0) {
+    throw new Error(`Pinned schematic trace solver build exited ${exitCode}`)
+  }
+
+  await cp(
+    join(buildDirectory, "dist"),
+    join(installedSolverDirectory, "dist"),
+    { recursive: true, force: true },
+  )
+  await cp(
+    join(publishedSolverDirectory, "dist", "index.d.ts"),
+    join(installedSolverDirectory, "dist", "index.d.ts"),
+    { force: true },
+  )
+} finally {
+  await rm(buildDirectory, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

- Pin schematic-trace-solver to the exact rebased head SHA from tscircuit/schematic-trace-solver#900.
- Build the source-only Git dependency during install so core exercises the PR code rather than a published package.
- Reuse the matching published 0.0.162 declarations for typechecking; PR #900 does not change the public API.

## Context

Core main currently uses schematic-trace-solver 0.0.160, while rebased PR #900 includes current solver main at 0.0.162 plus its focused fix. This PR intentionally pins the exact PR head so CI and snapshots expose its behavior in core.

## Validation

- bun install
- bunx tsc --noEmit
- 39 focused schematic trace, inline-net-label, component-text-bounds, and solver-input tests: 39 pass, 0 fail
- schematic-trace-solver: 270 pass, 4 skip, 0 fail