### PR TITLE
fix(netlabel): preserve projection identity for shared schematicsymbol ports

### DIFF
--- a/lib/components/primitive-components/NetLabel.ts
+++ b/lib/components/primitive-components/NetLabel.ts
@@ -92,8 +92,17 @@ export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
     if (props.schX === undefined && props.schY === undefined) {
       const connectedPorts = this._getConnectedPorts()
       if (connectedPorts.length > 0) {
-        const portPos =
-          connectedPorts[0]._getGlobalSchematicPositionBeforeLayout()
+        // For ports whose schematic position comes from a schematicsymbol
+        // projection (schematicSymbolPortDef), the pre-layout position is not
+        // available until the symbol's schematic ports have been created. Use
+        // the rendered schematic_port center when available, and fall back to
+        // the pre-layout position otherwise (e.g. plain schematic boxes).
+        let portPos = this._tryGetPortSchematicPosition(
+          connectedPorts[0],
+        )
+        if (!portPos) {
+          portPos = connectedPorts[0]._getGlobalSchematicPositionBeforeLayout()
+        }
         const parentCenter = applyToPoint(
           this.parent?.computeSchematicGlobalTransform?.() ?? identity(),
           { x: 0, y: 0 },
@@ -103,6 +112,36 @@ export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
     }
 
     return super.computeSchematicPropsTransform()
+  }
+
+  /**
+   * Best-effort schematic position of a port: prefer the already-rendered
+   * schematic_port row (set during SchematicComponentRender), then the
+   * schematic box / schematicsymbol pre-layout position. Returns null when
+   * the port has no position computable yet.
+   */
+  _tryGetPortSchematicPosition(port: Port): { x: number; y: number } | null {
+    if (port.schematic_port_id) {
+      const schematicPort = this.root?.db.schematic_port.get(
+        port.schematic_port_id,
+      )
+      if (schematicPort?.center) return schematicPort.center
+    }
+
+    if (port.schematicSymbolPortDef) {
+      const symbol = port.schematicSymbolPortDef
+      const parentNormalComponent = port.getParentNormalComponent()
+      if (parentNormalComponent) {
+        try {
+          const transform = parentNormalComponent.computeSchematicGlobalTransform()
+          return applyToPoint(transform, symbol) as { x: number; y: number }
+        } catch {
+          return null
+        }
+      }
+    }
+
+    return null
   }
 
   doInitialSchematicPrimitiveRender(): void {
@@ -198,7 +237,25 @@ export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
     if (this.getCollapsedSchematicBoxAncestor()) return
     if (this._parsedProps.inline) return
     const { schX, schY } = this._parsedProps
-    if (schX === undefined && schY === undefined) return
+    if (schX === undefined && schY === undefined) {
+      // Coordinate-free netlabels still represent a connection: mark the
+      // connected schematic port(s) as connected so the projection identity
+      // is preserved even without an explicit anchor (issue #3505).
+      const connectsTo = this._resolveConnectsTo()
+      if (connectsTo) {
+        const { db } = this.root!
+        for (const connection of connectsTo) {
+          const port = this.getSubcircuit().selectOne(connection, {
+            type: "port",
+          }) as Port | null
+          if (!port?.schematic_port_id) continue
+          db.schematic_port.update(port.schematic_port_id, {
+            is_connected: true,
+          })
+        }
+      }
+      return
+    }
 
     const { db } = this.root!
     const connectsTo = this._resolveConnectsTo()
@@ -228,6 +285,13 @@ export class NetLabel extends PrimitiveComponent<typeof netLabelProps> {
         type: "port",
       }) as Port | null
       if (!port || !port.schematic_port_id) continue
+
+      // This netlabel visually represents the connection, so mark this
+      // projection's schematic port connected even when a trace already
+      // exists for the shared source port (e.g. two schematicsymbol
+      // projections of the same dual op-amp power pin: both must show as
+      // connected, not just the first one).
+      db.schematic_port.update(port.schematic_port_id, { is_connected: true })
 
       // If a schematic trace for this connection already exists, skip
       let existingTraceForThisConnection = false

--- a/tests/components/primitive-components/schematic-symbol-3505.test.tsx
+++ b/tests/components/primitive-components/schematic-symbol-3505.test.tsx
@@ -1,0 +1,147 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+type NetLabel = {
+  center?: { x?: number; y?: number }
+  text?: string
+}
+type SchematicPort = {
+  display_pin_label?: string
+  is_connected?: boolean
+}
+
+async function renderDualOpamp(opts: {
+  explicitLabelCoords: boolean
+}) {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm">
+      <net name="V5" isPowerNet />
+      <net name="GND" isGroundNet />
+
+      <chip
+        name="U3"
+        footprint="soic8"
+        noSchematicRepresentation
+        pinLabels={{
+          pin1: "OUT_A",
+          pin2: "IN-_A",
+          pin3: "IN+_A",
+          pin4: "V-",
+          pin5: "IN+_B",
+          pin6: "IN-_B",
+          pin7: "OUT_B",
+          pin8: "V+",
+        }}
+      />
+
+      <schematicsymbol
+        name="U3A"
+        chipRef=".U3"
+        symbolName="opamp_with_power_right"
+        connections={{
+          inp1: "U3.pin3",
+          inp2: "U3.pin2",
+          out: "U3.pin1",
+          "V+": "U3.pin8",
+          "V-": "U3.pin4",
+        }}
+        schX={0}
+        schY={0}
+      />
+      <schematicsymbol
+        name="U3B"
+        chipRef=".U3"
+        symbolName="opamp_with_power_right"
+        connections={{
+          inp1: "U3.pin5",
+          inp2: "U3.pin6",
+          out: "U3.pin7",
+          "V+": "U3.pin8",
+          "V-": "U3.pin4",
+        }}
+        schX={5}
+        schY={0}
+      />
+
+      <netlabel
+        net="V5"
+        connection="U3A.pin5"
+        anchorSide="bottom"
+        {...(opts.explicitLabelCoords ? { schX: -0.03, schY: 0.39 } : {})}
+      />
+      <netlabel
+        net="GND"
+        connection="U3A.pin3"
+        anchorSide="top"
+        {...(opts.explicitLabelCoords ? { schX: -0.02, schY: -0.39 } : {})}
+      />
+      <netlabel
+        net="V5"
+        connection="U3B.pin5"
+        anchorSide="bottom"
+        {...(opts.explicitLabelCoords ? { schX: 4.97, schY: 0.39 } : {})}
+      />
+      <netlabel
+        net="GND"
+        connection="U3B.pin3"
+        anchorSide="top"
+        {...(opts.explicitLabelCoords ? { schX: 4.98, schY: -0.39 } : {})}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const soup = circuit.getCircuitJson()
+  const labels = soup.filter(
+    (el: any) => el.type === "schematic_net_label",
+  ) as NetLabel[]
+  const ports = soup.filter(
+    (el: any) => el.type === "schematic_port",
+  ) as SchematicPort[]
+
+  return { labels, ports }
+}
+
+test("#3505: coordinate-free netlabel on shared schematicsymbol projection does not throw", async () => {
+  const { labels, ports } = await renderDualOpamp({
+    explicitLabelCoords: false,
+  })
+
+  // Render must not throw: every netlabel has a position
+  expect(labels.length).toBeGreaterThanOrEqual(4)
+  for (const label of labels) {
+    expect(label?.center).toBeDefined()
+    expect(Number.isFinite(label.center!.x)).toBe(true)
+    expect(Number.isFinite(label.center!.y)).toBe(true)
+  }
+
+  // Both projections' shared power/ground ports must be marked connected
+  const v5Ports = ports.filter(
+    (p) => p.display_pin_label === "V+" || p.display_pin_label === "V-",
+  )
+  expect(v5Ports.length).toBe(4)
+  for (const port of v5Ports) {
+    expect(port.is_connected).toBe(true)
+  }
+})
+
+test("#3505: explicit-coordinate netlabel marks BOTH projections' shared power ports connected", async () => {
+  const { labels, ports } = await renderDualOpamp({
+    explicitLabelCoords: true,
+  })
+
+  expect(labels.length).toBeGreaterThanOrEqual(4)
+
+  // Both U3A and U3B V+/V- schematic ports must be connected (previously
+  // only the first projection was marked; the second stayed false)
+  const v5Ports = ports.filter(
+    (p) => p.display_pin_label === "V+" || p.display_pin_label === "V-",
+  )
+  expect(v5Ports.length).toBe(4)
+  for (const port of v5Ports) {
+    expect(port.is_connected).toBe(true)
+  }
+})


### PR DESCRIPTION
## Summary

Fixes #3505.

Two problems when netlabels connect to schematicsymbol projections that share physical source ports (e.g. both units of a dual op-amp mapping V+/V- to the same chip pins):

### 1. Coordinate-free netlabels crashed

`<netlabel net="V5" connection="U3A.pin5" />` (no `schX`/`schY`) threw `Couldn't find position for schematic_port` from `NetLabel.computeSchematicPropsTransform`, because the pre-layout position of a schematicsymbol projection port is not available at that phase.

**Fix:** use the already-rendered `schematic_port.center` when available, falling back to the pre-layout position (plain schematic boxes).

### 2. Only one projection's shared power/ground port was marked connected

The second projection's V+/V- `schematic_port.is_connected` stayed `false` because an existing source_trace caused an early `continue` before the update.

**Fix:** mark the projection port connected whenever its netlabel resolves, even when the trace already exists; coordinate-free netlabels also mark their connected ports.

## Tests

- `schematic-symbol-3505.test.tsx` — dual op-amp (U3A/U3B) with shared V+/V- pins:
  - coordinate-free netlabels render (no throw) and all 4 V+/V- schematic ports are connected;
  - explicit-coordinate netlabels mark both projections' shared power ports connected.

## Verification

- New tests pass (2/2).
- Existing `netlabel*` tests: no new failures (the 2 pre-existing failures on `main`, `netlabel-center` snapshot 0.02% and `netlabel-connection` timeout, reproduce unchanged without this patch).
