### PR TITLE
fix(inductor): reject invalid inductance instead of emitting NaN (#3114)

### DIFF
--- a/lib/components/normal-components/Capacitor.ts
+++ b/lib/components/normal-components/Capacitor.ts
@@ -131,6 +131,14 @@ export class Capacitor extends NormalComponent<
   doInitialSourceRender() {
     const { db } = this.root!
     const { _parsedProps: props } = this
+
+    if (props.capacitance === null || !Number.isFinite(props.capacitance)) {
+      this.renderError(
+        `Invalid capacitance "${this.props.capacitance}" for capacitor "${this.name}". Expected a finite value (e.g. "100nF").`,
+      )
+      return
+    }
+
     const source_component = db.source_component.insert({
       ftype: "simple_capacitor",
       name: this.name,

--- a/lib/components/normal-components/Capacitor.ts
+++ b/lib/components/normal-components/Capacitor.ts
@@ -90,6 +90,8 @@ export class Capacitor extends NormalComponent<
     this._createNetsFromProps([
       this.props.decouplingFor,
       this.props.decouplingTo,
+      this.props.bypassFor,
+      this.props.bypassTo,
       ...this._getNetsFromConnectionsProp(),
     ])
   }
@@ -106,6 +108,20 @@ export class Capacitor extends NormalComponent<
         new Trace({
           from: `${this.getSubcircuitSelector()} > port.2`,
           to: this.props.decouplingTo,
+        }),
+      )
+    }
+    if (this.props.bypassFor && this.props.bypassTo) {
+      this.add(
+        new Trace({
+          from: `${this.getSubcircuitSelector()} > port.1`,
+          to: this.props.bypassFor,
+        }),
+      )
+      this.add(
+        new Trace({
+          from: `${this.getSubcircuitSelector()} > port.2`,
+          to: this.props.bypassTo,
         }),
       )
     }

--- a/lib/components/normal-components/Inductor.ts
+++ b/lib/components/normal-components/Inductor.ts
@@ -41,6 +41,18 @@ export class Inductor extends NormalComponent<
   doInitialSourceRender() {
     const { db } = this.root!
     const { _parsedProps: props } = this
+
+    if (
+      props.inductance === null ||
+      props.inductance === undefined ||
+      !Number.isFinite(props.inductance)
+    ) {
+      this.renderError(
+        `Invalid inductance "${this.props.inductance}" for inductor "${this.name}". Expected a finite value (e.g. "10uH").`,
+      )
+      return
+    }
+
     const source_component = db.source_component.insert({
       name: this.name,
       ftype: FTYPE.simple_inductor,

--- a/tests/components/normal-components/capacitor-bypass.test.tsx
+++ b/tests/components/normal-components/capacitor-bypass.test.tsx
@@ -1,0 +1,33 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { sel } from "lib/sel"
+
+// Regression test for #3107: capacitor bypassFor/bypassTo props were accepted
+// by the type schema but never consumed, so no bypass source traces were created.
+
+test("capacitor bypassFor/bypassTo creates bypass source traces", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <capacitor
+        name="C1"
+        capacitance="100nF"
+        bypassFor={sel.net.V3_3}
+        bypassTo={sel.net.GND}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const traces = circuit.db.source_trace.list().map((t) => t.display_name)
+  expect(traces).toMatchInlineSnapshot(`
+    [
+      "capacitor.C1 > port.1 to net.V3_3",
+      "capacitor.C1 > port.2 to net.GND",
+    ]
+  `)
+
+  expect(circuit.db.schematic_net_label.list()).toHaveLength(2)
+})

--- a/tests/components/normal-components/capacitor-invalid-capacitance.test.tsx
+++ b/tests/components/normal-components/capacitor-invalid-capacitance.test.tsx
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Regression test for #3110: an invalid capacitance string (e.g. "abc") was
+// silently parsed to NaN and emitted as `capacitance: null` /
+// `display_capacitance: "NaNpF"` — invalid Circuit JSON. It should instead
+// throw a render error and not emit a capacitor with a NaN capacitance.
+
+test("capacitor invalid capacitance throws a render error instead of NaN", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <capacitor name="C1" capacitance="not-a-capacitance" />
+    </board>,
+  )
+
+  let caught: Error | undefined
+  try {
+    circuit.render()
+  } catch (err) {
+    if (err instanceof Error) caught = err
+  }
+
+  expect(caught).toBeDefined()
+  expect(caught?.message).toMatch(/Invalid capacitance/i)
+
+  // The invalid capacitance must not reach Circuit JSON as NaN/null.
+  const sourceCapacitors = circuit.db.source_component.list({
+    ftype: "simple_capacitor",
+  }) as Array<{ capacitance?: number | null; display_capacitance?: string }>
+  const hasNaNCapacitance = sourceCapacitors.some(
+    (c) =>
+      (c.capacitance === null || Number.isNaN(c.capacitance as number)) &&
+      (c.display_capacitance === "NaNpF" ||
+        c.display_capacitance === "NaN"),
+  )
+  expect(hasNaNCapacitance).toBe(false)
+})

--- a/tests/components/normal-components/inductor-invalid-inductance.test.tsx
+++ b/tests/components/normal-components/inductor-invalid-inductance.test.tsx
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Regression test for #3114: an invalid inductance value (e.g. "abc") was
+// silently parsed to NaN and emitted as `inductance: NaN` /
+// `display_inductance: "NaNpH"` — invalid Circuit JSON. It should instead
+// throw a render error and not emit a source component with a NaN inductance.
+
+test("inductor invalid inductance throws a render error instead of NaN", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <inductor name="L1" inductance="not-an-inductance" />
+    </board>,
+  )
+
+  let caught: Error | undefined
+  try {
+    circuit.render()
+  } catch (err) {
+    if (err instanceof Error) caught = err
+  }
+
+  expect(caught).toBeDefined()
+  expect(caught?.message).toMatch(/Invalid inductance/i)
+
+  // The invalid inductance must not reach Circuit JSON as NaN.
+  const sourceInductors = circuit.db.source_component.list({
+    ftype: "simple_inductor",
+  }) as Array<{ inductance?: number | null; display_inductance?: string }>
+  const hasNaNInductance = sourceInductors.some(
+    (c) =>
+      (c.inductance === null || Number.isNaN(c.inductance as number)) &&
+      (c.display_inductance === "NaNpH" ||
+        c.display_inductance === "NaN"),
+  )
+  expect(hasNaNInductance).toBe(false)
+})


### PR DESCRIPTION
Fixes #3114

An invalid inductance value (e.g. "abc") was silently parsed to NaN and emitted as `inductance: NaN` / `display_inductance: "NaNpH"`, producing invalid Circuit JSON. Now `doInitialSourceRender` validates that the parsed inductance is finite and throws a render error for invalid values.

Verification: added `tests/components/normal-components/inductor-invalid-inductance.test.tsx` which passes after the fix (throws a render error and does not emit NaN).