### PR TITLE
Fix local autorouting cache key invalidation

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -1493,6 +1493,34 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         ;(global as any).debugGraphics?.push(graphicsObject)
       }
 
+      const autorouterVersion =
+        phaseAutorouterConfig.autorouterVersion ?? this.props.autorouterVersion
+      const effortLevel = this.props.autorouterEffortLevel
+      const effort = effortLevel
+        ? Number.parseInt(effortLevel.replace("x", ""), 10)
+        : undefined
+      const commonAutorouterOptions: AutorouterOptions = {
+        capacityDepth: phaseAutorouterConfig.capacityDepth,
+        targetMinCapacity: phaseAutorouterConfig.targetMinCapacity,
+        platformConfig: this.root?.platform,
+        useAssignableSolver: phaseIsLaserPrefabPreset || isSingleLayerBoard,
+        useAutoJumperSolver: phaseIsAutoJumperPreset,
+        useLaserPrefabSolver: phaseIsLaserPrefabPreset,
+        autorouterVersion,
+        effort,
+      }
+      const localAutoroutingCacheSolverOptions = {
+        capacityDepth: commonAutorouterOptions.capacityDepth,
+        targetMinCapacity: commonAutorouterOptions.targetMinCapacity,
+        useAssignableSolver: commonAutorouterOptions.useAssignableSolver,
+        useAutoJumperSolver: commonAutorouterOptions.useAutoJumperSolver,
+        useLaserPrefabSolver: commonAutorouterOptions.useLaserPrefabSolver,
+        useTraceSimplificationSolver:
+          phaseAutorouterConfig.preset === "simplify",
+        autorouterVersion: commonAutorouterOptions.autorouterVersion,
+        effort: commonAutorouterOptions.effort,
+      }
+
       this.root?.emit("autorouting:start", {
         subcircuit_id: this.subcircuit_id,
         componentDisplayName: this.getString(),
@@ -1511,7 +1539,10 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
           ? undefined
           : this.root?.platform?.localCacheEngine
       const cacheKey = cacheEngine
-        ? getLocalAutoroutingCacheKey(simpleRouteJson)
+        ? getLocalAutoroutingCacheKey(
+            simpleRouteJson,
+            localAutoroutingCacheSolverOptions,
+          )
         : undefined
       const cachedResult = cacheKey
         ? await getCachedLocalAutoroutingPhaseResult({ cacheEngine, cacheKey })
@@ -1528,24 +1559,6 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             autorouter =
               await phaseAutorouterConfig.algorithmFn(simpleRouteJson)
           } else {
-            const autorouterVersion =
-              phaseAutorouterConfig.autorouterVersion ??
-              this.props.autorouterVersion
-            const effortLevel = this.props.autorouterEffortLevel
-            const effort = effortLevel
-              ? Number.parseInt(effortLevel.replace("x", ""), 10)
-              : undefined
-            const commonAutorouterOptions: AutorouterOptions = {
-              capacityDepth: phaseAutorouterConfig.capacityDepth,
-              targetMinCapacity: phaseAutorouterConfig.targetMinCapacity,
-              platformConfig: this.root?.platform,
-              useAssignableSolver:
-                phaseIsLaserPrefabPreset || isSingleLayerBoard,
-              useAutoJumperSolver: phaseIsAutoJumperPreset,
-              useLaserPrefabSolver: phaseIsLaserPrefabPreset,
-              autorouterVersion,
-              effort,
-            }
             autorouter = localAutorouterStrategy.create({
               simpleRouteJson,
               commonAutorouterOptions,

--- a/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
+++ b/lib/components/primitive-components/Group/Group_localAutoroutingCache.ts
@@ -1,4 +1,5 @@
 import type { LocalCacheEngine } from "lib/local-cache-engine"
+import type { AutorouterOptions } from "lib/utils/autorouting/CapacityMeshAutorouter"
 import type {
   SimpleRouteJson,
   SimplifiedPcbTrace,
@@ -14,14 +15,26 @@ const getFnv1aHash = (value: string): number => {
   return hash >>> 0
 }
 
-const getSrjHash = (simpleRouteJson: SimpleRouteJson): string => {
-  const serializedSrj = JSON.stringify(simpleRouteJson)
-  const hash1 = getFnv1aHash(serializedSrj)
-  const hash2 = getFnv1aHash(`${serializedSrj}${hash1}`)
+const getJsonHash = (value: object): string => {
+  const serializedValue = JSON.stringify(value)
+  const hash1 = getFnv1aHash(serializedValue)
+  const hash2 = getFnv1aHash(`${serializedValue}${hash1}`)
   return `${hash1.toString(16).padStart(8, "0")}${hash2
     .toString(16)
     .padStart(8, "0")}`
 }
+
+export type LocalAutoroutingCacheSolverOptions = Pick<
+  AutorouterOptions,
+  | "capacityDepth"
+  | "targetMinCapacity"
+  | "useAssignableSolver"
+  | "useAutoJumperSolver"
+  | "useLaserPrefabSolver"
+  | "useTraceSimplificationSolver"
+  | "autorouterVersion"
+  | "effort"
+>
 
 type CachedAutoroutingPhaseResult = SimpleRouteJson & {
   traces: SimplifiedPcbTrace[]
@@ -29,7 +42,9 @@ type CachedAutoroutingPhaseResult = SimpleRouteJson & {
 
 export const getLocalAutoroutingCacheKey = (
   simpleRouteJson: SimpleRouteJson,
-): string => `routes:core@${pkgJson.version}:srj:${getSrjHash(simpleRouteJson)}`
+  solverOptions: LocalAutoroutingCacheSolverOptions,
+): string =>
+  `routes:core@${pkgJson.version}:solver:${getJsonHash(solverOptions)}:srj:${getJsonHash(simpleRouteJson)}`
 
 export const getCachedLocalAutoroutingPhaseResult = async ({
   cacheEngine,

--- a/tests/features/local-autorouting-phase-cache.test.tsx
+++ b/tests/features/local-autorouting-phase-cache.test.tsx
@@ -1,11 +1,12 @@
 import { expect, test } from "bun:test"
+import type { BoardProps } from "@tscircuit/props"
 import type { LocalCacheEngine } from "lib/local-cache-engine"
 import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
 import pkgJson from "../../package.json"
 import { createBasicAutorouter } from "../fixtures/createBasicAutorouter"
 import { getTestFixture } from "../fixtures/get-test-fixture"
 
-test("built-in local autorouting caches each phase and custom algorithms bypass the cache", async () => {
+test("built-in local autorouting caches by solver options and custom algorithms bypass the cache", async () => {
   const cache = new Map<string, string>()
   const getKeys: string[] = []
   const setKeys: string[] = []
@@ -53,7 +54,13 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
     },
   )
 
-  const renderCircuit = async (algorithmFn?: typeof customAlgorithmFn) => {
+  const renderCircuit = async ({
+    algorithmFn,
+    autorouterEffortLevel,
+  }: {
+    algorithmFn?: typeof customAlgorithmFn
+    autorouterEffortLevel?: BoardProps["autorouterEffortLevel"]
+  } = {}) => {
     const { circuit } = getTestFixture({ platform: { localCacheEngine } })
     let autoroutingProgressCount = 0
     circuit.on("autorouting:progress", () => {
@@ -64,6 +71,7 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
         width="20mm"
         height="20mm"
         autorouter={algorithmFn ? { algorithmFn } : undefined}
+        autorouterEffortLevel={autorouterEffortLevel}
       >
         <resistor
           name="R1"
@@ -101,7 +109,7 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
     return { circuit, autoroutingProgressCount }
   }
 
-  const firstRender = await renderCircuit()
+  const firstRender = await renderCircuit({ autorouterEffortLevel: "1x" })
   expect(firstRender.autoroutingProgressCount).toBeGreaterThan(0)
   const firstCircuit = firstRender.circuit
   expect(firstCircuit.db.pcb_trace.list()).toHaveLength(2)
@@ -109,11 +117,13 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
   expect(new Set(setKeys).size).toBe(2)
   for (const key of setKeys) {
     expect(key).toMatch(
-      new RegExp(`^routes:core@${pkgJson.version}:srj:[a-f0-9]{16}$`),
+      new RegExp(
+        `^routes:core@${pkgJson.version}:solver:[a-f0-9]{16}:srj:[a-f0-9]{16}$`,
+      ),
     )
   }
 
-  const secondRender = await renderCircuit()
+  const secondRender = await renderCircuit({ autorouterEffortLevel: "1x" })
   expect(secondRender.autoroutingProgressCount).toBe(0)
   const secondCircuit = secondRender.circuit
   expect(secondCircuit.db.pcb_trace.list()).toEqual(
@@ -122,9 +132,17 @@ test("built-in local autorouting caches each phase and custom algorithms bypass 
   expect(getKeys.slice(-2)).toEqual(setKeys)
   expect(setKeys).toHaveLength(2)
 
+  const higherEffortRender = await renderCircuit({
+    autorouterEffortLevel: "10x",
+  })
+  expect(higherEffortRender.autoroutingProgressCount).toBeGreaterThan(0)
+  expect(higherEffortRender.circuit.db.pcb_trace.list()).toHaveLength(2)
+  expect(setKeys).toHaveLength(4)
+  expect(new Set(setKeys).size).toBe(4)
+
   const getCountBeforeCustomAutorouting = getKeys.length
   const setCountBeforeCustomAutorouting = setKeys.length
-  const customRender = await renderCircuit(customAlgorithmFn)
+  const customRender = await renderCircuit({ algorithmFn: customAlgorithmFn })
   expect(customSolverCallCount).toBe(2)
   expect(customRender.circuit.db.pcb_trace.list()).toHaveLength(2)
   expect(getKeys).toHaveLength(getCountBeforeCustomAutorouting)


### PR DESCRIPTION
## Summary
- include effective solver options in local autorouting cache keys
- prevent higher-effort or different solver configurations from reusing stale routes
- preserve cache hits for identical routing inputs and continue bypassing cache for custom algorithms

## Bug
The previous key contained only the Core version and Simple Route JSON. Autorouter effort and solver configuration are not part of that JSON, so changing from 1x to 10x could return the cached 1x route without running the solver.

## Testing
- bun test tests/features/local-autorouting-phase-cache.test.tsx tests/features/async-local-cache-engine-cache-provider.test.ts tests/features/autorouter-cache-provider.test.ts tests/utils/autorouting/local-autorouter-strategies.test.ts
- bunx tsc --noEmit
- bunx biome format on the three changed files
- git diff --check