### PR TITLE
Prevent duplicate preloaded traces between routing phases

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -1618,7 +1618,11 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         if (transformedSimpleRouteJson?.traces) {
           stageOutputTraces = transformedSimpleRouteJson.traces
         } else if (usesPreviousStageOutput) {
-          stageOutputTraces = [...(simpleRouteJson.traces ?? []), ...traces]
+          stageOutputTraces =
+            getAccumulatedPcbTracesWithStageOutputReplacements({
+              accumulatedPcbTraces: simpleRouteJson.traces ?? [],
+              stageOutputPcbTraces: traces,
+            })
         }
         const outputSimpleRouteJson = {
           ...(transformedSimpleRouteJson ?? simpleRouteJson),
@@ -1683,7 +1687,10 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             rerouteOriginalSrj as AutorouterSimpleRouteJson,
             {
               ...simpleRouteJson,
-              traces: [...(simpleRouteJson.traces ?? []), ...traces],
+              traces: getAccumulatedPcbTracesWithStageOutputReplacements({
+                accumulatedPcbTraces: simpleRouteJson.traces ?? [],
+                stageOutputPcbTraces: stageOutputTraces,
+              }),
             } as AutorouterSimpleRouteJson,
           ) as SimpleRouteJson
           outputTraces.splice(

--- a/tests/features/autoroutingphase-reroute-preloaded-traces.test.tsx
+++ b/tests/features/autoroutingphase-reroute-preloaded-traces.test.tsx
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test"
+import type {
+  SimpleRouteJson,
+  SimplifiedPcbTrace,
+} from "lib/utils/autorouting/SimpleRouteJson"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+type Point = { x: number; y: number; layer?: string }
+
+const createPipeline9LikeAutorouter = async (
+  simpleRouteJson: SimpleRouteJson,
+) => {
+  let complete: ((event: any) => void) | undefined
+
+  const solveSync = (): SimplifiedPcbTrace[] => [
+    ...(simpleRouteJson.traces ?? []),
+    ...simpleRouteJson.connections.map((connection) => {
+      const [start, end] = connection.pointsToConnect as [Point, Point]
+      const width = connection.nominalTraceWidth ?? 0.15
+
+      return {
+        type: "pcb_trace" as const,
+        pcb_trace_id: `${connection.name}_rerouted`,
+        connection_name: connection.source_trace_id ?? connection.name,
+        route: [
+          {
+            route_type: "wire" as const,
+            x: start.x,
+            y: start.y,
+            width,
+            layer: start.layer ?? "top",
+          },
+          {
+            route_type: "wire" as const,
+            x: end.x,
+            y: end.y,
+            width,
+            layer: end.layer ?? "top",
+          },
+        ],
+      }
+    }),
+  ]
+
+  return {
+    isRouting: false,
+    on: (event: string, callback: any) => {
+      if (event === "complete") complete = callback
+    },
+    start: () => complete?.({ type: "complete", traces: solveSync() }),
+    stop: () => {},
+    solveSync,
+  } as any
+}
+
+test("region reroute does not duplicate preloaded Pipeline9-like traces", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="18mm" height="12mm">
+      <testpoint name="T1" pcbX={-7} pcbY={3} padDiameter="0.8mm" />
+      <testpoint name="T2" pcbX={7} pcbY={3} padDiameter="0.8mm" />
+      <testpoint name="M1" pcbX={-7} pcbY={0} padDiameter="0.8mm" />
+      <testpoint name="M2" pcbX={7} pcbY={0} padDiameter="0.8mm" />
+      <testpoint name="B1" pcbX={-7} pcbY={-3} padDiameter="0.8mm" />
+      <testpoint name="B2" pcbX={7} pcbY={-3} padDiameter="0.8mm" />
+
+      <autoroutingphase
+        reroute
+        region={{ shape: "rect", minX: 0, maxX: 8, minY: -5, maxY: 5 }}
+        autorouter={{ algorithmFn: createPipeline9LikeAutorouter }}
+      />
+
+      <trace from="T1.pin1" to="T2.pin1" />
+      <trace from="M1.pin1" to="M2.pin1" />
+      <trace from="B1.pin1" to="B2.pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.pcb_autorouting_error.list()).toEqual([])
+  const pcbTraces = circuit.db.pcb_trace.list()
+  const logicalRouteSignatures = pcbTraces.map((trace) =>
+    JSON.stringify({
+      source_trace_id: trace.source_trace_id,
+      route: trace.route,
+    }),
+  )
+
+  expect(pcbTraces).toHaveLength(6)
+  expect(new Set(logicalRouteSignatures).size).toBe(pcbTraces.length)
+})

