### PR TITLE
feat: identify SRJ obstacle roles

### DIFF
--- a/lib/utils/autorouting/FanoutAutorouter.ts
+++ b/lib/utils/autorouting/FanoutAutorouter.ts
@@ -348,6 +348,7 @@ const createDownstreamSimpleRouteJson = ({
       obstacleId: `fanout-source-keepout:${componentId}`,
       componentId,
       isFanoutSourceKeepout: true,
+      obstacleRole: "keepout",
       type: "rect",
       layers: getViaBoardLayers(fanoutSimpleRouteJson.layerCount),
       center: { x: (minX + maxX) / 2, y: (minY + maxY) / 2 },

--- a/lib/utils/autorouting/SimpleRouteJson.ts
+++ b/lib/utils/autorouting/SimpleRouteJson.ts
@@ -3,9 +3,17 @@ import type {
   SimplifiedPcbTrace as AutorouterSimplifiedPcbTrace,
 } from "@tscircuit/capacity-autorouter"
 import type { PcbGroup } from "circuit-json"
-import type { CircuitJsonMetadata, Obstacle } from "../obstacles/types"
+import type {
+  CircuitJsonMetadata,
+  Obstacle,
+  ObstacleRole,
+} from "../obstacles/types"
 
-export type { CircuitJsonMetadata, Obstacle } from "../obstacles/types"
+export type {
+  CircuitJsonMetadata,
+  Obstacle,
+  ObstacleRole,
+} from "../obstacles/types"
 
 export type PcbGroupId = PcbGroup["pcb_group_id"]
 export type SimpleRouteBounds = {

--- a/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
+++ b/lib/utils/obstacles/getObstaclesFromCircuitJson.ts
@@ -129,6 +129,7 @@ export const getObstaclesFromCircuitJson = (
         obstacles.push({
           circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
           componentId: pcbComponentId,
+          obstacleRole: "pad",
           type: "rect",
           shape: "circle",
           layers: [element.layer],
@@ -144,6 +145,7 @@ export const getObstaclesFromCircuitJson = (
         obstacles.push({
           circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
           componentId: pcbComponentId,
+          obstacleRole: "pad",
           type: "rect",
           layers: [element.layer],
           center: {
@@ -167,6 +169,7 @@ export const getObstaclesFromCircuitJson = (
         obstacles.push({
           circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
           componentId: pcbComponentId,
+          obstacleRole: "pad",
           type: "rect",
           layers: [element.layer],
           center: rect.center,
@@ -181,6 +184,7 @@ export const getObstaclesFromCircuitJson = (
         obstacles.push({
           circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
           componentId: pcbComponentId,
+          obstacleRole: "pad",
           type: "rect",
           layers: [element.layer],
           center: {
@@ -200,6 +204,7 @@ export const getObstaclesFromCircuitJson = (
           obstacles.push({
             circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
             componentId: pcbComponentId,
+            obstacleRole: "pad",
             type: "rect",
             layers: [element.layer],
             ...axisAlignedRect,
@@ -216,6 +221,7 @@ export const getObstaclesFromCircuitJson = (
           obstacles.push({
             circuitJsonMetadata: pcbSmtPadCircuitJsonMetadata,
             componentId: pcbComponentId,
+            obstacleRole: "pad",
             type: "rect",
             layers: [element.layer],
             center: rect.center,
@@ -229,6 +235,7 @@ export const getObstaclesFromCircuitJson = (
       if (element.shape === "circle") {
         obstacles.push({
           componentId: pcbComponentId,
+          obstacleRole: "keepout",
           // @ts-ignore
           type: "oval",
           layers: element.layers,
@@ -243,6 +250,7 @@ export const getObstaclesFromCircuitJson = (
       } else if (element.shape === "rect") {
         obstacles.push({
           componentId: pcbComponentId,
+          obstacleRole: "keepout",
           type: "rect",
           layers: element.layers,
           center: {
@@ -258,6 +266,7 @@ export const getObstaclesFromCircuitJson = (
       if (element.shape === "rect") {
         obstacles.push({
           componentId: pcbComponentId,
+          obstacleRole: "keepout",
           type: "rect",
           layers: everyLayer,
           center: {
@@ -280,6 +289,7 @@ export const getObstaclesFromCircuitJson = (
         for (const rect of approximatingRects) {
           obstacles.push({
             componentId: pcbComponentId,
+            obstacleRole: "keepout",
             type: "rect",
             layers: everyLayer,
             center: rect.center,
@@ -296,6 +306,7 @@ export const getObstaclesFromCircuitJson = (
         for (const rect of approximatingRects) {
           obstacles.push({
             componentId: pcbComponentId,
+            obstacleRole: "keepout",
             type: "rect",
             layers: everyLayer,
             center: rect.center,
@@ -396,6 +407,7 @@ export const getObstaclesFromCircuitJson = (
         obstacles.push({
           circuitJsonMetadata: pcbPlatedHoleCircuitJsonMetadata,
           componentId: pcbComponentId,
+          obstacleRole: "pad",
           // @ts-ignore
           type: "oval",
           layers: everyLayer,
@@ -411,6 +423,7 @@ export const getObstaclesFromCircuitJson = (
         obstacles.push({
           circuitJsonMetadata: pcbPlatedHoleCircuitJsonMetadata,
           componentId: pcbComponentId,
+          obstacleRole: "pad",
           // @ts-ignore
           type: "rect",
           layers: everyLayer,
@@ -426,6 +439,7 @@ export const getObstaclesFromCircuitJson = (
         obstacles.push({
           circuitJsonMetadata: pcbPlatedHoleCircuitJsonMetadata,
           componentId: pcbComponentId,
+          obstacleRole: "pad",
           // @ts-ignore
           type: "oval",
           layers: everyLayer,
@@ -441,6 +455,7 @@ export const getObstaclesFromCircuitJson = (
         obstacles.push({
           circuitJsonMetadata: pcbPlatedHoleCircuitJsonMetadata,
           componentId: pcbComponentId,
+          obstacleRole: "pad",
           type: "rect",
           layers: everyLayer,
           center: {
@@ -470,6 +485,7 @@ export const getObstaclesFromCircuitJson = (
           obstacles.push({
             circuitJsonMetadata: pcbPlatedHoleCircuitJsonMetadata,
             componentId: pcbComponentId,
+            obstacleRole: "pad",
             // @ts-ignore
             type: "rect",
             layers: everyLayer,

--- a/lib/utils/obstacles/types.ts
+++ b/lib/utils/obstacles/types.ts
@@ -7,9 +7,13 @@ export type CircuitJsonMetadata = {
   source_port_name?: string
 }
 
+export type ObstacleRole = "pad" | "component_body" | "keepout"
+
 export type Obstacle = {
   obstacleId?: string
   componentId?: string
+  /** Routing-domain identity; unlike provenance metadata, routers may use it. */
+  obstacleRole?: ObstacleRole
   /** True when this obstacle replaces one completed fanout source footprint. */
   isFanoutSourceKeepout?: boolean
   /** Circuit JSON provenance carried through SRJ but forbidden for routing. */

--- a/tests/repros/repro-simple-route-json-45-degree.test.tsx
+++ b/tests/repros/repro-simple-route-json-45-degree.test.tsx
@@ -84,6 +84,7 @@ test("45 degree rects bug", () => {
           "layers": [
             "top",
           ],
+          "obstacleRole": "pad",
           "type": "rect",
           "width": 3.9,
         },

--- a/tests/utils/autorouting/obstacle-roles-keepouts-and-components.test.ts
+++ b/tests/utils/autorouting/obstacle-roles-keepouts-and-components.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getObstaclesFromCircuitJson } from "lib/utils/obstacles/getObstaclesFromCircuitJson"
+
+test("explicit keepouts are tagged without mislabeling component-owned pads", () => {
+  const circuitJson = [
+    {
+      type: "pcb_component",
+      pcb_component_id: "pcb_component_0",
+      source_component_id: "source_component_0",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 8,
+      layer: "top",
+      rotation: 0,
+    },
+    {
+      type: "pcb_smtpad",
+      shape: "rect",
+      pcb_smtpad_id: "pcb_smtpad_0",
+      pcb_component_id: "pcb_component_0",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 0.5,
+      layer: "top",
+    },
+    {
+      type: "pcb_keepout",
+      shape: "circle",
+      pcb_keepout_id: "pcb_keepout_0",
+      pcb_component_id: "pcb_component_0",
+      center: { x: 2, y: 0 },
+      radius: 0.5,
+      layers: ["top"],
+    },
+    {
+      type: "pcb_keepout",
+      shape: "rect",
+      pcb_keepout_id: "pcb_keepout_1",
+      center: { x: 4, y: 0 },
+      width: 1,
+      height: 1,
+      layers: ["bottom"],
+    },
+    {
+      type: "pcb_cutout",
+      shape: "rect",
+      pcb_cutout_id: "pcb_cutout_0",
+      center: { x: 6, y: 0 },
+      width: 1,
+      height: 1,
+    },
+    {
+      type: "pcb_cutout",
+      shape: "circle",
+      pcb_cutout_id: "pcb_cutout_1",
+      center: { x: 8, y: 0 },
+      radius: 0.5,
+    },
+    {
+      type: "pcb_cutout",
+      shape: "polygon",
+      pcb_cutout_id: "pcb_cutout_2",
+      points: [
+        { x: 9, y: -0.5 },
+        { x: 10, y: -0.5 },
+        { x: 10, y: 0.5 },
+        { x: 9, y: 0.5 },
+      ],
+    },
+  ] as unknown as AnyCircuitElement[]
+
+  const obstacles = getObstaclesFromCircuitJson(circuitJson)
+  const [padObstacle] = obstacles.filter((obstacle) =>
+    obstacle.connectedTo.includes("pcb_smtpad_0"),
+  )
+  const keepoutObstacles = obstacles.filter(
+    ({ obstacleRole }) => obstacleRole === "keepout",
+  )
+  const explicitKeepoutRegions = [
+    { minX: 1, maxX: 3 },
+    { minX: 3, maxX: 5 },
+    { minX: 5, maxX: 7 },
+    { minX: 7, maxX: 9 },
+    { minX: 9, maxX: 10 },
+  ]
+
+  expect(padObstacle).toMatchObject({
+    componentId: "pcb_component_0",
+    obstacleRole: "pad",
+  })
+  for (const { minX, maxX } of explicitKeepoutRegions) {
+    const regionObstacles = obstacles.filter(
+      ({ center }) => center.x >= minX && center.x <= maxX,
+    )
+    expect(regionObstacles.length).toBeGreaterThan(0)
+    expect(
+      regionObstacles.every(({ obstacleRole }) => obstacleRole === "keepout"),
+    ).toBe(true)
+  }
+  expect(keepoutObstacles).toHaveLength(obstacles.length - 1)
+  expect(
+    obstacles.some(({ obstacleRole }) => obstacleRole === "component_body"),
+  ).toBe(false)
+})

--- a/tests/utils/autorouting/obstacle-roles-pad-shapes.test.ts
+++ b/tests/utils/autorouting/obstacle-roles-pad-shapes.test.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getObstaclesFromCircuitJson } from "lib/utils/obstacles/getObstaclesFromCircuitJson"
+
+test("all PCB pad shapes emit pad-role obstacles", () => {
+  const smtPads = [
+    {
+      type: "pcb_smtpad",
+      shape: "circle",
+      radius: 0.5,
+    },
+    {
+      type: "pcb_smtpad",
+      shape: "rect",
+      width: 1,
+      height: 0.5,
+    },
+    {
+      type: "pcb_smtpad",
+      shape: "rotated_rect",
+      width: 1,
+      height: 0.5,
+      ccw_rotation: 45,
+    },
+    {
+      type: "pcb_smtpad",
+      shape: "pill",
+      width: 1,
+      height: 0.5,
+    },
+    {
+      type: "pcb_smtpad",
+      shape: "rotated_pill",
+      width: 1,
+      height: 0.5,
+      ccw_rotation: 45,
+    },
+    {
+      type: "pcb_smtpad",
+      shape: "polygon",
+      points: [
+        { x: -0.5, y: -0.5 },
+        { x: 0.5, y: -0.5 },
+        { x: 0.5, y: 0.5 },
+        { x: -0.5, y: 0.5 },
+      ],
+    },
+    {
+      type: "pcb_smtpad",
+      shape: "polygon",
+      points: [
+        { x: 0, y: -0.6 },
+        { x: 0.6, y: 0 },
+        { x: 0, y: 0.6 },
+        { x: -0.6, y: 0 },
+      ],
+    },
+  ].map((pad, padIndex) => ({
+    ...pad,
+    pcb_smtpad_id: `pcb_smtpad_${padIndex}`,
+    pcb_component_id: "pcb_component_0",
+    x: padIndex * 2,
+    y: 0,
+    layer: "top",
+  }))
+  const platedHoles = [
+    {
+      type: "pcb_plated_hole",
+      shape: "circle",
+      outer_diameter: 1,
+      hole_diameter: 0.5,
+    },
+    {
+      type: "pcb_plated_hole",
+      shape: "circular_hole_with_rect_pad",
+      hole_diameter: 0.5,
+      rect_pad_width: 1,
+      rect_pad_height: 0.8,
+    },
+    {
+      type: "pcb_plated_hole",
+      shape: "oval",
+      outer_width: 1.2,
+      outer_height: 0.8,
+      hole_width: 0.6,
+      hole_height: 0.4,
+    },
+    {
+      type: "pcb_plated_hole",
+      shape: "pill",
+      outer_width: 1.2,
+      outer_height: 0.8,
+      hole_width: 0.6,
+      hole_height: 0.4,
+      ccw_rotation: 30,
+    },
+    {
+      type: "pcb_plated_hole",
+      shape: "hole_with_polygon_pad",
+      hole_shape: "circle",
+      hole_diameter: 0.5,
+      pad_outline: [
+        { x: -0.5, y: -0.4 },
+        { x: 0.5, y: -0.4 },
+        { x: 0.5, y: 0.4 },
+        { x: -0.5, y: 0.4 },
+      ],
+    },
+  ].map((pad, padIndex) => ({
+    ...pad,
+    pcb_plated_hole_id: `pcb_plated_hole_${padIndex}`,
+    pcb_component_id: "pcb_component_0",
+    x: padIndex * 2,
+    y: 3,
+    layers: ["top", "bottom"],
+  }))
+  const circuitJson = [
+    ...smtPads,
+    ...platedHoles,
+  ] as unknown as AnyCircuitElement[]
+
+  const obstacles = getObstaclesFromCircuitJson(circuitJson)
+  const padIds = [
+    ...smtPads.map((pad) => pad.pcb_smtpad_id),
+    ...platedHoles.map((pad) => pad.pcb_plated_hole_id),
+  ]
+
+  for (const padId of padIds) {
+    const padObstacles = obstacles.filter((obstacle) =>
+      obstacle.connectedTo.includes(padId),
+    )
+    expect(padObstacles.length).toBeGreaterThan(0)
+    expect(
+      padObstacles.every(({ obstacleRole }) => obstacleRole === "pad"),
+    ).toBe(true)
+  }
+})


### PR DESCRIPTION
Adds an explicit routing-domain obstacleRole to SimpleRouteJson obstacles.

- marks SMT pads and plated holes as pad
- marks PCB keepouts, cutouts, and fanout-source boxes as keepout
- keeps Circuit JSON provenance diagnostic-only
- covers all currently emitted pad and keepout shapes

This is the producer-side prerequisite for tscircuit/tscircuit-autorouter#2240 and its stacked CM5 DRC repair PR.

Validation: focused tests, TypeScript, build, Biome, and diff-check pass.