### PR TITLE
fix: scope local autorouting cache by solver

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -29,7 +29,10 @@ import type { GraphicsObject } from "graphics-debug"
 import type { PrimitiveComponent } from "lib/components/base-components/PrimitiveComponent"
 import { isAssemblyDeviceContainer } from "lib/components/base-components/is-assembly-device-container"
 import { AutorouterError } from "lib/errors/AutorouterError"
-import type { AutorouterOptions } from "lib/utils/autorouting/CapacityMeshAutorouter"
+import {
+  type AutorouterOptions,
+  getCapacityAutorouterSolverName,
+} from "lib/utils/autorouting/CapacityMeshAutorouter"
 import { FanoutAutorouter } from "lib/utils/autorouting/FanoutAutorouter"
 import type { GenericLocalAutorouter } from "lib/utils/autorouting/GenericLocalAutorouter"
 import type {
@@ -1472,12 +1475,36 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         simpleRouteJson,
       })
 
+      const autorouterVersion =
+        phaseAutorouterConfig.autorouterVersion ?? this.props.autorouterVersion
+      const effortLevel = this.props.autorouterEffortLevel
+      const effort = effortLevel
+        ? Number.parseInt(effortLevel.replace("x", ""), 10)
+        : undefined
+      const commonAutorouterOptions: AutorouterOptions = {
+        capacityDepth: phaseAutorouterConfig.capacityDepth,
+        targetMinCapacity: phaseAutorouterConfig.targetMinCapacity,
+        platformConfig: this.root?.platform,
+        useAssignableSolver: phaseIsLaserPrefabPreset || isSingleLayerBoard,
+        useAutoJumperSolver: phaseIsAutoJumperPreset,
+        useLaserPrefabSolver: phaseIsLaserPrefabPreset,
+        autorouterVersion,
+        effort,
+      }
+
       const cacheEngine =
         phaseAutorouterConfig.algorithmFn || !localAutorouterStrategy.cacheable
           ? undefined
           : this.root?.platform?.localCacheEngine
       const cacheKey = cacheEngine
-        ? getLocalAutoroutingCacheKey(simpleRouteJson)
+        ? getLocalAutoroutingCacheKey(simpleRouteJson, {
+            solverName: getCapacityAutorouterSolverName(
+              commonAutorouterOptions,
+            ),
+            capacityDepth: commonAutorouterOptions.capacityDepth,
+            targetMinCapacity: commonAutorouterOptions.targetMinCapacity,
+            effort: commonAutorouterOptions.effort,
+          })
         : undefined
       const cachedResult = cacheKey
         ? await getCachedLocalAutoroutingPhaseResult({ cacheEngine, cacheKey })
