### PR TITLE
fix: expose autorouter cache decisions

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -1288,14 +1288,17 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
 
     let previousStageOutputSimpleRouteJson: SimpleRouteJson | undefined
 
-    for (const {
-      routingPhasePlan,
-      autorouterConfig: phaseAutorouterConfig,
-      strategy: localAutorouterStrategy,
-      usesPreviousStageOutput,
-      phaseStageIndex,
-      phaseStageCount,
-    } of routingStages) {
+    for (const [
+      routingStageIndex,
+      {
+        routingPhasePlan,
+        autorouterConfig: phaseAutorouterConfig,
+        strategy: localAutorouterStrategy,
+        usesPreviousStageOutput,
+        phaseStageIndex,
+        phaseStageCount,
+      },
+    ] of routingStages.entries()) {
       if (!usesPreviousStageOutput) {
         previousStageOutputSimpleRouteJson = undefined
       }
@@ -1493,7 +1496,81 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         ;(global as any).debugGraphics?.push(graphicsObject)
       }
 
+      const autorouterVersion =
+        phaseAutorouterConfig.autorouterVersion ?? this.props.autorouterVersion
+      const effortLevel = this.props.autorouterEffortLevel
+      const effort = effortLevel
+        ? Number.parseInt(effortLevel.replace("x", ""), 10)
+        : undefined
+      const commonAutorouterOptions: AutorouterOptions = {
+        capacityDepth: phaseAutorouterConfig.capacityDepth,
+        targetMinCapacity: phaseAutorouterConfig.targetMinCapacity,
+        platformConfig: this.root?.platform,
+        useAssignableSolver: phaseIsLaserPrefabPreset || isSingleLayerBoard,
+        useAutoJumperSolver: phaseIsAutoJumperPreset,
+        useLaserPrefabSolver: phaseIsLaserPrefabPreset,
+        autorouterVersion,
+        effort,
+      }
+      const autorouterName = phaseAutorouterConfig.algorithmFn
+        ? "custom"
+        : localAutorouterStrategy.name
+      const solverName = phaseAutorouterConfig.algorithmFn
+        ? undefined
+        : localAutorouterStrategy.getSolverName(commonAutorouterOptions)
+      const localAutoroutingCacheSolverOptions = {
+        autorouterName,
+        solverName,
+        capacityDepth: commonAutorouterOptions.capacityDepth,
+        targetMinCapacity: commonAutorouterOptions.targetMinCapacity,
+        useAssignableSolver: commonAutorouterOptions.useAssignableSolver,
+        useAutoJumperSolver: commonAutorouterOptions.useAutoJumperSolver,
+        useLaserPrefabSolver: commonAutorouterOptions.useLaserPrefabSolver,
+        useTraceSimplificationSolver:
+          phaseAutorouterConfig.preset === "simplify",
+        autorouterVersion: commonAutorouterOptions.autorouterVersion,
+        effort: commonAutorouterOptions.effort,
+      }
+
+      const cacheEngine =
+        phaseAutorouterConfig.algorithmFn || !localAutorouterStrategy.cacheable
+          ? undefined
+          : this.root?.platform?.localCacheEngine
+      const cacheKey = cacheEngine
+        ? getLocalAutoroutingCacheKey(
+            simpleRouteJson,
+            localAutoroutingCacheSolverOptions,
+          )
+        : undefined
+      const cachedResult = cacheKey
+        ? await getCachedLocalAutoroutingPhaseResult({ cacheEngine, cacheKey })
+        : null
+      const cacheDisabledReason = phaseAutorouterConfig.algorithmFn
+        ? "custom_algorithm"
+        : !localAutorouterStrategy.cacheable
+          ? "strategy_not_cacheable"
+          : !cacheEngine
+            ? "no_cache_engine"
+            : undefined
+      const autoroutingMetadata = {
+        routingPhaseIndex: routingStageIndex,
+        phaseOrdinal: routingStageIndex + 1,
+        phaseCount: routingStages.length,
+        connectionCount: simpleRouteJson.connections.length,
+        obstacleCount: simpleRouteJson.obstacles.length,
+        previousTraceCount: simpleRouteJson.traces?.length ?? 0,
+        isReroutePhase,
+        autorouterName,
+        autorouterVersion,
+        solverName,
+        effort,
+        cacheStatus: cacheEngine ? (cachedResult ? "hit" : "miss") : "disabled",
+        cacheKey,
+        cacheDisabledReason,
+      } as const
+
       this.root?.emit("autorouting:start", {
+        type: "autorouting:start",
         subcircuit_id: this.subcircuit_id,
         componentDisplayName: this.getString(),
         ...(routingPhasePlan.phaseName !== undefined
@@ -1503,19 +1580,9 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
               phaseStageCount,
             }
           : {}),
+        ...autoroutingMetadata,
         simpleRouteJson,
       })