--- a/tests/repros/repro116-arduino-uno-reroute-utils.tsx
+++ b/tests/repros/repro116-arduino-uno-reroute-utils.tsx
@@ -277,6 +277,14 @@ export async function expectArduinoUnoRerouteRegion({
   }
 
   expect(afterRerouteCircuit.db.pcb_autorouting_error.list()).toHaveLength(0)
+  const finalPcbTraces = afterRerouteCircuit.db.pcb_trace.list()
+  const finalLogicalRouteSignatures = finalPcbTraces.map((trace) =>
+    JSON.stringify({
+      source_trace_id: trace.source_trace_id,
+      route: trace.route,
+    }),
+  )
+  expect(new Set(finalLogicalRouteSignatures).size).toBe(finalPcbTraces.length)
   expect(phaseInputs).toHaveLength(1)
   expect(phaseInputs[0]!.connections.length).toBeGreaterThan(0)
   for (const connection of phaseInputs[0]!.connections) {

--- a/tests/utils/autorouting/accumulate-stage-output-traces.test.ts
+++ b/tests/utils/autorouting/accumulate-stage-output-traces.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { getAccumulatedPcbTracesWithStageOutputReplacements } from "lib/components/primitive-components/Group/get-accumulated-pcb-traces-with-stage-output-replacements"
+import type { SimplifiedPcbTrace } from "lib/utils/autorouting/SimpleRouteJson"
+
+const makeTrace = (pcbTraceId: string, x: number): SimplifiedPcbTrace => ({
+  type: "pcb_trace",
+  pcb_trace_id: pcbTraceId,
+  route: [
+    { route_type: "wire", x, y: 0, width: 0.15, layer: "top" },
+    { route_type: "wire", x: x + 1, y: 0, width: 0.15, layer: "top" },
+  ],
+})
+
+test("stage output replaces accumulated IDs while preserving split sections", () => {
+  const accumulatedTrace = makeTrace("split", 0)
+  const firstReplacementSection = makeTrace("split", 2)
+  const secondReplacementSection = makeTrace("split", 4)
+  const retainedTrace = makeTrace("retained", 6)
+
+  expect(
+    getAccumulatedPcbTracesWithStageOutputReplacements({
+      accumulatedPcbTraces: [accumulatedTrace, retainedTrace],
+      stageOutputPcbTraces: [firstReplacementSection, secondReplacementSection],
+    }),
+  ).toEqual([retainedTrace, firstReplacementSection, secondReplacementSection])
+})


### PR DESCRIPTION
## Summary

- replace accumulated PCB traces by `pcb_trace_id` when a routing stage returns preloaded traces
- use the same replacement boundary before reconnecting a rerouted region
- preserve multiple split sections returned by one stage, even when they share a trace ID
- add a fast Pipeline9-like region integration regression plus Arduino logical-route uniqueness coverage

## Why

Pipeline9 can return its preloaded traces together with newly routed traces. `Group` previously prepended the same preloaded traces again in follow-up-stage and region-reroute paths, materializing duplicate copper. The mocked region regression produced 9 traces before this fix and 6 unique traces after it.

This uses the existing trace-ID replacement helper at the two accumulation boundaries instead of silently canonicalizing or deduplicating malformed stage output.

## Validation

- `bun test tests/utils/autorouting/accumulate-stage-output-traces.test.ts`
- `bun test tests/features/autoroutingphase-reroute-preloaded-traces.test.tsx`
- `bun test tests/features/autorouter-fanout.test.tsx`
- `bun test tests/features/autorouter-beta-pipeline9-multiple-phases.test.tsx`
- `bun test tests/repros/repro-gameboy-direct-subcircuit-routing.test.tsx`
- `bun test tests/repros/repro116-arduino-uno-reroute.test.tsx`
- `bun test tests/features/autoroutingphase-reroute.test.tsx`
- `bun test tests/features/autoroutingphase-imported-circuit-json-reroute-builtin.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`