### PR TITLE
scope schematic sheet assertions to missing sheet warnings

### DIFF
--- a/tests/features/schematic-sheet/schematic-sheet-missing-warning.test.tsx
+++ b/tests/features/schematic-sheet/schematic-sheet-missing-warning.test.tsx
@@ -14,13 +14,13 @@ test("warns when a schematic has no schematic sheet", async () => {
 
   expect(
     circuitWithoutSheet.db.schematic_component_styling_warning.list(),
-  ).toEqual([
+  ).toContainEqual(
     expect.objectContaining({
       warning_type: "schematic_component_styling_warning",
       styling_issue_type: "missing_schematic_sheet",
       message: expect.stringContaining("No <schematicsheet> was found"),
     }),
-  ])
+  )
 
   const { circuit: circuitWithSheet } = getTestFixture()
   circuitWithSheet.add(
@@ -35,7 +35,11 @@ test("warns when a schematic has no schematic sheet", async () => {
 
   expect(
     circuitWithSheet.db.schematic_component_styling_warning.list(),
-  ).toEqual([])
+  ).not.toContainEqual(
+    expect.objectContaining({
+      styling_issue_type: "missing_schematic_sheet",
+    }),
+  )
 
   const { circuit: schematicDisabledCircuit } = getTestFixture()
   schematicDisabledCircuit.add(
@@ -61,11 +65,11 @@ test("warns when a schematic has no schematic sheet", async () => {
 
   await assemblyCircuit.renderUntilSettled()
 
-  expect(assemblyCircuit.db.schematic_component_styling_warning.list()).toEqual(
-    [
-      expect.objectContaining({
-        styling_issue_type: "missing_schematic_sheet",
-      }),
-    ],
+  expect(
+    assemblyCircuit.db.schematic_component_styling_warning.list(),
+  ).toContainEqual(
+    expect.objectContaining({
+      styling_issue_type: "missing_schematic_sheet",
+    }),
   )
 })


### PR DESCRIPTION
### Motivation
- Keep the missing-sheet test focused on whether that warning is emitted.

### Before
- The test required the complete warning list to contain only missing-sheet warnings, so a valid missing-reference-designator warning failed CI.

### After
- The test checks for the presence or absence of the missing-sheet warning while preserving the strict schematic-disabled assertion.