-
-      const cacheEngine =
-        phaseAutorouterConfig.algorithmFn || !localAutorouterStrategy.cacheable
-          ? undefined
-          : this.root?.platform?.localCacheEngine
-      const cacheKey = cacheEngine
-        ? getLocalAutoroutingCacheKey(simpleRouteJson)
-        : undefined
-      const cachedResult = cacheKey
-        ? await getCachedLocalAutoroutingPhaseResult({ cacheEngine, cacheKey })
-        : null
       let autorouter: GenericLocalAutorouter | undefined
 
       try {
@@ -1528,24 +1595,6 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             autorouter =
               await phaseAutorouterConfig.algorithmFn(simpleRouteJson)
           } else {
-            const autorouterVersion =
-              phaseAutorouterConfig.autorouterVersion ??
-              this.props.autorouterVersion
-            const effortLevel = this.props.autorouterEffortLevel
-            const effort = effortLevel
-              ? Number.parseInt(effortLevel.replace("x", ""), 10)
-              : undefined
-            const commonAutorouterOptions: AutorouterOptions = {
-              capacityDepth: phaseAutorouterConfig.capacityDepth,
-              targetMinCapacity: phaseAutorouterConfig.targetMinCapacity,
-              platformConfig: this.root?.platform,
-              useAssignableSolver:
-                phaseIsLaserPrefabPreset || isSingleLayerBoard,
-              useAutoJumperSolver: phaseIsAutoJumperPreset,
-              useLaserPrefabSolver: phaseIsLaserPrefabPreset,
-              autorouterVersion,
-              effort,
-            }
             autorouter = localAutorouterStrategy.create({
               simpleRouteJson,
               commonAutorouterOptions,
@@ -1600,7 +1649,9 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
                     phaseStageCount,
                   }
                 : {}),
+              ...autoroutingMetadata,
               ...event,
+              type: "autorouting:progress",
             })
           })
 
@@ -1700,6 +1751,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
                 phaseStageCount,
               }
             : {}),
+          ...autoroutingMetadata,
           simpleRouteJson: outputSimpleRouteJson,
         })
 
