### PR TITLE
chore: update copper pour solver to 0.0.52

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@tscircuit/checks": "^0.0.180",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",
-    "@tscircuit/copper-pour-solver": "^0.0.51",
+    "@tscircuit/copper-pour-solver": "^0.0.52",
     "@tscircuit/create-fdm-enclosure": "0.0.4",
     "@tscircuit/fanout-solver": "0.0.54",
     "@tscircuit/footprinter": "^0.0.426",


### PR DESCRIPTION
## Why

Version 0.0.52 of @tscircuit/copper-pour-solver adds copper-pour handling for oval plated holes. Earlier versions omitted oval pcb_plated_hole geometry when building the solver input, so a different-net copper pour could extend into the required clearance around elongated through-hole pads.

Updating core ensures boards with oval plated holes receive the configured copper clearance and thermal-relief behavior without board-specific keepouts. This is especially relevant for elongated battery contacts and similar through-hole terminals.

Upstream solver change: https://github.com/tscircuit/copper-pour-solver/pull/86

## What changed

- Update @tscircuit/copper-pour-solver from ^0.0.51 to ^0.0.52.
- Keep the existing dependency range convention used by core.

## Validation

- Confirmed 0.0.52 is the npm latest dist-tag and highest published version.
- Installed the 0.0.52 tarball locally and verified the solver exports used by core load successfully.
- git diff --check passes.
- PR CI format, smoke-test, type-check, and test shards 1-8 and 10 pass.
- The copper-pour test executed in shard 9 passes.

Test shard 9 also runs tests/features/schematic-sheet/schematic-sheet-missing-warning.test.tsx, which fails because the fixture now emits an additional missing_reference_designator_text warning. The same test fails with the identical output on the immediately preceding main commit, so this is an existing base-branch failure unrelated to the copper-pour solver update:
https://github.com/tscircuit/core/actions/runs/33656020232/job/100334643685