### PR TITLE
chore: update schematic trace solver to 0.0.175

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
     "@tscircuit/props": "^0.0.644",
     "@tscircuit/schematic-match-adapt": "^0.0.18",
-    "@tscircuit/schematic-trace-solver": "^0.0.174",
+    "@tscircuit/schematic-trace-solver": "^0.0.175",
     "@tscircuit/solver-utils": "^0.0.16",
     "@tscircuit/soup-util": "^0.0.41",
     "@tscircuit/winding-breakout-point-solver": "github:tscircuit/winding-breakout-point-solver#202dbe9eb0088633b6fa094120dba6f2f41f8803",


### PR DESCRIPTION
## Summary

- update @tscircuit/schematic-trace-solver from ^0.0.174 to ^0.0.175

## Testing

- Not run (per request; dependency-only update)