### PR TITLE
Respect analogSimulationDisabled during rendering

### DIFF
--- a/lib/components/primitive-components/Group/Group_doInitialSimulationSpiceEngineRender.ts
+++ b/lib/components/primitive-components/Group/Group_doInitialSimulationSpiceEngineRender.ts
@@ -133,6 +133,8 @@ const getCircuitJsonForAnalogSimulation = ({
 }
 
 export function Group_doInitialSimulationSpiceEngineRender(group: Group<any>) {
+  if (group.getInheritedProperty("analogSimulationDisabled")) return
+
   // Only run spice simulation for subcircuits
   if (!group.isSubcircuit) return
 

--- a/lib/components/primitive-components/SpiceModel.ts
+++ b/lib/components/primitive-components/SpiceModel.ts
@@ -4,8 +4,8 @@ import type {
   SourceInvalidComponentPropertyErrorInput,
 } from "circuit-json"
 import { parseSpiceNetlist } from "spicets"
-import { Port } from "./Port"
 import { PrimitiveComponent } from "../base-components/PrimitiveComponent"
+import { Port } from "./Port"
 
 export class SpiceModel extends PrimitiveComponent<typeof spicemodelProps> {
   get config() {
@@ -16,6 +16,8 @@ export class SpiceModel extends PrimitiveComponent<typeof spicemodelProps> {
   }
 
   doInitialSimulationRender() {
+    if (this.getInheritedProperty("analogSimulationDisabled")) return
+
     const parent = this.parent
     if (!parent) return
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
-    "@tscircuit/props": "^0.0.641",
+    "@tscircuit/props": "^0.0.642",
     "@tscircuit/schematic-match-adapt": "^0.0.18",
     "@tscircuit/schematic-trace-solver": "^0.0.170",
     "@tscircuit/solver-utils": "^0.0.16",
@@ -132,7 +132,7 @@
   },
   "overrides": {
     "@tscircuit/circuit-json-util": "^0.0.106",
-    "@tscircuit/props": "^0.0.641",
+    "@tscircuit/props": "^0.0.642",
     "circuit-json": "^0.0.479"
   }
 }

--- a/tests/features/analog-simulation-disabled.test.tsx
+++ b/tests/features/analog-simulation-disabled.test.tsx
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("analogSimulationDisabled skips model validation and simulation", async () => {
+  let simulationCallCount = 0
+  const { circuit } = getTestFixture({
+    platform: {
+      analogSimulationDisabled: true,
+      spiceEngineMap: {
+        capturing: {
+          simulate: async () => {
+            simulationCallCount += 1
+            return { simulationResultCircuitJson: [] }
+          },
+        },
+      },
+    },
+  })
+
+  circuit.add(
+    <board>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: "OUT", pin2: "IN" }}
+        spiceModel={<spicemodel source="not a valid SPICE subcircuit" />}
+      />
+      <analogsimulation
+        duration="1ms"
+        timePerStep="0.1ms"
+        spiceEngine="capturing"
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  expect(simulationCallCount).toBe(0)
+  expect(
+    circuitJson.some(
+      (element) => element.type === "simulation_spice_subcircuit",
+    ),
+  ).toBe(false)
+  expect(
+    circuitJson.some(
+      (element) =>
+        element.type === "source_invalid_component_property_error" &&
+        element.property_name === "spiceModel",
+    ),
+  ).toBe(false)
+})


### PR DESCRIPTION
## Summary

- respect `analogSimulationDisabled` while processing analog models
- skip SPICE model validation and Circuit JSON generation when disabled
- skip analog simulator engine execution when disabled
- add regression coverage proving invalid models do not emit errors or invoke an engine

## Props dependency

`analogSimulationDisabled` landed in tscircuit/props#823 and is published in `@tscircuit/props@0.0.642`. This PR now consumes that release directly.

## Testing

- focused analog/SPICE model tests passed
- `bunx tsc --noEmit`
- `bun run build`
- Biome check on changed files