@@ -1778,6 +1830,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         })
 
         this.root?.emit("autorouting:error", {
+          type: "autorouting:error",
           subcircuit_id: this.subcircuit_id,
           componentDisplayName: this.getString(),
           ...(routingPhasePlan.phaseName !== undefined
@@ -1787,6 +1840,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
                 phaseStageCount,
               }
             : {}),
+          ...autoroutingMetadata,
           error: {
             message: error instanceof Error ? error.message : String(error),
           },

--- a/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
+++ b/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
@@ -1,4 +1,5 @@
 import type { LocalCacheEngine } from "lib/local-cache-engine"
+import type { AutorouterOptions } from "lib/utils/autorouting/CapacityMeshAutorouter"
 import type {
   SimpleRouteJson,
   SimplifiedPcbTrace,
@@ -14,13 +15,28 @@ const getFnv1aHash = (value: string): number => {
   return hash >>> 0
 }
 
-const getSrjHash = (simpleRouteJson: SimpleRouteJson): string => {
-  const serializedSrj = JSON.stringify(simpleRouteJson)
-  const hash1 = getFnv1aHash(serializedSrj)
-  const hash2 = getFnv1aHash(`${serializedSrj}${hash1}`)
+const getJsonHash = (value: object): string => {
+  const serializedValue = JSON.stringify(value)
+  const hash1 = getFnv1aHash(serializedValue)
+  const hash2 = getFnv1aHash(`${serializedValue}${hash1}`)
   return `${hash1.toString(16).padStart(8, "0")}${hash2
     .toString(16)
     .padStart(8, "0")}`
+}
+
+export type LocalAutoroutingCacheSolverOptions = Pick<
+  AutorouterOptions,
+  | "capacityDepth"
+  | "targetMinCapacity"
+  | "useAssignableSolver"
+  | "useAutoJumperSolver"
+  | "useLaserPrefabSolver"
+  | "useTraceSimplificationSolver"
+  | "autorouterVersion"
+  | "effort"
+> & {
+  autorouterName: string
+  solverName?: string
 }
 
 type CachedAutoroutingPhaseResult = SimpleRouteJson & {
@@ -29,7 +45,9 @@ type CachedAutoroutingPhaseResult = SimpleRouteJson & {
 
 export const getLocalAutoroutingCacheKey = (
   simpleRouteJson: SimpleRouteJson,
-): string => `routes:core@${pkgJson.version}:srj:${getSrjHash(simpleRouteJson)}`
+  solverOptions: LocalAutoroutingCacheSolverOptions,
+): string =>
+  `routes:core@${pkgJson.version}:solver:${getJsonHash(solverOptions)}:srj:${getJsonHash(simpleRouteJson)}`
 
 export const getCachedLocalAutoroutingPhaseResult = async ({
   cacheEngine,

--- a/lib/events/index.ts
+++ b/lib/events/index.ts
@@ -22,7 +22,31 @@ export type RootCircuitEventName =
   | "renderComplete"
   | "debug:logOutput"
 
-export interface AutoroutingStartEvent {
+export type AutoroutingCacheStatus = "disabled" | "hit" | "miss"
+
+export type AutoroutingCacheDisabledReason =
+  | "custom_algorithm"
+  | "strategy_not_cacheable"
+  | "no_cache_engine"
+
+export interface AutoroutingExecutionMetadata {
+  routingPhaseIndex?: number | null
+  phaseOrdinal?: number
+  phaseCount?: number
+  connectionCount?: number
+  obstacleCount?: number
+  previousTraceCount?: number
+  isReroutePhase?: boolean
+  autorouterName?: string
+  autorouterVersion?: string
+  solverName?: string
+  effort?: number
+  cacheStatus?: AutoroutingCacheStatus
+  cacheKey?: string
+  cacheDisabledReason?: AutoroutingCacheDisabledReason
+}
+
+export interface AutoroutingStartEvent extends AutoroutingExecutionMetadata {
   type: "autorouting:start"
   subcircuit_id: string
   componentDisplayName: string
@@ -32,7 +56,7 @@ export interface AutoroutingStartEvent {
   simpleRouteJson: SimpleRouteJson
 }
 
-export interface AutoroutingErrorEvent {
+export interface AutoroutingErrorEvent extends AutoroutingExecutionMetadata {
   type: "autorouting:error"
   subcircuit_id: string
   componentDisplayName: string
@@ -44,7 +68,7 @@ export interface AutoroutingErrorEvent {
   debugGraphics?: any
 }
 
-export interface AutoroutingProgressEvent {
+export interface AutoroutingProgressEvent extends AutoroutingExecutionMetadata {
   type: "autorouting:progress"
   subcircuit_id: string
   componentDisplayName: string
@@ -56,7 +80,7 @@ export interface AutoroutingProgressEvent {
   debugGraphics?: any
 }
 
-export interface AutoroutingEndEvent {
+export interface AutoroutingEndEvent extends AutoroutingExecutionMetadata {
   type: "autorouting:end"
   subcircuit_id: string
   componentDisplayName: string

--- a/lib/utils/autorouting/CapacityMeshAutorouter.ts
+++ b/lib/utils/autorouting/CapacityMeshAutorouter.ts
@@ -1,8 +1,8 @@
 import {
-  AutoroutingPipelineSolver,
   AssignableAutoroutingPipeline2,
   AssignableAutoroutingPipeline3,
   AutoroutingPipeline1_OriginalUnravel,
+  AutoroutingPipelineSolver,
   AutoroutingPipelineSolver3_HgPortPointPathing,
   AutoroutingPipelineSolver4,
   AutoroutingPipelineSolver5,
@@ -14,16 +14,16 @@ import {
 } from "@tscircuit/capacity-autorouter"
 import type { PlatformConfig } from "@tscircuit/props"
 import { AutorouterError } from "lib/errors/AutorouterError"
-import type { SimpleRouteJson, SimplifiedPcbTrace } from "./SimpleRouteJson"
+import { SOLVERS, type SolverName } from "lib/solvers"
 import type {
   AutorouterCompleteEvent,
   AutorouterErrorEvent,
-  AutorouterProgressEvent,
   AutorouterEvent,
+  AutorouterProgressEvent,
   GenericLocalAutorouter,
 } from "./GenericLocalAutorouter"
-import { SOLVERS, type SolverName } from "lib/solvers"
 import { getCacheProviderForLocalCacheEngine } from "./LocalCacheEngineCacheProvider"
+import type { SimpleRouteJson, SimplifiedPcbTrace } from "./SimpleRouteJson"
 import type { AutorouterVersion } from "./autorouter-version"
 
 export interface SolverStartedDetails {
@@ -51,6 +51,62 @@ export interface AutorouterOptions {
   effort?: number
   platformConfig?: Pick<PlatformConfig, "localCacheEngine">
   onSolverStarted?: (details: SolverStartedDetails) => void
+}
+
+export type AutorouterSolverName =
+  | "AutoroutingPipelineSolver11_Simplification"
+  | "AutoroutingPipeline1_OriginalUnravel"
+  | "AutoroutingPipelineSolver3_HgPortPointPathing"
+  | "AutoroutingPipelineSolver4"
+  | "AutoroutingPipelineSolver5"
+  | "AutoroutingPipelineSolver7_MultiGraph"
+  | "AutoroutingPipelineSolver9_PreloadedTraceGraph"
+  | "AutoroutingPipelineSolver8"
+  | "AssignableAutoroutingPipeline3"
+  | "AssignableAutoroutingPipeline2"
+
+export const getAutorouterSolverName = ({
+  useAssignableSolver = false,
+  useAutoJumperSolver = false,
+  autorouterVersion,
+  useLaserPrefabSolver = false,
+  useTraceSimplificationSolver = false,
+}: Pick<
+  AutorouterOptions,
+  | "useAssignableSolver"
+  | "useAutoJumperSolver"
+  | "autorouterVersion"
+  | "useLaserPrefabSolver"
+  | "useTraceSimplificationSolver"
+>): AutorouterSolverName => {
+  if (useTraceSimplificationSolver) {
+    return "AutoroutingPipelineSolver11_Simplification"
+  }
+  if (autorouterVersion === "beta_pipeline1") {
+    return "AutoroutingPipeline1_OriginalUnravel"
+  }
+  if (autorouterVersion === "beta_pipeline3") {
+    return "AutoroutingPipelineSolver3_HgPortPointPathing"
+  }
+  if (autorouterVersion === "beta_pipeline4") {
+    return "AutoroutingPipelineSolver4"
+  }
+  if (autorouterVersion === "beta_pipeline5") {
+    return "AutoroutingPipelineSolver5"
+  }
+  if (
+    autorouterVersion === "beta_pipeline7" ||
+    autorouterVersion === "latest"
+  ) {
+    return "AutoroutingPipelineSolver7_MultiGraph"
+  }
+  if (autorouterVersion === "beta_pipeline9") {
+    return "AutoroutingPipelineSolver9_PreloadedTraceGraph"
+  }
+  if (useLaserPrefabSolver) return "AutoroutingPipelineSolver8"
+  if (useAutoJumperSolver) return "AssignableAutoroutingPipeline3"
+  if (useAssignableSolver) return "AssignableAutoroutingPipeline2"
+  return "AutoroutingPipelineSolver7_MultiGraph"
 }
 
 function getCapacityAutorouterCacheProvider(
@@ -105,33 +161,13 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
     } = options
 
     // Initialize the solver with input and optional configuration
-    let solverName: keyof typeof SOLVERS
-    if (useTraceSimplificationSolver) {
-      solverName = "AutoroutingPipelineSolver11_Simplification"
-    } else if (autorouterVersion === "beta_pipeline1") {
-      solverName = "AutoroutingPipeline1_OriginalUnravel"
-    } else if (autorouterVersion === "beta_pipeline3") {
-      solverName = "AutoroutingPipelineSolver3_HgPortPointPathing"
-    } else if (autorouterVersion === "beta_pipeline4") {
-      solverName = "AutoroutingPipelineSolver4"
-    } else if (autorouterVersion === "beta_pipeline5") {
-      solverName = "AutoroutingPipelineSolver5"
-    } else if (
-      autorouterVersion === "beta_pipeline7" ||
-      autorouterVersion === "latest"
-    ) {
-      solverName = "AutoroutingPipelineSolver7_MultiGraph"
-    } else if (autorouterVersion === "beta_pipeline9") {
-      solverName = "AutoroutingPipelineSolver9_PreloadedTraceGraph"
-    } else if (useLaserPrefabSolver) {
-      solverName = "AutoroutingPipelineSolver8"
-    } else if (useAutoJumperSolver) {
-      solverName = "AssignableAutoroutingPipeline3"
-    } else if (useAssignableSolver) {
-      solverName = "AssignableAutoroutingPipeline2"
-    } else {
-      solverName = "AutoroutingPipelineSolver7_MultiGraph"
-    }
+    const solverName = getAutorouterSolverName({
+      useAssignableSolver,
+      useAutoJumperSolver,
+      autorouterVersion,
+      useLaserPrefabSolver,
+      useTraceSimplificationSolver,
+    })
     const SolverClass = SOLVERS[solverName]
     const solverCacheProvider =
       getCapacityAutorouterCacheProvider(platformConfig)

--- a/lib/utils/autorouting/local-autorouter-strategies.ts
+++ b/lib/utils/autorouting/local-autorouter-strategies.ts
@@ -7,6 +7,7 @@ import type { SolverName } from "lib/solvers"
 import {
   type AutorouterOptions,
   TscircuitAutorouter,
+  getAutorouterSolverName,
 } from "./CapacityMeshAutorouter"
 import { FanoutAutorouter, type FanoutAutorouterMode } from "./FanoutAutorouter"
 import type { GenericLocalAutorouter } from "./GenericLocalAutorouter"
@@ -32,8 +33,10 @@ export interface LocalAutorouterStrategyContext {
 }
 
 export interface LocalAutorouterStrategy {
+  name: string
   cacheable: boolean
   followUpAutorouter?: AutorouterProp
+  getSolverName: (options: AutorouterOptions) => SolverName
   create: (context: LocalAutorouterStrategyContext) => GenericLocalAutorouter
 }
 
@@ -44,9 +47,13 @@ export interface LocalAutoroutingStage {
 }
 
 const createTscircuitAutorouterStrategy = (
+  name: string,
   strategyOptions: Pick<AutorouterOptions, "useTraceSimplificationSolver">,
 ): LocalAutorouterStrategy => ({
+  name,
   cacheable: true,
+  getSolverName: (options) =>
+    getAutorouterSolverName({ ...options, ...strategyOptions }),
   create: ({ simpleRouteJson, commonAutorouterOptions, onSolverStarted }) =>
     new TscircuitAutorouter(simpleRouteJson, {
       ...commonAutorouterOptions,
@@ -59,16 +66,22 @@ const createTscircuitAutorouterStrategy = (
     }),
 })
 
-const defaultLocalAutorouterStrategy = createTscircuitAutorouterStrategy({})
+const defaultLocalAutorouterStrategy = createTscircuitAutorouterStrategy(
+  "tscircuit",
+  {},
+)
 const simplificationLocalAutorouterStrategy = createTscircuitAutorouterStrategy(
+  "tscircuit_simplify",
   { useTraceSimplificationSolver: true },
 )
 
 const createFanoutAutorouterStrategy = (
   mode: FanoutAutorouterMode,
 ): LocalAutorouterStrategy => ({
+  name: mode,
   cacheable: false,
   followUpAutorouter: "default",
+  getSolverName: () => "FanoutSolver",
   create: ({
     simpleRouteJson,
     busFanoutDirections,

--- a/tests/features/local-autorouting-phase-cache.test.tsx
+++ b/tests/features/local-autorouting-phase-cache.test.tsx
@@ -1,11 +1,13 @@
 import { expect, test } from "bun:test"
+import type { BoardProps } from "@tscircuit/props"
+import type { AutoroutingStartEvent } from "lib/events"
 import type { LocalCacheEngine } from "lib/local-cache-engine"
 import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
 import pkgJson from "../../package.json"
 import { createBasicAutorouter } from "../fixtures/createBasicAutorouter"
 import { getTestFixture } from "../fixtures/get-test-fixture"
 
-test("built-in local autorouting caches each phase and custom algorithms bypass the cache", async () => {
+test("built-in local autorouting caches by solver options and custom algorithms bypass the cache", async () => {
   const cache = new Map<string, string>()
   const getKeys: string[] = []
   const setKeys: string[] = []
@@ -53,9 +55,19 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
     },
   )
 
-  const renderCircuit = async (algorithmFn?: typeof customAlgorithmFn) => {
+  const renderCircuit = async ({
+    algorithmFn,
+    autorouterEffortLevel,
+  }: {
+    algorithmFn?: typeof customAlgorithmFn
+    autorouterEffortLevel?: BoardProps["autorouterEffortLevel"]
+  } = {}) => {
     const { circuit } = getTestFixture({ platform: { localCacheEngine } })
     let autoroutingProgressCount = 0
+    const autoroutingStarts: AutoroutingStartEvent[] = []
+    circuit.on("autorouting:start", (event) => {
+      autoroutingStarts.push(event)
+    })
     circuit.on("autorouting:progress", () => {
       autoroutingProgressCount++
     })
@@ -64,6 +76,7 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
         width="20mm"
         height="20mm"
         autorouter={algorithmFn ? { algorithmFn } : undefined}
+        autorouterEffortLevel={autorouterEffortLevel}
       >
         <resistor
           name="R1"
@@ -98,23 +111,42 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
       </board>,
     )
     await circuit.renderUntilSettled()
-    return { circuit, autoroutingProgressCount }
+    return { circuit, autoroutingProgressCount, autoroutingStarts }
   }
 
-  const firstRender = await renderCircuit()
+  const firstRender = await renderCircuit({ autorouterEffortLevel: "1x" })
   expect(firstRender.autoroutingProgressCount).toBeGreaterThan(0)
   const firstCircuit = firstRender.circuit
   expect(firstCircuit.db.pcb_trace.list()).toHaveLength(2)
+  expect(firstRender.autoroutingStarts).toHaveLength(2)
+  expect(firstRender.autoroutingStarts[0]).toMatchObject({
+    routingPhaseIndex: 0,
+    phaseOrdinal: 1,
+    phaseCount: 2,
+    connectionCount: 1,
+    autorouterName: "tscircuit",
+    solverName: "AutoroutingPipelineSolver7_MultiGraph",
+    effort: 1,
+    cacheStatus: "miss",
+  })
   expect(setKeys).toHaveLength(2)
   expect(new Set(setKeys).size).toBe(2)
   for (const key of setKeys) {
     expect(key).toMatch(
-      new RegExp(`^routes:core@${pkgJson.version}:srj:[a-f0-9]{16}$`),
+      new RegExp(
+        `^routes:core@${pkgJson.version}:solver:[a-f0-9]{16}:srj:[a-f0-9]{16}$`,
+      ),
     )
   }
 
-  const secondRender = await renderCircuit()
+  const secondRender = await renderCircuit({ autorouterEffortLevel: "1x" })
   expect(secondRender.autoroutingProgressCount).toBe(0)
+  expect(secondRender.autoroutingStarts[0]).toMatchObject({
+    solverName: "AutoroutingPipelineSolver7_MultiGraph",
+    effort: 1,
+    cacheStatus: "hit",
+    cacheKey: setKeys[0],
+  })
   const secondCircuit = secondRender.circuit
   expect(secondCircuit.db.pcb_trace.list()).toEqual(
     firstCircuit.db.pcb_trace.list(),
@@ -122,10 +154,29 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
   expect(getKeys.slice(-2)).toEqual(setKeys)
   expect(setKeys).toHaveLength(2)
 
+  const higherEffortRender = await renderCircuit({
+    autorouterEffortLevel: "10x",
+  })
+  expect(higherEffortRender.autoroutingProgressCount).toBeGreaterThan(0)
+  expect(higherEffortRender.autoroutingStarts[0]).toMatchObject({
+    effort: 10,
+    cacheStatus: "miss",
+  })
+  expect(higherEffortRender.circuit.db.pcb_trace.list()).toHaveLength(2)
+  expect(setKeys).toHaveLength(4)
+  expect(new Set(setKeys).size).toBe(4)
+
   const getCountBeforeCustomAutorouting = getKeys.length
   const setCountBeforeCustomAutorouting = setKeys.length
-  const customRender = await renderCircuit(customAlgorithmFn)
+  const customRender = await renderCircuit({ algorithmFn: customAlgorithmFn })
   expect(customSolverCallCount).toBe(2)
+  expect(customRender.autoroutingStarts[0]).toMatchObject({
+    autorouterName: "custom",
+    cacheStatus: "disabled",
+    cacheDisabledReason: "custom_algorithm",
+  })
+  expect(customRender.autoroutingStarts[0].solverName).toBeUndefined()
+  expect(customRender.autoroutingStarts[0].cacheKey).toBeUndefined()
   expect(customRender.circuit.db.pcb_trace.list()).toHaveLength(2)
   expect(getKeys).toHaveLength(getCountBeforeCustomAutorouting)
   expect(setKeys).toHaveLength(setCountBeforeCustomAutorouting)


### PR DESCRIPTION
## Summary

- expose phase, router, resolved solver, effort, and cache metadata on local autorouting lifecycle events
- include solver-affecting options in phase cache keys so effort or pipeline changes cannot reuse stale routes
- identify why caching is disabled for custom and non-cacheable strategies

## Why

The phase cache previously keyed only on Simple Route JSON and the Core package version. Rendering the same board at 5x and then 10x effort could therefore reuse the 5x result, which made routing experiments misleading and difficult to diagnose.

## Companion PR

tscircuit/cli#4604 surfaces this metadata in live diagnostics and debug artifacts.

## Testing

- bun test tests/features/local-autorouting-phase-cache.test.tsx tests/utils/autorouting/local-autorouter-strategies.test.ts
- bunx tsc --noEmit
- git diff --check origin/main...HEAD
