### PR TITLE
test: scope schematic sheet warning assertions

### DIFF
--- a/tests/features/schematic-sheet/schematic-sheet-missing-warning.test.tsx
+++ b/tests/features/schematic-sheet/schematic-sheet-missing-warning.test.tsx
@@ -14,13 +14,13 @@ test("warns when a schematic has no schematic sheet", async () => {
 
   expect(
     circuitWithoutSheet.db.schematic_component_styling_warning.list(),
-  ).toEqual([
+  ).toContainEqual(
     expect.objectContaining({
       warning_type: "schematic_component_styling_warning",
       styling_issue_type: "missing_schematic_sheet",
       message: expect.stringContaining("No <schematicsheet> was found"),
     }),
-  ])
+  )
 
   const { circuit: circuitWithSheet } = getTestFixture()
   circuitWithSheet.add(
@@ -61,11 +61,11 @@ test("warns when a schematic has no schematic sheet", async () => {
 
   await assemblyCircuit.renderUntilSettled()
 
-  expect(assemblyCircuit.db.schematic_component_styling_warning.list()).toEqual(
-    [
-      expect.objectContaining({
-        styling_issue_type: "missing_schematic_sheet",
-      }),
-    ],
+  expect(
+    assemblyCircuit.db.schematic_component_styling_warning.list(),
+  ).toContainEqual(
+    expect.objectContaining({
+      styling_issue_type: "missing_schematic_sheet",
+    }),
   )
 })

--- a/tests/features/schematic-sheet/schematic-sheet-missing-warning.test.tsx
+++ b/tests/features/schematic-sheet/schematic-sheet-missing-warning.test.tsx
@@ -12,15 +12,20 @@ test("warns when a schematic has no schematic sheet", async () => {
 
   await circuitWithoutSheet.renderUntilSettled()
 
-  expect(
-    circuitWithoutSheet.db.schematic_component_styling_warning.list(),
-  ).toContainEqual(
+  const circuitWithoutSheetMissingSchematicSheetWarnings =
+    circuitWithoutSheet.db.schematic_component_styling_warning
+      .list()
+      .filter(
+        ({ styling_issue_type }) =>
+          styling_issue_type === "missing_schematic_sheet",
+      )
+  expect(circuitWithoutSheetMissingSchematicSheetWarnings).toEqual([
     expect.objectContaining({
       warning_type: "schematic_component_styling_warning",
       styling_issue_type: "missing_schematic_sheet",
       message: expect.stringContaining("No <schematicsheet> was found"),
     }),
-  )
+  ])
 
   const { circuit: circuitWithSheet } = getTestFixture()
   circuitWithSheet.add(
@@ -33,9 +38,14 @@ test("warns when a schematic has no schematic sheet", async () => {
 
   await circuitWithSheet.renderUntilSettled()
 
-  expect(
-    circuitWithSheet.db.schematic_component_styling_warning.list(),
-  ).toEqual([])
+  const circuitWithSheetMissingSchematicSheetWarnings =
+    circuitWithSheet.db.schematic_component_styling_warning
+      .list()
+      .filter(
+        ({ styling_issue_type }) =>
+          styling_issue_type === "missing_schematic_sheet",
+      )
+  expect(circuitWithSheetMissingSchematicSheetWarnings).toEqual([])
 
   const { circuit: schematicDisabledCircuit } = getTestFixture()
   schematicDisabledCircuit.add(
@@ -46,9 +56,14 @@ test("warns when a schematic has no schematic sheet", async () => {
 
   await schematicDisabledCircuit.renderUntilSettled()
 
-  expect(
-    schematicDisabledCircuit.db.schematic_component_styling_warning.list(),
-  ).toEqual([])
+  const schematicDisabledCircuitMissingSchematicSheetWarnings =
+    schematicDisabledCircuit.db.schematic_component_styling_warning
+      .list()
+      .filter(
+        ({ styling_issue_type }) =>
+          styling_issue_type === "missing_schematic_sheet",
+      )
+  expect(schematicDisabledCircuitMissingSchematicSheetWarnings).toEqual([])
 
   const { circuit: assemblyCircuit } = getTestFixture()
   assemblyCircuit.add(
@@ -61,11 +76,16 @@ test("warns when a schematic has no schematic sheet", async () => {
 
   await assemblyCircuit.renderUntilSettled()
 
-  expect(
-    assemblyCircuit.db.schematic_component_styling_warning.list(),
-  ).toContainEqual(
+  const assemblyCircuitMissingSchematicSheetWarnings =
+    assemblyCircuit.db.schematic_component_styling_warning
+      .list()
+      .filter(
+        ({ styling_issue_type }) =>
+          styling_issue_type === "missing_schematic_sheet",
+      )
+  expect(assemblyCircuitMissingSchematicSheetWarnings).toEqual([
     expect.objectContaining({
       styling_issue_type: "missing_schematic_sheet",
     }),
-  )
+  ])
 })


### PR DESCRIPTION
## Why

The Bun Test workflow on main is failing in tests/features/schematic-sheet/schematic-sheet-missing-warning.test.tsx. The test verifies whether circuits emit missing_schematic_sheet warnings, but it previously asserted against the complete schematic styling-warning table.

The fixtures can also emit a valid missing_reference_designator_text warning for R1. That independent warning made the test fail even though the missing_schematic_sheet behavior under test was correct. In the first CI follow-up, the same issue appeared in the with-sheet case because the full warning table was still expected to be empty.

Original failing main job: https://github.com/tscircuit/core/actions/runs/33656020232/job/100334643685
Follow-up CI evidence: https://github.com/tscircuit/core/actions/runs/33661816907/job/100353903234

<img width="608" height="382" alt="image" src="https://github.com/user-attachments/assets/0c1a3589-0baf-46e4-aeee-3bc051adc267" />
<img width="657" height="478" alt="image" src="https://github.com/user-attachments/assets/d06f6b53-1e3e-46bc-9cf5-4e8ba00bc935" />


## What changed

- Filter schematic styling warnings by styling_issue_type === missing_schematic_sheet before asserting.
- Continue to require exactly one missing-sheet warning for circuits without a sheet.
- Continue to require zero missing-sheet warnings when a sheet exists or schematic rendering is disabled.

This keeps the assertions strict for the behavior the test owns without coupling them to independent styling diagnostics.

## Validation

- bun test tests/features/schematic-sheet/schematic-sheet-missing-warning.test.tsx
- Full node 9 test-plan sequence confirms the schematic-sheet test passes in the CI ordering.
- bunx tsc --noEmit
- Biome formatting
- git diff --check