### PR TITLE
fix(capacitor): consume bypassFor/bypassTo props to create bypass traces

### DIFF
--- a/lib/components/normal-components/Capacitor.ts
+++ b/lib/components/normal-components/Capacitor.ts
@@ -90,6 +90,8 @@ export class Capacitor extends NormalComponent<
     this._createNetsFromProps([
       this.props.decouplingFor,
       this.props.decouplingTo,
+      this.props.bypassFor,
+      this.props.bypassTo,
       ...this._getNetsFromConnectionsProp(),
     ])
   }
@@ -106,6 +108,20 @@ export class Capacitor extends NormalComponent<
         new Trace({
           from: `${this.getSubcircuitSelector()} > port.2`,
           to: this.props.decouplingTo,
+        }),
+      )
+    }
+    if (this.props.bypassFor && this.props.bypassTo) {
+      this.add(
+        new Trace({
+          from: `${this.getSubcircuitSelector()} > port.1`,
+          to: this.props.bypassFor,
+        }),
+      )
+      this.add(
+        new Trace({
+          from: `${this.getSubcircuitSelector()} > port.2`,
+          to: this.props.bypassTo,
         }),
       )
     }

--- a/tests/components/normal-components/capacitor-bypass.test.tsx
+++ b/tests/components/normal-components/capacitor-bypass.test.tsx
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { sel } from "lib/sel"
+
+// Regression test for #3107: capacitor bypassFor/bypassTo props were accepted
+// by the type schema but never consumed, so no bypass source traces were created.
+
+test("capacitor bypassFor/bypassTo creates bypass source traces", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <capacitor
+        name="C1"
+        capacitance="100nF"
+        bypassFor={sel.net.V3_3}
+        bypassTo={sel.net.GND}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const traces = circuit.db.source_trace.list().map((t) => t.display_name)
+  expect(traces).toMatchInlineSnapshot(`
+    [
+      "capacitor.C1 > port.1 to net.V3_3",
+      "capacitor.C1 > port.2 to net.GND",
+    ]
+  `)
+
+  expect(circuit.db.schematic_net_label.list()).toHaveLength(2)
+})


### PR DESCRIPTION
Fixes #3107

Capacitor accepted `bypassFor`/`bypassTo` in its prop schema but never created the corresponding source traces (unlike `decouplingFor`/`decouplingTo`). This mirrors the decoupling code path so bypass props generate the traces and schematic net labels.

Root cause: `doInitialCreateNetsFromProps`/`doInitialCreateTracesFromProps` in `lib/components/normal-components/Capacitor.ts` only consumed `decouplingFor`/`decouplingTo`.

Verification: added `tests/components/normal-components/capacitor-bypass.test.tsx` which fails on main (no traces) and passes after the fix.