### PR TITLE
chore: update capacity autorouter to 0.0.874

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/bga-fanout-solver": "github:tscircuit/bga-fanout-solver#247c835cb8d69b65e53891dcf869731079415b39",
-    "@tscircuit/capacity-autorouter": "^0.0.866",
+    "@tscircuit/capacity-autorouter": "^0.0.874",
     "@tscircuit/checks": "^0.0.182",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

- update `@tscircuit/capacity-autorouter` from `^0.0.866` to `^0.0.874`
- keep the existing peer dependency contract unchanged

## Validation

- `bunx tsc --noEmit`
- `bun run build`
- `bun test tests/utils/autorouting/capacity-mesh-autorouter` — 4 passed, 0 failed
- full `bun test` — 1,510 passed, 40 skipped, 2 unrelated snapshot-format failures

The two full-suite failures compare the same near-zero value rendered in exponential versus decimal notation in silkscreen snapshots. Both failures reproduce with the previous `@tscircuit/capacity-autorouter@0.0.866`, confirming they are unrelated to this dependency update.