### PR TITLE
fix: add feed1 alias to folded dipole antennas

### DIFF
--- a/lib/components/normal-components/Antenna.ts
+++ b/lib/components/normal-components/Antenna.ts
@@ -10,7 +10,7 @@ import { getGeneratedAntennaGeometry } from "./get-generated-antenna-geometry"
 
 export class Antenna extends NormalComponent<
   typeof antennaProps,
-  "pin1" | "feed" | "pin2" | "ground" | "gnd" | "feed2"
+  "pin1" | "feed" | "feed1" | "pin2" | "ground" | "gnd" | "feed2"
 > {
   get config() {
     return {
@@ -39,7 +39,7 @@ export class Antenna extends NormalComponent<
     super.initPorts({
       pinCount: secondaryPortRole ? 2 : 1,
       additionalAliases: {
-        pin1: ["feed"],
+        pin1: secondaryPortRole === "feed2" ? ["feed", "feed1"] : ["feed"],
         ...(secondaryPortRole === "ground"
           ? { pin2: ["ground", "gnd"] }
           : secondaryPortRole === "feed2"

--- a/tests/components/normal-components/antenna-generated-shapes.test.tsx
+++ b/tests/components/normal-components/antenna-generated-shapes.test.tsx
@@ -82,6 +82,21 @@ test("antennaShape generates common 2.4 GHz PCB antenna geometries", async () =>
   expect(circuit.db.source_port.list()).toHaveLength(8)
   expect(circuit.db.pcb_missing_footprint_error.list()).toHaveLength(0)
 
+  const foldedDipoleSourceComponent = circuit.db.source_component.getWhere({
+    name: "ANT5",
+  })!
+  const foldedDipoleFeed1 = circuit.db.source_port.getWhere({
+    source_component_id: foldedDipoleSourceComponent.source_component_id,
+    pin_number: 1,
+  })!
+  const foldedDipoleFeed2 = circuit.db.source_port.getWhere({
+    source_component_id: foldedDipoleSourceComponent.source_component_id,
+    pin_number: 2,
+  })!
+  expect(foldedDipoleFeed1.port_hints).toContain("feed")
+  expect(foldedDipoleFeed1.port_hints).toContain("feed1")
+  expect(foldedDipoleFeed2.port_hints).toContain("feed2")
+
   const quarterWaveSourceComponent = circuit.db.source_component.getWhere({
     name: "ANT1",
   })!


### PR DESCRIPTION
## Summary

- add `feed1` as a primary-port alias for folded dipole antennas
- preserve `feed` as the general primary-feed alias
- verify folded dipoles expose `feed`, `feed1`, and `feed2` in source port hints

## Validation

- `bun test tests/components/normal-components/antenna-generated-shapes.test.tsx`
- `bunx tsc --noEmit`

## CI note

The unrelated `repro58-pcb-autolayout-out-of-board` snapshot differs by 0.01%
in test shard 9. It reproduces unchanged on `origin/main` at `c1e8a4ba`; the
antenna test and every other check pass.
