### PR TITLE
chore: use published copper pour solver

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Reject preview package dependencies
+        run: |
+          if grep -nF "pkg.pr.new" package.json; then
+            echo "::error::Replace pkg.pr.new dependency specs with published package versions before merging."
+            exit 1
+          fi
+
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@tscircuit/checks": "^0.0.175",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",
-    "@tscircuit/copper-pour-solver": "https://pkg.pr.new/@tscircuit/copper-pour-solver@85",
+    "@tscircuit/copper-pour-solver": "^0.0.51",
     "@tscircuit/create-fdm-enclosure": "0.0.4",
     "@tscircuit/fanout-solver": "0.0.39",
     "@tscircuit/footprinter": "^0.0.426",


### PR DESCRIPTION
## Summary

- replace the copper-pour-solver PR preview with published @tscircuit/copper-pour-solver@^0.0.51
- reject committed pkg.pr.new dependency specs in the existing Dependency Check workflow
- keep the same PR #85 implementation used by the AM62L and implicit-pour work while removing an unreliable install source

## Testing

- bun install (resolved @tscircuit/copper-pour-solver@0.0.51)
- bun run format
- bunx tsc --noEmit
- bun run build
- bun run smoke-test:dist
- bunx @tscircuit/dependency-check
- focused copper-pour and fanout regressions: 5 passed, 4,909 assertions