### PR TITLE
Update fanout solver to 0.0.55

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "^0.0.52",
     "@tscircuit/create-fdm-enclosure": "0.0.4",
-    "@tscircuit/fanout-solver": "0.0.54",
+    "@tscircuit/fanout-solver": "0.0.55",
     "@tscircuit/footprinter": "^0.0.426",
     "@tscircuit/image-utils": "^0.0.8",
     "@tscircuit/implicit-copper-pour-solver": "github:tscircuit/implicit-copper-pour-solver#d880f80e4eb7a34d5da5a521f10a63c810d4728b",


### PR DESCRIPTION
## Summary

- update @tscircuit/fanout-solver from 0.0.54 to 0.0.55
- pick up browser-safe handling for runtimes without the Node process global
- prevent dense fanout routing on tscircuit.com from aborting with process is not defined

Upstream fix: https://github.com/tscircuit/fanout-solver/pull/150

## Validation

- bunx tsc --noEmit
- bun run build
- 5 focused fanout and global-routing tests passed