### PR TITLE
chore: update schematic-trace-solver to 0.0.170

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
     "@tscircuit/props": "^0.0.641",
     "@tscircuit/schematic-match-adapt": "^0.0.18",
-    "@tscircuit/schematic-trace-solver": "^0.0.168",
+    "@tscircuit/schematic-trace-solver": "^0.0.170",
     "@tscircuit/solver-utils": "^0.0.16",
     "@tscircuit/soup-util": "^0.0.41",
     "@tscircuit/winding-breakout-point-solver": "github:tscircuit/winding-breakout-point-solver#202dbe9eb0088633b6fa094120dba6f2f41f8803",


### PR DESCRIPTION
## Summary
- update `@tscircuit/schematic-trace-solver` from `^0.0.168` to `^0.0.170`
- regenerate the visual snapshots against the new solver; existing schematic snapshots remain current, so no snapshot files changed

## Testing
- `bunx tsc --noEmit`
- `bun run build`
- 11 focused schematic snapshot tests (all passed)
- `BUN_UPDATE_SNAPSHOTS=1 bun test --timeout 120000` (1,476 passed, 40 skipped; 2 unrelated inline snapshots failed because Bun 1.3.2 serializes a tiny float in decimal rather than scientific notation)