### PR TITLE
ci: keep Bun test matrix running after failures

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         node: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 


### PR DESCRIPTION
## Summary
- disable GitHub Actions matrix fail-fast behavior for the Bun test workflow
- allow all ten test shards to finish even when one shard fails
- preserve normal failure reporting for every failed shard

## Validation
- parsed the workflow as YAML
- ran git diff --check