### PR TITLE
chore: update matchpack to 0.0.88

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@tscircuit/jlcpcb-manufacturing-specs": "git+https://github.com/tscircuit/jlcpcb-manufacturing-specs#e08af159db01a37db007e33f0a7268d0e4a279a5",
     "@tscircuit/krt-wasm": "^0.1.1",
     "@tscircuit/log-soup": "^1.0.2",
-    "@tscircuit/matchpack": "^0.0.84",
+    "@tscircuit/matchpack": "^0.0.88",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.20",


### PR DESCRIPTION
## Summary

- update the Core development dependency from `@tscircuit/matchpack@^0.0.84` to `^0.0.88`
- bring the resistor/facing-two-pin-component alignment fix from [matchpack#232](https://github.com/tscircuit/matchpack/pull/232) downstream into Core
- keep the existing wildcard peer dependency unchanged

The Matchpack fix was developed against the rectifier reproduction added in [matchpack#229](https://github.com/tscircuit/matchpack/pull/229).

## Snapshot impact

No Core snapshots or generated files changed.

I ran the 125 schematic-snapshot test files that contain resistors (excluding the existing 12×12 LED-matrix stress test). Of those, 119 passed, one was skipped, and six hit their existing explicit time limits. The same six timeouts reproduced on `0.0.84` with equivalent timings, so they are not regressions from this update.

The focused Matchpack integration set passes: 5 tests, 0 failures.

GitHub's complete CI matrix also passes, including all 10 test shards, typecheck, format, smoke, and preview checks.

## Validation

- `bun run format`
- `NODE_OPTIONS=--max-old-space-size=4096 bunx tsc --noEmit`
- `NODE_OPTIONS=--max-old-space-size=4096 bun run build`
- focused Matchpack integration tests
- resistor-containing schematic snapshot sweep and `0.0.84`/`0.0.88` timeout comparison
