### PR TITLE
fix: carry the component rotation on hole_with_polygon_pad plated holes

### DIFF
--- a/lib/components/primitive-components/PlatedHole.ts
+++ b/lib/components/primitive-components/PlatedHole.ts
@@ -352,6 +352,7 @@ export class PlatedHole extends PrimitiveComponent<typeof platedHoleProps> {
         hole_width: props.holeWidth,
         hole_height: props.holeHeight,
         pad_outline: padOutline,
+        ccw_rotation: finalRotationDegrees,
         hole_offset_x:
           typeof props.holeOffsetX === "number"
             ? props.holeOffsetX

--- a/tests/components/primitive-components/pcb-hole-with-polygon-pad-rotation.test.tsx
+++ b/tests/components/primitive-components/pcb-hole-with-polygon-pad-rotation.test.tsx
@@ -1,0 +1,66 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("pcb plated hole with polygon pad carries the component rotation", async () => {
+  const { circuit } = getTestFixture()
+
+  const footprint = (
+    <footprint>
+      <platedhole
+        portHints={["pin1"]}
+        pcbX={3}
+        pcbY={0}
+        shape="hole_with_polygon_pad"
+        holeShape="circle"
+        holeDiameter={1}
+        holeOffsetX={0}
+        holeOffsetY={0}
+        padOutline={[
+          { x: -2, y: -0.5 },
+          { x: 2, y: -0.5 },
+          { x: 2, y: 0.5 },
+          { x: -2, y: 0.5 },
+        ]}
+      />
+      <platedhole
+        portHints={["pin2"]}
+        pcbX={-3}
+        pcbY={0}
+        shape="circular_hole_with_rect_pad"
+        holeDiameter={1}
+        rectPadWidth={4}
+        rectPadHeight={1}
+      />
+    </footprint>
+  )
+
+  circuit.add(
+    <board width={20} height={20}>
+      <chip name="U1" footprint={footprint} pcbRotation={90} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const holes = circuit.db.pcb_plated_hole.list()
+  const polygonHole = holes.find((h) => h.shape === "hole_with_polygon_pad")!
+  const rectHole = holes.find((h) => h.shape === "circular_hole_with_rect_pad")!
+
+  // both holes are moved by the component rotation
+  expect(polygonHole.x).toBeCloseTo(0, 6)
+  expect(polygonHole.y).toBeCloseTo(3, 6)
+  expect(rectHole.x).toBeCloseTo(0, 6)
+  expect(rectHole.y).toBeCloseTo(-3, 6)
+
+  // the rect pad already carried the rotation, the polygon pad did not
+  expect((rectHole as any).rect_ccw_rotation).toBe(90)
+  expect((polygonHole as any).ccw_rotation).toBe(90)
+
+  // pad_outline stays relative to the hole position, unrotated
+  expect((polygonHole as any).pad_outline).toEqual([
+    { x: -2, y: -0.5 },
+    { x: 2, y: -0.5 },
+    { x: 2, y: 0.5 },
+    { x: -2, y: 0.5 },
+  ])
+})


### PR DESCRIPTION
Fixes #3647

## Summary

`PlatedHole.ts` emits the component rotation for every plated hole shape (`ccw_rotation`, `rect_ccw_rotation`, `hole_ccw_rotation`) except `hole_with_polygon_pad`, whose branch inserted `pad_outline` unrotated and no `ccw_rotation`. A rotated component therefore had its polygon pads drawn, checked and exported unrotated by every consumer.

This adds `ccw_rotation: finalRotationDegrees` to the emitted record, the same way the oval/pill branch does. `pad_outline` stays relative to the hole position, which is what the circuit-json schema and the consumers (checks board-edge clearance, KiCad export, bounds) expect.

## Test

`tests/components/primitive-components/pcb-hole-with-polygon-pad-rotation.test.tsx`: a chip rotated by 90 degrees with a polygon-pad hole and a rect-pad hole; both positions rotate, the rect pad has `rect_ccw_rotation: 90`, the polygon pad now has `ccw_rotation: 90` and its outline is unchanged. Fails on `main` (`ccw_rotation` is `undefined`). The existing `pcb-hole-with-polygon-pad` snapshot is unchanged (rotation 0).

## Verification

- `bun test tests/components/primitive-components/pcb-hole-with-polygon-pad*.test.tsx`
- `bunx tsc --noEmit`
- `biome format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Tbs6mJUsouNVBTYJndPuf