### PR TITLE
chore: update @tscircuit/checks to 0.0.182

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/bga-fanout-solver": "github:tscircuit/bga-fanout-solver#247c835cb8d69b65e53891dcf869731079415b39",
     "@tscircuit/capacity-autorouter": "^0.0.866",
-    "@tscircuit/checks": "^0.0.181",
+    "@tscircuit/checks": "^0.0.182",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "^0.0.52",


### PR DESCRIPTION
## Summary
- Bump @tscircuit/checks from ^0.0.181 to ^0.0.182.
- Consume the owned-footprint-cutout placement fix and outline-keepout compatibility fix from https://github.com/tscircuit/checks/pull/259.
- Dependency-only update; no source or test changes.

## Validation
- Confirmed 0.0.182 is the latest published version and its release commit includes checks#259.
- git diff --check passed.
- Core tests not run, as requested earlier.