### PR TITLE
chore: update capacity autorouter to 0.0.851

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/bga-fanout-solver": "github:tscircuit/bga-fanout-solver#03c67d2b00925a3ac24a822cd5a071d8ac2ad087",
-    "@tscircuit/capacity-autorouter": "^0.0.845",
+    "@tscircuit/capacity-autorouter": "^0.0.851",
     "@tscircuit/checks": "^0.0.178",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

- update @tscircuit/capacity-autorouter from ^0.0.845 to ^0.0.851
- keep existing snapshots unchanged after routing-focused verification

## Testing

- bun test tests/features/autorouter tests/features/autorouting tests/utils/autorouting tests/breakout tests/repros/repro-nrf52810-without-copper-pours (100 pass, 7 skip, 0 fail)
- bunx tsc --noEmit
- bun run build

A broader bun test run reached the routing features and a large repro segment without failures or snapshot mismatches, then was stopped in the unrelated routingDisabled repro159 schematic LED-matrix fixture after its synchronous layout work ran beyond the nominal timeout.