### PR TITLE
fix: share routing connection resolution for buses and differential pairs

### DIFF
--- a/lib/utils/autorouting/getBusesForSimpleRouteJson.ts
+++ b/lib/utils/autorouting/getBusesForSimpleRouteJson.ts
@@ -1,13 +1,15 @@
-import type { SourceNet, SourcePort, SourceTrace } from "circuit-json"
+import type { SourceNet, SourceTrace } from "circuit-json"
 import type { Bus } from "lib/components/primitive-components/Bus"
-import type { Port } from "lib/components/primitive-components/Port/Port"
+import {
+  getSourceTracesForRoutingConnectionSelector,
+  getSrjConnectionsForSourceTraces,
+} from "./resolve-routing-connection"
 import type {
   SimpleRouteBus,
   SimpleRouteConnection,
   SrjConnectionName,
 } from "./SimpleRouteJson"
 
-type SourcePortId = NonNullable<SourcePort["source_port_id"]>
 type SubcircuitId = NonNullable<SourceTrace["subcircuit_id"]>
 type GetBusesParams = {
   srjConnections: SimpleRouteConnection[]
@@ -21,7 +23,7 @@ export type FanoutPourNetMap = Readonly<
   Record<string, string | readonly string[]>
 >
 
-const getBusSourceTraceIdOrThrow = ({
+const getBusSourceTraceOrThrow = ({
   bus,
   busSourceTraces,
   traceNameOrPortSelector,
@@ -29,23 +31,12 @@ const getBusSourceTraceIdOrThrow = ({
   bus: Bus
   busSourceTraces: SourceTrace[]
   traceNameOrPortSelector: string
-}): SourceTrace["source_trace_id"] => {
-  const sourceTracesWithMatchingName = busSourceTraces.filter(
-    (sourceTrace) => sourceTrace.name === traceNameOrPortSelector,
-  )
-  const selectedPort =
-    sourceTracesWithMatchingName.length === 0
-      ? bus.getSubcircuit().selectOne<Port>(traceNameOrPortSelector, {
-          type: "port",
-        })
-      : null
-  const selectedSourcePortId: SourcePortId | undefined =
-    selectedPort?.source_port_id ?? undefined
-  const matchingSourceTraces = selectedSourcePortId
-    ? busSourceTraces.filter((sourceTrace) =>
-        sourceTrace.connected_source_port_ids.includes(selectedSourcePortId),
-      )
-    : sourceTracesWithMatchingName
+}): SourceTrace => {
+  const matchingSourceTraces = getSourceTracesForRoutingConnectionSelector({
+    subcircuit: bus.getSubcircuit(),
+    sourceTraces: busSourceTraces,
+    traceNameOrPortSelector,
+  })
 
   if (matchingSourceTraces.length === 0) {
     throw new Error(
@@ -59,23 +50,27 @@ const getBusSourceTraceIdOrThrow = ({
   }
 
   const sourceTrace = matchingSourceTraces[0]
-  return sourceTrace.source_trace_id
+  return sourceTrace
 }
 
 const getBusSrjConnectionNamesOrThrow = ({
   srjConnections,
   bus,
-  sourceTraceId,
+  sourceTrace,
+  busSourceTraces,
   traceNameOrPortSelector,
 }: {
   srjConnections: SimpleRouteConnection[]
   bus: Bus
-  sourceTraceId: SourceTrace["source_trace_id"]
+  sourceTrace: SourceTrace
+  busSourceTraces: SourceTrace[]
   traceNameOrPortSelector: string
 }): SrjConnectionName[] => {
-  const matchingSrjConnections = srjConnections.filter(
-    (srjConnection) => srjConnection.source_trace_id === sourceTraceId,
-  )
+  const matchingSrjConnections = getSrjConnectionsForSourceTraces({
+    selectedSourceTraces: [sourceTrace],
+    sourceTraces: busSourceTraces,
+    srjConnections,
+  })
 
   if (matchingSrjConnections.length === 0) {
     throw new Error(
@@ -164,7 +159,7 @@ export const getBusesForSimpleRouteJson = ({
     )
     const connectionNames = bus._parsedProps.connections.flatMap(
       (traceNameOrPortSelector) => {
-        const sourceTraceId = getBusSourceTraceIdOrThrow({
+        const sourceTrace = getBusSourceTraceOrThrow({
           bus,
           busSourceTraces,
           traceNameOrPortSelector,
@@ -172,7 +167,8 @@ export const getBusesForSimpleRouteJson = ({
         return getBusSrjConnectionNamesOrThrow({
           srjConnections,
           bus,
-          sourceTraceId,
+          sourceTrace,
+          busSourceTraces,
           traceNameOrPortSelector,
         })
       },

--- a/lib/utils/autorouting/getDifferentialPairsForSimpleRouteJson.ts
+++ b/lib/utils/autorouting/getDifferentialPairsForSimpleRouteJson.ts
@@ -1,6 +1,9 @@
-import type { SourcePort, SourceTrace } from "circuit-json"
+import type { SourceTrace } from "circuit-json"
 import type { DifferentialPair } from "lib/components/primitive-components/DifferentialPair"
-import type { Port } from "lib/components/primitive-components/Port/Port"
+import {
+  getSourceTracesForRoutingConnectionSelector,
+  getSrjConnectionsForSourceTraces,
+} from "./resolve-routing-connection"
 import type {
   PcbGroupId,
   SimpleRouteConnection,
@@ -8,13 +11,7 @@ import type {
   SrjConnectionName,
 } from "./SimpleRouteJson"
 
-type SourceTraceId = SourceTrace["source_trace_id"]
-type SourceNetId = NonNullable<SourceTrace["connected_source_net_ids"]>[number]
-type SourcePortId = NonNullable<SourcePort["source_port_id"]>
 type SubcircuitId = NonNullable<SourceTrace["subcircuit_id"]>
-type SubcircuitConnectivityMapKey = NonNullable<
-  SourceTrace["subcircuit_connectivity_map_key"]
->
 
 type GetDifferentialPairsParams = {
   srjConnections: SimpleRouteConnection[]
@@ -23,7 +20,7 @@ type GetDifferentialPairsParams = {
   subcircuitId?: SubcircuitId | null
 }
 
-type GetDifferentialPairTraceSubcircuitConnectivityMapKeyOrThrowParams = {
+type GetDifferentialPairSourceTraceOrThrowParams = {
   differentialPair: DifferentialPair
   differentialPairSourceTraces: SourceTrace[]
   traceNameOrPortSelector: string
@@ -33,7 +30,7 @@ type GetDifferentialPairSrjConnectionNamesByCohortOrThrowParams = {
   srjConnections: SimpleRouteConnection[]
   differentialPairName: string
   differentialPairSourceTraces: SourceTrace[]
-  traceSubcircuitConnectivityMapKey: SubcircuitConnectivityMapKey
+  sourceTrace: SourceTrace
   traceNameOrPortSelector: string
 }
 
@@ -44,47 +41,16 @@ type GetDifferentialPairSrjConnectionNamesByCohortOrThrowParams = {
  */
 type DifferentialPairSrjConnectionCohort = PcbGroupId | undefined
 
-const getDifferentialPairSourceTracesByTraceName = (
-  differentialPairSourceTraces: SourceTrace[],
-  traceName: string,
-): SourceTrace[] =>
-  differentialPairSourceTraces.filter(
-    (sourceTrace) => sourceTrace.name === traceName,
-  )
-
-const getDifferentialPairSourceTracesByPortId = (
-  differentialPairSourceTraces: SourceTrace[],
-  sourcePortId: SourcePortId,
-): SourceTrace[] =>
-  differentialPairSourceTraces.filter((sourceTrace) =>
-    sourceTrace.connected_source_port_ids.includes(sourcePortId),
-  )
-
-const getDifferentialPairTraceSubcircuitConnectivityMapKeyOrThrow = ({
+const getDifferentialPairSourceTraceOrThrow = ({
   differentialPair,
   differentialPairSourceTraces,
   traceNameOrPortSelector,
-}: GetDifferentialPairTraceSubcircuitConnectivityMapKeyOrThrowParams): SubcircuitConnectivityMapKey => {
-  const differentialPairSubcircuit = differentialPair.getSubcircuit()
-  const sourceTracesWithMatchingName =
-    getDifferentialPairSourceTracesByTraceName(
-      differentialPairSourceTraces,
-      traceNameOrPortSelector,
-    )
-  const selectedPort =
-    sourceTracesWithMatchingName.length === 0
-      ? differentialPairSubcircuit.selectOne<Port>(traceNameOrPortSelector, {
-          type: "port",
-        })
-      : null
-  const selectedSourcePortId: SourcePortId | undefined =
-    selectedPort?.source_port_id ?? undefined
-  const matchingSourceTraces = selectedSourcePortId
-    ? getDifferentialPairSourceTracesByPortId(
-        differentialPairSourceTraces,
-        selectedSourcePortId,
-      )
-    : sourceTracesWithMatchingName
+}: GetDifferentialPairSourceTraceOrThrowParams): SourceTrace => {
+  const matchingSourceTraces = getSourceTracesForRoutingConnectionSelector({
+    subcircuit: differentialPair.getSubcircuit(),
+    sourceTraces: differentialPairSourceTraces,
+    traceNameOrPortSelector,
+  })
 
   if (matchingSourceTraces.length === 0) {
     throw new Error(
@@ -112,43 +78,24 @@ const getDifferentialPairTraceSubcircuitConnectivityMapKeyOrThrow = ({
     )
   }
 
-  return subcircuitConnectivityMapKey
+  return sourceTrace
 }
 
 const getDifferentialPairSrjConnectionNamesByCohortOrThrow = ({
   srjConnections,
   differentialPairName,
   differentialPairSourceTraces,
-  traceSubcircuitConnectivityMapKey,
+  sourceTrace,
   traceNameOrPortSelector,
 }: GetDifferentialPairSrjConnectionNamesByCohortOrThrowParams): Map<
   DifferentialPairSrjConnectionCohort,
   SrjConnectionName
 > => {
-  const differentialPairSourceTraceIds: SourceTraceId[] = []
-  const differentialPairSourceNetIds = new Set<SourceNetId>()
-  for (const sourceTrace of differentialPairSourceTraces) {
-    if (
-      sourceTrace.subcircuit_connectivity_map_key ===
-      traceSubcircuitConnectivityMapKey
-    ) {
-      differentialPairSourceTraceIds.push(sourceTrace.source_trace_id)
-      for (const sourceNetId of sourceTrace.connected_source_net_ids ?? []) {
-        differentialPairSourceNetIds.add(sourceNetId)
-      }
-    }
-  }
-
-  const matchingSrjConnections: SimpleRouteConnection[] = []
-  for (const srjConnection of srjConnections) {
-    if (
-      differentialPairSourceNetIds.has(srjConnection.name) ||
-      (srjConnection.source_trace_id &&
-        differentialPairSourceTraceIds.includes(srjConnection.source_trace_id))
-    ) {
-      matchingSrjConnections.push(srjConnection)
-    }
-  }
+  const matchingSrjConnections = getSrjConnectionsForSourceTraces({
+    selectedSourceTraces: [sourceTrace],
+    sourceTraces: differentialPairSourceTraces,
+    srjConnections,
+  })
 
   if (matchingSrjConnections.length === 0) {
     throw new Error(
@@ -168,7 +115,7 @@ const getDifferentialPairSrjConnectionNamesByCohortOrThrow = ({
           ? "the global routing cohort"
           : `routing PCB group "${cohort}"`
       throw new Error(
-        `Subcircuit connectivity map key "${traceSubcircuitConnectivityMapKey}" matches multiple SRJ connections in ${cohortLabel} for differential pair "${differentialPairName}"`,
+        `Subcircuit connectivity map key "${sourceTrace.subcircuit_connectivity_map_key}" matches multiple SRJ connections in ${cohortLabel} for differential pair "${differentialPairName}"`,
       )
     }
     connectionNamesByCohort.set(cohort, srjConnection.name)
@@ -207,25 +154,23 @@ export const getDifferentialPairsForSimpleRouteJson = ({
       differentialPair._parsedProps.positiveConnection
     const negativeTraceNameOrPortSelector =
       differentialPair._parsedProps.negativeConnection
-    const positiveSubcircuitConnectivityMapKey =
-      getDifferentialPairTraceSubcircuitConnectivityMapKeyOrThrow({
-        differentialPair,
-        differentialPairSourceTraces,
-        traceNameOrPortSelector: positiveTraceNameOrPortSelector,
-      })
-    const negativeSubcircuitConnectivityMapKey =
-      getDifferentialPairTraceSubcircuitConnectivityMapKeyOrThrow({
-        differentialPair,
-        differentialPairSourceTraces,
-        traceNameOrPortSelector: negativeTraceNameOrPortSelector,
-      })
+    const positiveSourceTrace = getDifferentialPairSourceTraceOrThrow({
+      differentialPair,
+      differentialPairSourceTraces,
+      traceNameOrPortSelector: positiveTraceNameOrPortSelector,
+    })
+    const negativeSourceTrace = getDifferentialPairSourceTraceOrThrow({
+      differentialPair,
+      differentialPairSourceTraces,
+      traceNameOrPortSelector: negativeTraceNameOrPortSelector,
+    })
 
     const positiveSrjConnectionNamesByCohort =
       getDifferentialPairSrjConnectionNamesByCohortOrThrow({
         srjConnections,
         differentialPairName: differentialPair.name,
         differentialPairSourceTraces,
-        traceSubcircuitConnectivityMapKey: positiveSubcircuitConnectivityMapKey,
+        sourceTrace: positiveSourceTrace,
         traceNameOrPortSelector: positiveTraceNameOrPortSelector,
       })
     const negativeSrjConnectionNamesByCohort =
@@ -233,7 +178,7 @@ export const getDifferentialPairsForSimpleRouteJson = ({
         srjConnections,
         differentialPairName: differentialPair.name,
         differentialPairSourceTraces,
-        traceSubcircuitConnectivityMapKey: negativeSubcircuitConnectivityMapKey,
+        sourceTrace: negativeSourceTrace,
         traceNameOrPortSelector: negativeTraceNameOrPortSelector,
       })
 

--- a/lib/utils/autorouting/resolve-routing-connection.ts
+++ b/lib/utils/autorouting/resolve-routing-connection.ts
@@ -1,0 +1,79 @@
+import type { SourceNet, SourceTrace } from "circuit-json"
+import type { PrimitiveComponent } from "lib/components/base-components/PrimitiveComponent"
+import type { Port } from "lib/components/primitive-components/Port/Port"
+import type { SimpleRouteConnection } from "./SimpleRouteJson"
+
+/**
+ * Resolve a routing constraint's trace name or port selector within its
+ * subcircuit. Trace names take precedence over port selectors. Return all
+ * matches so callers can report missing or ambiguous selections in context.
+ */
+export const getSourceTracesForRoutingConnectionSelector = ({
+  subcircuit,
+  sourceTraces,
+  traceNameOrPortSelector,
+}: {
+  subcircuit: Pick<PrimitiveComponent, "selectOne">
+  sourceTraces: SourceTrace[]
+  traceNameOrPortSelector: string
+}): SourceTrace[] => {
+  const namedTraces = sourceTraces.filter(
+    (trace) => trace.name === traceNameOrPortSelector,
+  )
+  if (namedTraces.length > 0) return namedTraces
+
+  const port = subcircuit.selectOne<Port>(traceNameOrPortSelector, {
+    type: "port",
+  })
+  const sourcePortId = port?.source_port_id
+  if (!sourcePortId) return []
+  return sourceTraces.filter((trace) =>
+    trace.connected_source_port_ids.includes(sourcePortId),
+  )
+}
+
+/**
+ * Map selected source traces to routing connections through electrical
+ * connectivity, independent of whether SRJ represents a trace or a merged
+ * net. sourceTraces must belong to the same subcircuit as selectedSourceTraces.
+ * Keep all breakout connections; routing consumers decide which groups apply.
+ */
+export const getSrjConnectionsForSourceTraces = ({
+  selectedSourceTraces,
+  sourceTraces,
+  srjConnections,
+}: {
+  selectedSourceTraces: SourceTrace[]
+  sourceTraces: SourceTrace[]
+  srjConnections: SimpleRouteConnection[]
+}): SimpleRouteConnection[] => {
+  const traceIds = new Set<SourceTrace["source_trace_id"]>()
+  const netIds = new Set<SourceNet["source_net_id"]>()
+  const connectivityKeys = new Set<
+    NonNullable<SourceTrace["subcircuit_connectivity_map_key"]>
+  >()
+  for (const trace of selectedSourceTraces) {
+    traceIds.add(trace.source_trace_id)
+    if (trace.subcircuit_connectivity_map_key) {
+      connectivityKeys.add(trace.subcircuit_connectivity_map_key)
+    }
+  }
+  for (const trace of sourceTraces) {
+    if (
+      traceIds.has(trace.source_trace_id) ||
+      (trace.subcircuit_connectivity_map_key &&
+        connectivityKeys.has(trace.subcircuit_connectivity_map_key))
+    ) {
+      traceIds.add(trace.source_trace_id)
+      for (const netId of trace.connected_source_net_ids ?? []) {
+        netIds.add(netId)
+      }
+    }
+  }
+  return srjConnections.filter(
+    (connection) =>
+      netIds.has(connection.name) ||
+      (connection.source_trace_id !== undefined &&
+        traceIds.has(connection.source_trace_id)),
+  )
+}

--- a/tests/components/primitive-components/bus/net-connections.test.tsx
+++ b/tests/components/primitive-components/bus/net-connections.test.tsx
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("buses and differential pairs resolve pins and trace names to the same net connections", () => {
+  const { circuit } = getTestFixture()
+  circuit.add(
+    <board width={24} height={14} routingDisabled>
+      <chip name="U1" footprint="soic8" pcbX={-7} />
+      <chip name="U2" footprint="soic8" pcbX={7} />
+      <trace name="P_START" from=".U1 > .pin1" to="net.P" />
+      <trace from=".U2 > .pin1" to="net.P" />
+      <trace name="N_START" from=".U1 > .pin2" to="net.N" />
+      <trace from=".U2 > .pin2" to="net.N" />
+      <bus name="DATA" connections={[".U1 > .pin1", "N_START"]} />
+      <differentialpair
+        name="PAIR"
+        positiveConnection="P_START"
+        negativeConnection=".U2 > .pin2"
+      />
+    </board>,
+  )
+  circuit.render()
+  const board = circuit.firstChild
+  if (!board) throw new Error("Expected a board")
+  const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
+    db: circuit.db,
+    subcircuitComponent: board,
+  })
+  const connectionNames = ["P", "N"].map(
+    (name) => circuit.db.source_net.getWhere({ name })!.source_net_id,
+  )
+  expect(simpleRouteJson.buses).toEqual([
+    { busId: "DATA", name: "DATA", connectionNames },
+  ])
+  expect(simpleRouteJson.differentialPairs).toEqual([
+    {
+      connectionNames: [connectionNames[0], connectionNames[1]],
+      lengthTolerance: 0.1,
+    },
+  ])
+})


### PR DESCRIPTION
Bus constraints selected through a component pin or trace name fail to find their SRJ connection when the wiring is merged through a named net. Differential pairs already handle this after #3665, but buses duplicate the older trace-only lookup.

Share trace-name/port selection and source-connectivity-to-SRJ matching between buses and differential pairs. Both now resolve direct traces and named-net connections through the same helpers. Keep existing selector precedence, ambiguity errors, subcircuit scoping, and differential-pair breakout cohort checks.

Add a regression using the same named-net signals in a bus and a differential pair, selected by a mix of pin selectors and trace names. It fails with the previous bus lookup and passes with the shared resolver.

Validation:
- 25 tests pass covering differential pairs, buses, the USB reproduction, routing phases, breakout cohorts, and fanout plane termination.
- `bunx tsc --noEmit`
- `git diff --check`
