### PR TITLE
Fix pin-header mating-side aliases in CAD

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -1894,9 +1894,10 @@ export class NormalComponent<
           : 0
         : 0
 
-    const computedLayer = this.props.layer === "bottom" ? "bottom" : "top"
-
     const pcbComponent = db.pcb_component.get(this.pcb_component_id)
+    // pcb_component.layer is the canonical resolved layer after aliases and
+    // footprint metadata have been applied during PCB component rendering.
+    const computedLayer = pcbComponent?.layer === "bottom" ? "bottom" : "top"
     const globalTransform = this._computePcbGlobalTransformBeforeLayout()
     const decomposedTransform = decomposeTSR(globalTransform)
     const preLayoutRotation =

--- a/tests/components/normal-components/pin-header-connects-from-cad-layer.test.tsx
+++ b/tests/components/normal-components/pin-header-connects-from-cad-layer.test.tsx
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("pinheader mating-side aliases consistently set PCB and CAD layers", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="10mm">
+      <pinheader name="J1" pinCount={2} pcbX={-4} connectsFromAbove />
+      <pinheader name="J2" pinCount={2} pcbX={4} connectsFromBelow />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const getPcbAndCadComponents = (name: string) => {
+    const sourceComponent = circuit.db.source_component
+      .list()
+      .find((component) => component.name === name)
+    if (!sourceComponent) throw new Error(`Missing source component ${name}`)
+
+    const pcbComponent = circuit.db.pcb_component
+      .list()
+      .find(
+        (component) =>
+          component.source_component_id === sourceComponent.source_component_id,
+      )
+    const cadComponent = circuit.db.cad_component
+      .list()
+      .find(
+        (component) =>
+          component.source_component_id === sourceComponent.source_component_id,
+      )
+    if (!pcbComponent || !cadComponent) {
+      throw new Error(`Missing PCB or CAD component for ${name}`)
+    }
+
+    return { pcbComponent, cadComponent }
+  }
+
+  const above = getPcbAndCadComponents("J1")
+  expect(above.pcbComponent.layer).toBe("top")
+  expect(above.cadComponent.position.z).toBeGreaterThan(0)
+  expect(above.cadComponent.rotation?.y).toBe(0)
+
+  const below = getPcbAndCadComponents("J2")
+  expect(below.pcbComponent.layer).toBe("bottom")
+  expect(below.cadComponent.position.z).toBeLessThan(0)
+  expect(below.cadComponent.rotation?.y).toBe(180)
+})


### PR DESCRIPTION
## Summary

- use the emitted PCB component layer as the canonical layer for CAD placement
- keep CAD placement consistent with `connectsFromAbove` and `connectsFromBelow`
- cover top- and bottom-side pin headers with a focused regression test

## Why

`pinHeaderProps` resolves the mating-side aliases into `layer` during prop parsing. PCB component rendering used that resolved value, but CAD model rendering read the raw `layer` prop instead. As a result, `connectsFromBelow` emitted a bottom-layer PCB component while leaving its CAD model above the board.

Reading the already-emitted `pcb_component.layer` keeps the PCB and CAD transforms on the same resolved source of truth, including explicit layers and footprint-derived layers.

## Validation

- `bun test tests/components/normal-components/pin-header-connects-from-cad-layer.test.tsx tests/components/normal-components/pin-header-cad-component.test.tsx tests/components/normal-components/pin-header-female-cad-model.test.tsx tests/components/primitive-components/cadmodel-z-offset-from-surface.test.tsx`
- `bunx biome check lib/components/base-components/NormalComponent/NormalComponent.ts tests/components/normal-components/pin-header-connects-from-cad-layer.test.tsx`
- `bunx tsc --noEmit`
- `git diff origin/main...HEAD --check`
