### PR TITLE
Repro: trace maxViaCount is missing from Pipeline 9 input

### DIFF
--- a/tests/repros/repro-trace-max-via-count-router-input.test.tsx
+++ b/tests/repros/repro-trace-max-via-count-router-input.test.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { createAutoroutingPhaseIoStack } from "tests/fixtures/create-autorouting-phase-io-stack"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test.failing("trace maxViaCount must reach the Pipeline 9 input", async () => {
+  const { circuit } = getTestFixture()
+  const autoroutingPhaseIoStack = createAutoroutingPhaseIoStack(circuit)
+
+  circuit.add(
+    <board width="14mm" height="8mm" layers={2} autorouter="beta-pipeline9">
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-4} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={4} />
+      <trace
+        name="NO_VIAS"
+        from=".R1 > .pin2"
+        to=".R2 > .pin1"
+        maxViaCount={0}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const sourceTrace = circuit.db.source_trace.getWhere({ name: "NO_VIAS" })!
+  const srjConnection = autoroutingPhaseIoStack
+    .flatMap((phase) => phase.startSimpleRouteJson?.connections ?? [])
+    .find((connection) => connection.name === sourceTrace.source_trace_id)
+
+  expect(circuit.db.pcb_autorouting_error.list()).toEqual([])
+  expect(sourceTrace.max_via_count).toBe(0)
+  expect(srjConnection).toBeDefined()
+
+  // This is an input-contract repro, not a geometry/via-count snapshot: the
+  // unobstructed route can use zero vias even when the router lost the limit.
+  // Inspect the actual autorouting:start event rather than constructing SRJ.
+  expect(srjConnection).toHaveProperty("maxViaCount", 0)
+})


### PR DESCRIPTION
An explicit `<trace maxViaCount={0}>` reaches `source_trace.max_via_count`, but the corresponding connection passed to Pipeline 9 drops the limit. The same omission affects the zero-via limits Core assigns to crystal signal traces. Pipeline 9 consequently receives no instruction to keep these connections via-free.

This repro uses two ordinary 0402 resistors and a normal trace on a two-layer board. It captures the actual `autorouting:start` input with the existing phase-capture fixture. The expected-failure assertion requires `maxViaCount: 0` on that connection. No routing data is fabricated and no production code changes are included.

This is specifically a missing-input-contract repro. An unobstructed trace can coincidentally route without vias even when its constraint was discarded, so a routed picture alone would not demonstrate this bug. Router enforcement and a congested-board behavioral regression belong in the subsequent fix.

Prepared against Core `0.0.1848`, upstream commit `8c16d03858c48242d18e8b08e3ea1e5434a2d5af`. Validation is delegated to PR CI; no local tests, builds, or routing were run.
