### PR TITLE
fix(schematic-symbol): preserve directional symbol name and rotate ports with schRotation

### DIFF
--- a/lib/components/primitive-components/SchematicSymbol/SchematicSymbol.ts
+++ b/lib/components/primitive-components/SchematicSymbol/SchematicSymbol.ts
@@ -1,10 +1,62 @@
 import { schematicSymbolProps } from "@tscircuit/props"
 import { type SchSymbol, symbols } from "schematic-symbols"
 import { getPinNumberFromLabels } from "../../../utils/getPortFromHints"
+import { getRotatedSymbolName } from "lib/utils/schematic/getRotatedSymbolName"
 import { PrimitiveComponent } from "../../base-components/PrimitiveComponent"
 import { Port } from "../Port"
 import { SchematicSymbol_doInitialSchematicComponentRender } from "./SchematicSymbol_doInitialSchematicComponentRender"
 import { SchematicSymbol_doInitialPortMatching } from "./SchematicSymbol_doInitialPortMatching"
+
+/**
+ * Whether replacing `originalName` with `variantName` (the name
+ * `getRotatedSymbolName` suggests for a `rotation`-degree turn) is
+ * geometrically faithful: every port of the original symbol must land exactly
+ * on the corresponding port of the variant, when rotated by either `+rotation`
+ * or `-rotation` degrees. Directional variants like `..._left`/`..._right` are
+ * mirror images, so e.g. `opamp_with_power_left` rotated 180° does NOT equal
+ * `opamp_with_power_right` (the inverting/non-inverting inputs would not swap).
+ * In that case core must keep the literal symbol and rotate its ports
+ * geometrically instead. Conversely `n_channel_e_mosfet_transistor_horz`
+ * rotated 90° IS `..._vert` (the variant is drawn at -90°), so the existing
+ * name-substitution behavior is preserved for families whose variants are true
+ * rotations.
+ */
+function isRotationFaithful(
+  originalName: keyof typeof symbols,
+  variantName: keyof typeof symbols,
+  rotation: number,
+): boolean {
+  const original = symbols[originalName]
+  const variant = symbols[variantName]
+  if (!original || !variant) return false
+
+  for (const angle of [rotation, -rotation]) {
+    const angleRad = (angle * Math.PI) / 180
+    const cos = Math.cos(angleRad)
+    const sin = Math.sin(angleRad)
+    let allPortsMatch = true
+    for (const port of original.ports) {
+      const dx = port.x - original.center.x
+      const dy = port.y - original.center.y
+      const rotated = {
+        x: original.center.x + dx * cos - dy * sin,
+        y: original.center.y + dx * sin + dy * cos,
+      }
+      const counterpart = variant.ports.find(
+        (variantPort) =>
+          variantPort.labels.some((label) => port.labels.includes(label)) &&
+          Math.abs(variantPort.x - rotated.x) < 1e-6 &&
+          Math.abs(variantPort.y - rotated.y) < 1e-6,
+      )
+      if (!counterpart) {
+        allPortsMatch = false
+        break
+      }
+    }
+    if (allPortsMatch) return true
+  }
+  return false
+}
 
 export class SchematicSymbol extends PrimitiveComponent<
   typeof schematicSymbolProps
@@ -18,6 +70,65 @@ export class SchematicSymbol extends PrimitiveComponent<
       schematicSymbolName: this.props.symbolName,
       zodProps: schematicSymbolProps,
     }
