### PR TITLE
update checks to 0.0.183

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/bga-fanout-solver": "github:tscircuit/bga-fanout-solver#247c835cb8d69b65e53891dcf869731079415b39",
     "@tscircuit/capacity-autorouter": "^0.0.874",
-    "@tscircuit/checks": "^0.0.182",
+    "@tscircuit/checks": "^0.0.183",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "^0.0.52",


### PR DESCRIPTION
### Motivation
- enable the released same-net switch contact check in core.

### Before
- core uses @tscircuit/checks ^0.0.182.

### After
- update @tscircuit/checks to ^0.0.183 so board netlist checks report shorted two-terminal switch contacts.