@@ -1494,24 +1521,6 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             autorouter =
               await phaseAutorouterConfig.algorithmFn(simpleRouteJson)
           } else {
-            const autorouterVersion =
-              phaseAutorouterConfig.autorouterVersion ??
-              this.props.autorouterVersion
-            const effortLevel = this.props.autorouterEffortLevel
-            const effort = effortLevel
-              ? Number.parseInt(effortLevel.replace("x", ""), 10)
-              : undefined
-            const commonAutorouterOptions: AutorouterOptions = {
-              capacityDepth: phaseAutorouterConfig.capacityDepth,
-              targetMinCapacity: phaseAutorouterConfig.targetMinCapacity,
-              platformConfig: this.root?.platform,
-              useAssignableSolver:
-                phaseIsLaserPrefabPreset || isSingleLayerBoard,
-              useAutoJumperSolver: phaseIsAutoJumperPreset,
-              useLaserPrefabSolver: phaseIsLaserPrefabPreset,
-              autorouterVersion,
-              effort,
-            }
             autorouter = localAutorouterStrategy.create({
               simpleRouteJson,
               commonAutorouterOptions,

--- a/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
+++ b/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
@@ -1,4 +1,5 @@
 import type { LocalCacheEngine } from "lib/local-cache-engine"
+import type { CapacityAutorouterSolverName } from "lib/utils/autorouting/CapacityMeshAutorouter"
 import type {
   SimpleRouteJson,
   SimplifiedPcbTrace,
@@ -14,14 +15,34 @@ const getFnv1aHash = (value: string): number => {
   return hash >>> 0
 }
 
-const getSrjHash = (simpleRouteJson: SimpleRouteJson): string => {
-  const serializedSrj = JSON.stringify(simpleRouteJson)
-  const hash1 = getFnv1aHash(serializedSrj)
-  const hash2 = getFnv1aHash(`${serializedSrj}${hash1}`)
+const getStringHash = (value: string): string => {
+  const hash1 = getFnv1aHash(value)
+  const hash2 = getFnv1aHash(`${value}${hash1}`)
   return `${hash1.toString(16).padStart(8, "0")}${hash2
     .toString(16)
     .padStart(8, "0")}`
 }
+
+const getSrjHash = (simpleRouteJson: SimpleRouteJson): string =>
+  getStringHash(JSON.stringify(simpleRouteJson))
+
+export interface LocalAutoroutingCacheConfig {
+  solverName: CapacityAutorouterSolverName
+  capacityDepth?: number
+  targetMinCapacity?: number
+  effort?: number
+}
+
+const getAutorouterOptionsHash = (
+  config: LocalAutoroutingCacheConfig,
+): string =>
+  getStringHash(
+    JSON.stringify({
+      capacityDepth: config.capacityDepth ?? null,
+      targetMinCapacity: config.targetMinCapacity ?? null,
+      effort: config.effort ?? null,
+    }),
+  )
 
 type CachedAutoroutingPhaseResult = SimpleRouteJson & {
   traces: SimplifiedPcbTrace[]
@@ -29,7 +50,15 @@ type CachedAutoroutingPhaseResult = SimpleRouteJson & {
 
 export const getLocalAutoroutingCacheKey = (
   simpleRouteJson: SimpleRouteJson,
-): string => `routes:core@${pkgJson.version}:srj:${getSrjHash(simpleRouteJson)}`
+  config: LocalAutoroutingCacheConfig,
+): string =>
+  [
+    `routes:core@${pkgJson.version}`,
+    "local:v1",
+    `solver:${config.solverName}`,
+    `options:${getAutorouterOptionsHash(config)}`,
+    `srj:${getSrjHash(simpleRouteJson)}`,
+  ].join(":")
 
 export const getCachedLocalAutoroutingPhaseResult = async ({
   cacheEngine,

--- a/lib/utils/autorouting/CapacityMeshAutorouter.ts
+++ b/lib/utils/autorouting/CapacityMeshAutorouter.ts
@@ -51,6 +51,56 @@ export interface AutorouterOptions {
   onSolverStarted?: (details: SolverStartedDetails) => void
 }
 
+export type CapacityAutorouterSolverName =
+  | "AutoroutingPipeline1_OriginalUnravel"
+  | "AutoroutingPipelineSolver3_HgPortPointPathing"
+  | "AutoroutingPipelineSolver4"
+  | "AutoroutingPipelineSolver5"
+  | "AutoroutingPipelineSolver7_MultiGraph"
+  | "AutoroutingPipelineSolver8"
+  | "AutoroutingPipelineSolver9_PreloadedTraceGraph"
+  | "AssignableAutoroutingPipeline2"
+  | "AssignableAutoroutingPipeline3"
+
+export const getCapacityAutorouterSolverName = ({
+  autorouterVersion,
+  useAssignableSolver = false,
+  useAutoJumperSolver = false,
+  useLaserPrefabSolver = false,
+}: Pick<
+  AutorouterOptions,
+  | "autorouterVersion"
+  | "useAssignableSolver"
+  | "useAutoJumperSolver"
+  | "useLaserPrefabSolver"
+>): CapacityAutorouterSolverName => {
+  if (autorouterVersion === "beta_pipeline1") {
+    return "AutoroutingPipeline1_OriginalUnravel"
+  }
+  if (autorouterVersion === "beta_pipeline3") {
+    return "AutoroutingPipelineSolver3_HgPortPointPathing"
+  }
+  if (autorouterVersion === "beta_pipeline4") {
+    return "AutoroutingPipelineSolver4"
+  }
+  if (autorouterVersion === "beta_pipeline5") {
+    return "AutoroutingPipelineSolver5"
+  }
+  if (
+    autorouterVersion === "beta_pipeline7" ||
+    autorouterVersion === "latest"
+  ) {
+    return "AutoroutingPipelineSolver7_MultiGraph"
+  }
+  if (autorouterVersion === "beta_pipeline9") {
+    return "AutoroutingPipelineSolver9_PreloadedTraceGraph"
+  }
+  if (useLaserPrefabSolver) return "AutoroutingPipelineSolver8"
+  if (useAutoJumperSolver) return "AssignableAutoroutingPipeline3"
+  if (useAssignableSolver) return "AssignableAutoroutingPipeline2"
+  return "AutoroutingPipelineSolver7_MultiGraph"
+}
+
 function getCapacityAutorouterCacheProvider(
   platformConfig?: Pick<PlatformConfig, "localCacheEngine">,
 ): CacheProvider | null {
@@ -100,32 +150,12 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
       onSolverStarted,
     } = options
 
-    // Initialize the solver with input and optional configuration
-    let solverName: keyof typeof SOLVERS
-    if (autorouterVersion === "beta_pipeline1") {
-      solverName = "AutoroutingPipeline1_OriginalUnravel"
-    } else if (autorouterVersion === "beta_pipeline3") {
-      solverName = "AutoroutingPipelineSolver3_HgPortPointPathing"
-    } else if (autorouterVersion === "beta_pipeline4") {
-      solverName = "AutoroutingPipelineSolver4"
-    } else if (autorouterVersion === "beta_pipeline5") {
-      solverName = "AutoroutingPipelineSolver5"
-    } else if (
-      autorouterVersion === "beta_pipeline7" ||
-      autorouterVersion === "latest"
-    ) {
-      solverName = "AutoroutingPipelineSolver7_MultiGraph"
-    } else if (autorouterVersion === "beta_pipeline9") {
-      solverName = "AutoroutingPipelineSolver9_PreloadedTraceGraph"
-    } else if (useLaserPrefabSolver) {
-      solverName = "AutoroutingPipelineSolver8"
-    } else if (useAutoJumperSolver) {
-      solverName = "AssignableAutoroutingPipeline3"
-    } else if (useAssignableSolver) {
-      solverName = "AssignableAutoroutingPipeline2"
-    } else {
-      solverName = "AutoroutingPipelineSolver7_MultiGraph"
-    }
+    const solverName = getCapacityAutorouterSolverName({
+      autorouterVersion,
+      useAssignableSolver,
+      useAutoJumperSolver,
+      useLaserPrefabSolver,
+    })
     const SolverClass = SOLVERS[solverName]
     const solverCacheProvider =
       getCapacityAutorouterCacheProvider(platformConfig)

--- a/tests/features/local-autorouting-cache-autorouter-identity.test.tsx
+++ b/tests/features/local-autorouting-cache-autorouter-identity.test.tsx
@@ -1,0 +1,90 @@
+import { expect, test } from "bun:test"
+import type { LocalCacheEngine } from "lib/local-cache-engine"
+import { getTestFixture } from "../fixtures/get-test-fixture"
+
+type ExplicitAutorouterVersion = "beta_pipeline7" | "beta_pipeline9"
+
+test("local autorouting cache separates explicit Pipeline7 and Pipeline9", async () => {
+  const cache = new Map<string, string>()
+  const getKeys: string[] = []
+  const setKeys: string[] = []
+  const localCacheEngine: LocalCacheEngine = {
+    getItem: (key) => {
+      getKeys.push(key)
+      return cache.get(key) ?? null
+    },
+    setItem: (key, value) => {
+      setKeys.push(key)
+      cache.set(key, value)
+    },
+  }
+
+  const renderCircuit = async (
+    autorouterVersion: ExplicitAutorouterVersion,
+  ): Promise<string[]> => {
+    const { circuit } = getTestFixture({ platform: { localCacheEngine } })
+    const startedAutorouters: string[] = []
+    circuit.on("solver:started", ({ solverName }) => {
+      if (
+        solverName.startsWith("AutoroutingPipeline") ||
+        solverName.startsWith("AssignableAutoroutingPipeline")
+      ) {
+        startedAutorouters.push(solverName)
+      }
+    })
+    circuit.add(
+      <board width="20mm" height="10mm" autorouterVersion={autorouterVersion}>
+        <resistor
+          name="R1"
+          resistance="1k"
+          footprint="0402"
+          pcbX={-5}
+          pcbY={0}
+        />
+        <resistor
+          name="R2"
+          resistance="1k"
+          footprint="0402"
+          pcbX={5}
+          pcbY={0}
+        />
+        <trace from=".R1 > .pin1" to=".R2 > .pin1" />
+      </board>,
+    )
+    await circuit.renderUntilSettled()
+    expect(circuit.db.pcb_trace.list()).toHaveLength(1)
+    return startedAutorouters
+  }
+
+  expect(await renderCircuit("beta_pipeline7")).toEqual([
+    "AutoroutingPipelineSolver7_MultiGraph",
+  ])
+  expect(await renderCircuit("beta_pipeline9")).toEqual([
+    "AutoroutingPipelineSolver9_PreloadedTraceGraph",
+  ])
+
+  const phaseCacheKeys = setKeys.filter((key) => key.startsWith("routes:"))
+  expect(phaseCacheKeys).toHaveLength(2)
+  expect(new Set(phaseCacheKeys).size).toBe(2)
+  expect(phaseCacheKeys[0]).toContain(
+    ":solver:AutoroutingPipelineSolver7_MultiGraph:",
+  )
+  expect(phaseCacheKeys[1]).toContain(
+    ":solver:AutoroutingPipelineSolver9_PreloadedTraceGraph:",
+  )
+  expect(
+    new Set(phaseCacheKeys.map((key) => key.match(/:srj:([a-f0-9]{16})$/)?.[1]))
+      .size,
+  ).toBe(1)
+
+  const getCountBeforePipeline9CacheHit = getKeys.length
+  expect(await renderCircuit("beta_pipeline9")).toEqual([])
+  expect(
+    getKeys
+      .slice(getCountBeforePipeline9CacheHit)
+      .filter((key) => key.startsWith("routes:")),
+  ).toEqual([phaseCacheKeys[1]])
+  expect(setKeys.filter((key) => key.startsWith("routes:"))).toEqual(
+    phaseCacheKeys,
+  )
+})

--- a/tests/features/local-autorouting-phase-cache.test.tsx
+++ b/tests/features/local-autorouting-phase-cache.test.tsx
@@ -109,7 +109,9 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
   expect(new Set(setKeys).size).toBe(2)
   for (const key of setKeys) {
     expect(key).toMatch(
-      new RegExp(`^routes:core@${pkgJson.version}:srj:[a-f0-9]{16}$`),
+      new RegExp(
+        `^routes:core@${pkgJson.version}:local:v1:solver:AutoroutingPipelineSolver7_MultiGraph:options:[a-f0-9]{16}:srj:[a-f0-9]{16}$`,
+      ),
     )
   }
 

--- a/tests/utils/autorouting/local-autorouting-cache-key.test.ts
+++ b/tests/utils/autorouting/local-autorouting-cache-key.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import {
+  getLocalAutoroutingCacheKey,
+  type LocalAutoroutingCacheConfig,
+} from "lib/components/primitive-components/Group/Group_localAutoroutingCache"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+
+const simpleRouteJson: SimpleRouteJson = {
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  obstacles: [],
+  connections: [],
+  bounds: { minX: -1, maxX: 1, minY: -1, maxY: 1 },
+}
+
+test("local autorouting cache keys include solver and capacity options", () => {
+  const baseConfig: LocalAutoroutingCacheConfig = {
+    solverName: "AutoroutingPipelineSolver7_MultiGraph",
+  }
+  const getKey = (config: LocalAutoroutingCacheConfig) =>
+    getLocalAutoroutingCacheKey(simpleRouteJson, config)
+
+  expect(getKey(baseConfig)).toBe(getKey({ ...baseConfig }))
+  expect(
+    new Set([
+      getKey(baseConfig),
+      getKey({
+        ...baseConfig,
+        solverName: "AutoroutingPipelineSolver9_PreloadedTraceGraph",
+      }),
+      getKey({ ...baseConfig, capacityDepth: 6 }),
+      getKey({ ...baseConfig, targetMinCapacity: 0.7 }),
+      getKey({ ...baseConfig, effort: 2 }),
+    ]).size,
+  ).toBe(5)
+})


### PR DESCRIPTION
## Summary

- centralize capacity autorouter solver-name resolution without changing the current Pipeline7 default
- version local phase cache keys by resolved solver, capacity depth, target minimum capacity, and effort
- prove explicit Pipeline7 and Pipeline9 renders cannot reuse each other's cached routes

This prepares the cache boundary for a later default-solver change while preserving current routing behavior. No snapshots are changed.

## Validation

- 9 focused cache and solver-selection tests pass
- bunx tsc --noEmit
- bun run build
- targeted Biome formatting check
- git diff --check