+  }
+
+  /**
+   * Normalized `schRotation` (0-360, multiple of 90). Returns 0 when no
+   * rotation was given.
+   */
+  getNormalizedSchRotation(): number {
+    const { schRotation } = this._parsedProps
+    if (schRotation === undefined) return 0
+    let rotation: number =
+      typeof schRotation === "string" ? parseFloat(schRotation) : schRotation
+    rotation = rotation % 360
+    if (rotation < 0) rotation += 360
+    if (rotation % 90 !== 0) {
+      throw new Error(
+        `Schematic rotation ${schRotation} is not supported for ${this.componentName}`,
+      )
+    }
+    return rotation
+  }
+
+  /**
+   * Returns the rotation that must be applied geometrically to the symbol's
+   * ports (and NOT absorbed by a name substitution). When the rotated name
+   * variant is a faithful geometric rotation, the rotation is absorbed by the
+   * symbol name and this returns 0.
+   */
+  getSchematicRotation(): number {
+    const rotation = this.getNormalizedSchRotation()
+    if (!rotation) return 0
+    const literalName = this._parsedProps.symbolName as keyof typeof symbols
+    if (!literalName) return rotation
+    const rotatedVariant = getRotatedSymbolName(literalName, rotation)
+    if (
+      rotatedVariant &&
+      rotatedVariant !== literalName &&
+      rotatedVariant in symbols &&
+      isRotationFaithful(literalName, rotatedVariant as keyof typeof symbols, rotation)
+    ) {
+      return 0
+    }
+    return rotation
+  }
+
+  _getSchematicSymbolName(): keyof typeof symbols | undefined {
+    const literalName = this._parsedProps.symbolName as keyof typeof symbols
+    if (!literalName) return super._getSchematicSymbolName()
+    const rotation = this.getNormalizedSchRotation()
+    if (!rotation) return literalName
+    const rotatedVariant = getRotatedSymbolName(literalName, rotation)
+    if (
+      rotatedVariant &&
+      rotatedVariant !== literalName &&
+      rotatedVariant in symbols &&
+      isRotationFaithful(literalName, rotatedVariant as keyof typeof symbols, rotation)
+    ) {
+      return rotatedVariant as keyof typeof symbols
+    }
+    return literalName
   }
 
   initPorts(): void {

--- a/lib/components/primitive-components/SchematicSymbol/SchematicSymbol_doInitialSchematicComponentRender.ts
+++ b/lib/components/primitive-components/SchematicSymbol/SchematicSymbol_doInitialSchematicComponentRender.ts
@@ -32,6 +32,8 @@ export const SchematicSymbol_doInitialSchematicComponentRender = (
   schematicSymbol.schematic_component_id =
     schematicComponent.schematic_component_id
 
+  const rotation = schematicSymbol.getSchematicRotation()
+
   for (const symbolPort of symbol.ports) {
     const port = schematicSymbol.getPortForSymbolPort(symbolPort)
     if (!port?.source_port_id) {
@@ -39,9 +41,22 @@ export const SchematicSymbol_doInitialSchematicComponentRender = (
         `Missing source port for schematic symbol port "${symbolPort.labels.join("/")}" on ${schematicSymbol.getString()}`,
       )
     }
-    const portCenter = {
-      x: center.x + symbolPort.x - symbol.center.x,
-      y: center.y + symbolPort.y - symbol.center.y,
+    let portCenter = {
+      x: symbolPort.x - symbol.center.x,
+      y: symbolPort.y - symbol.center.y,
+    }
+    if (rotation) {
+      const angleRad = (rotation * Math.PI) / 180
+      const cos = Math.cos(angleRad)
+      const sin = Math.sin(angleRad)
+      portCenter = {
+        x: portCenter.x * cos - portCenter.y * sin,
+        y: portCenter.x * sin + portCenter.y * cos,
+      }
+    }
+    portCenter = {
+      x: center.x + portCenter.x,
+      y: center.y + portCenter.y,
     }
 
     const schematicPort = db.schematic_port.insert({

--- a/tests/components/primitive-components/schematic-symbol-3520.test.tsx
+++ b/tests/components/primitive-components/schematic-symbol-3520.test.tsx
@@ -1,0 +1,104 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+async function renderOpamp(rotation: number) {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm">
+      <chip
+        name="U"
+        pinLabels={{
+          pin1: "IN_PLUS",
+          pin2: "IN_MINUS",
+          pin3: "V_MINUS",
+          pin4: "OUT",
+          pin5: "V_PLUS",
+        }}
+        noSchematicRepresentation
+      />
+      <schematicsymbol
+        name="U1"
+        chipRef=".U"
+        symbolName="opamp_with_power_left"
+        schRotation={rotation}
+        connections={{
+          inp1: "U.IN_PLUS",
+          inp2: "U.IN_MINUS",
+          out: "U.OUT",
+          "V-": "U.V_PLUS",
+          "V+": "U.V_MINUS",
+        }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const soup = circuit.getCircuitJson()
+  const ports = soup.filter((el: any) => el.type === "schematic_port") as any[]
+
+  const portByLabel = (label: string) =>
+    ports.find((p) => p.display_pin_label === label)
+
+  return {
+    symbolName: (soup.find((el: any) => el.type === "schematic_component") as any)
+      .symbol_name,
+    inp1: portByLabel("inp1"),
+    inp2: portByLabel("inp2"),
+  }
+}
+
+test("schematic-symbol #3520: schRotation=180 preserves directional name and rotates ports geometrically", async () => {
+  const rot0 = await renderOpamp(0)
+  const rot180 = await renderOpamp(180)
+
+  // The directional symbol name must be preserved (NOT substituted with the
+  // mirrored variant `opamp_with_power_right`, which would lose the rotation)
+  expect(rot180.symbolName).toBe("opamp_with_power_left")
+
+  expect(rot0.inp1).toBeDefined()
+  expect(rot0.inp2).toBeDefined()
+  expect(rot180.inp1).toBeDefined()
+  expect(rot180.inp2).toBeDefined()
+
+  // A true 180° rotation flips the vertical order of the two input ports.
+  // With schRotation=0 inp1 and inp2 have one ordering; with 180° the sign of
+  // (inp1.y - inp2.y) must invert.
+  const order0 = rot0.inp1.center.y - rot0.inp2.center.y
+  const order180 = rot180.inp1.center.y - rot180.inp2.center.y
+
+  expect(Math.sign(order0)).not.toBe(0)
+  expect(Math.sign(order180)).toBe(-Math.sign(order0))
+})
+
+test("schematic-symbol #3520: faithful rotation family (mosfet horz->vert) still substitutes the name", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm">
+      <chip
+        name="Q"
+        pinLabels={{ pin1: "G", pin2: "D", pin3: "S" }}
+        noSchematicRepresentation
+      />
+      <schematicsymbol
+        name="Q1"
+        chipRef=".Q"
+        symbolName="n_channel_e_mosfet_transistor_horz"
+        schRotation={90}
+        connections={{
+          gate: "Q.G",
+          drain: "Q.D",
+          source: "Q.S",
+        }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const soup = circuit.getCircuitJson()
+  const comp = soup.find((el: any) => el.type === "schematic_component") as any
+  expect(comp.symbol_name).toBe("n_channel_e_mosfet_transistor_vert")
+})


### PR DESCRIPTION
## Summary

Fixes #3520.

When `schRotation` was set on a `<schematicsymbol>` whose `symbolName` has a directional variant (e.g. `opamp_with_power_left`), core **substituted the name** with the "rotated" variant (`opamp_with_power_right` for 180°) — but directional variants are **mirror images, not true rotations**: rotating `opamp_with_power_left` by 180° does NOT produce `opamp_with_power_right` (the `+`/`-` inputs would not swap). The requested rotation was silently lost.

## Changes

- `SchematicSymbol._getSchematicSymbolName()`: preserves the **literal** `symbolName` when the rotated variant is not a faithful geometric rotation of the original.
- `SchematicSymbol_doInitialSchematicComponentRender`: rotates the symbol ports **geometrically** by `schRotation` when the rotation is not absorbed by the name.
- `isRotationFaithful()`: checks whether every port of the original symbol lands exactly on the corresponding port of the variant when rotated by `+rotation` or `-rotation` (directional variants fail this check).
- For families whose variants ARE true rotations (`n_channel_e_mosfet_transistor_horz` → `_vert` at -90°), the existing name-substitution behavior is preserved.

## Test

- `schematic-symbol-3520.test.tsx`: 
  - `opamp_with_power_left` + `schRotation={180}` keeps `symbol_name` and **inverts the vertical order of inp1/inp2** (true 180° rotation), compared against `schRotation={0}`.
  - `n_channel_e_mosfet_transistor_horz` + `schRotation={90}` still resolves to `_vert` (faithful family unchanged).
