### PR TITLE
Update @tscircuit/schematic-trace-solver to 5a5b2a6

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
     "@tscircuit/props": "^0.0.644",
     "@tscircuit/schematic-match-adapt": "^0.0.18",
-    "@tscircuit/schematic-trace-solver": "^0.0.174",
+    "@tscircuit/schematic-trace-solver": "github:tscircuit/schematic-trace-solver#5a5b2a60ac410381475e92881ffb857bcc8e9098",
     "@tscircuit/solver-utils": "^0.0.16",
     "@tscircuit/soup-util": "^0.0.41",
     "@tscircuit/winding-breakout-point-solver": "github:tscircuit/winding-breakout-point-solver#202dbe9eb0088633b6fa094120dba6f2f41f8803",


### PR DESCRIPTION
### Motivation
- Use the schematic trace solver changes from PR #1015 in Core.

### Before
- Core used the published `^0.0.174` solver dependency.

### After
- Core pins `@tscircuit/schematic-trace-solver` to PR #1015 head commit `5a5b2a6`.