### PR TITLE
Emit display_tolerance for resistors

### DIFF
--- a/lib/components/normal-components/Resistor.ts
+++ b/lib/components/normal-components/Resistor.ts
@@ -50,6 +50,12 @@ export class Resistor extends NormalComponent<
     return `${formatSiUnit(this._parsedProps.resistance)}Ω`
   }
 
+  _getDisplayTolerance(): string | undefined {
+    const { tolerance } = this._parsedProps
+    if (tolerance === undefined) return undefined
+    return `${parseFloat((tolerance * 100).toPrecision(12))}%`
+  }
+
   doInitialCreateNetsFromProps() {
     this._createNetsFromProps([
       this.props.pullupFor,
@@ -103,6 +109,7 @@ export class Resistor extends NormalComponent<
 
       resistance: props.resistance,
       display_resistance: this._getSchematicSymbolDisplayValue(),
+      display_tolerance: this._getDisplayTolerance(),
       are_pins_interchangeable: true,
       display_name: props.displayName,
     } as SourceSimpleResistorInput)

--- a/tests/components/normal-components/resistor-display-value.test.tsx
+++ b/tests/components/normal-components/resistor-display-value.test.tsx
@@ -22,3 +22,55 @@ test("resistor display_value property", () => {
   expect(resistors).toHaveLength(1)
   expect(resistors[0].display_resistance).toBe("10kΩ")
 })
+
+test("resistor display_tolerance property", () => {
+  const { project } = getTestFixture()
+
+  project.add(
+    <board width="10mm" height="10mm">
+      <resistor
+        name="R1"
+        resistance="10k"
+        tolerance="5%"
+        footprint="0402"
+        pcbX={0}
+        pcbY={0}
+      />
+      <resistor
+        name="R2"
+        resistance="10k"
+        tolerance="7%"
+        footprint="0402"
+        pcbX={3}
+        pcbY={0}
+      />
+      <resistor
+        name="R3"
+        resistance="10k"
+        tolerance={0.001}
+        footprint="0402"
+        pcbX={6}
+        pcbY={0}
+      />
+      <resistor name="R4" resistance="10k" footprint="0402" pcbX={9} pcbY={0} />
+    </board>,
+  )
+
+  project.render()
+
+  const resistors = project.db.source_component.list({
+    ftype: "simple_resistor",
+  }) as Array<{
+    name: string
+    display_tolerance?: string
+  }>
+
+  const toleranceByName = Object.fromEntries(
+    resistors.map((r) => [r.name, r.display_tolerance]),
+  )
+
+  expect(toleranceByName.R1).toBe("5%")
+  expect(toleranceByName.R2).toBe("7%")
+  expect(toleranceByName.R3).toBe("0.1%")
+  expect(toleranceByName.R4).toBeUndefined()
+})


### PR DESCRIPTION
Blocked on tscircuit/circuit-json#759, which adds the field. CI here is red until that releases: `^0.0.484` is an exact pin for a `0.0.x` range, zod strips the unknown key, and the new test fails with `Received: undefined` against the released build. Everything else is done.

Writes `display_tolerance` on `source_simple_resistor` so the `tolerance` a resistor already accepts reaches Circuit JSON. `resistorProps` parses `tolerance="5%"` into `0.05` and validates it to 0..1, but `doInitialSourceRender` never wrote it, so the value was dropped straight after parsing. Addresses #3103 using the field suggested in #3097 rather than the normalized number that was pushed back on there.

The value is emitted as a percentage string to match `display_resistance`. `tolerance * 100` is rounded through `toPrecision(12)` because the multiplication is lossy for a lot of ordinary tolerances: `0.07 * 100` is `7.000000000000001`, and 191 of the first 2000 tenth-of-a-percent values are affected, including 0.9%, 1.7% and 3.3%. The familiar 1%, 5%, 10% and 20% happen to be exact, which is what makes it easy to miss.

For a resistor with no `tolerance` the key is present but `undefined`, the same as the existing `manufacturer_part_number`, and `JSON.stringify` drops it, so serialized Circuit JSON for those resistors is unchanged.

Validation, against a locally patched circuit-json carrying the field: `bunx tsc --noEmit` and biome pass. Ran all 374 tests in `tests/components/normal-components/` on an unmodified tree and again with this change, then diffed the failure sets: no new failures, the 9 that fail do so either way. Reverting the field write or the rounding each makes the new test fail, the second with `Received: "7.000000000000001%"`.
