### PR TITLE
chore: update @tscircuit/checks to 0.0.181

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/bga-fanout-solver": "github:tscircuit/bga-fanout-solver#247c835cb8d69b65e53891dcf869731079415b39",
     "@tscircuit/capacity-autorouter": "^0.0.866",
-    "@tscircuit/checks": "^0.0.180",
+    "@tscircuit/checks": "^0.0.181",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "^0.0.51",


### PR DESCRIPTION
## Summary
- update `@tscircuit/checks` from `^0.0.180` to `^0.0.181`
- pick up the plated-hole pill clearance geometry fix from tscircuit/checks#257

## Testing
- Not run, per request (dependency-only change)