### PR TITLE
Honor capacitor bypassFor and bypassTo

### DIFF
--- a/lib/components/normal-components/Capacitor.ts
+++ b/lib/components/normal-components/Capacitor.ts
@@ -103,24 +103,26 @@ export class Capacitor extends NormalComponent<
 
   doInitialCreateNetsFromProps() {
     this._createNetsFromProps([
-      this.props.decouplingFor,
-      this.props.decouplingTo,
+      this.props.decouplingFor ?? this.props.bypassFor,
+      this.props.decouplingTo ?? this.props.bypassTo,
       ...this._getNetsFromConnectionsProp(),
     ])
   }
 
   doInitialCreateTracesFromProps() {
-    if (this.props.decouplingFor && this.props.decouplingTo) {
+    const decouplingFor = this.props.decouplingFor ?? this.props.bypassFor
+    const decouplingTo = this.props.decouplingTo ?? this.props.bypassTo
+    if (decouplingFor && decouplingTo) {
       this.add(
         new Trace({
           from: `${this.getSubcircuitSelector()} > port.1`,
-          to: this.props.decouplingFor,
+          to: decouplingFor,
         }),
       )
       this.add(
         new Trace({
           from: `${this.getSubcircuitSelector()} > port.2`,
-          to: this.props.decouplingTo,
+          to: decouplingTo,
         }),
       )
     }

--- a/tests/components/normal-components/capacitor-bypass-props.test.tsx
+++ b/tests/components/normal-components/capacitor-bypass-props.test.tsx
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const traceNames = (circuit: any) =>
+  circuit.db.source_trace
+    .list()
+    .map((sourceTrace: any) => sourceTrace.display_name)
+    .sort()
+
+test("capacitor bypassFor and bypassTo create the same traces as decouplingFor and decouplingTo", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <capacitor
+        name="C1"
+        capacitance="100nF"
+        footprint="0402"
+        bypassFor="net.VCC"
+        bypassTo="net.GND"
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  expect(traceNames(circuit)).toEqual([
+    "capacitor.C1 > port.1 to net.VCC",
+    "capacitor.C1 > port.2 to net.GND",
+  ])
+
+  const netNames = circuit.db.source_net
+    .list()
+    .map((sourceNet: any) => sourceNet.name)
+    .sort()
+  expect(netNames).toContain("VCC")
+  expect(netNames).toContain("GND")
+})
+
+test("capacitor decouplingFor and decouplingTo still win when both pairs are given", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <capacitor
+        name="C1"
+        capacitance="100nF"
+        footprint="0402"
+        decouplingFor="net.VCC"
+        decouplingTo="net.GND"
+        bypassFor="net.OTHER_POWER"
+        bypassTo="net.OTHER_GROUND"
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  expect(traceNames(circuit)).toEqual([
+    "capacitor.C1 > port.1 to net.VCC",
+    "capacitor.C1 > port.2 to net.GND",
+  ])
+})
+
+test("capacitor with neither pair creates no traces", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+    </board>,
+  )
+
+  circuit.render()
+
+  expect(traceNames(circuit)).toEqual([])
+})


### PR DESCRIPTION
`bypassFor` and `bypassTo` are declared in `CapacitorProps` and parsed, but `Capacitor` only ever reads `decouplingFor` and `decouplingTo`, so a capacitor declared with the bypass pair produces no nets and no source traces. Fixes #3107.

They are handled as aliases of the decoupling pair, which is what the repro linked from that issue expects: the bypass props "should create the capacitor's two connections, as `decouplingFor` and `decouplingTo` do for the same component". The decoupling pair wins when both are given, so nothing gets a duplicate trace. `Capacitor_getAutomaticMaxDecouplingTraceLength` reads port connectivity rather than the props, so the automatic 1mm limit now covers bypass capacitors with no change needed there.

Validation: three new tests covering the bypass pair alone, both pairs together, and neither. `bunx tsc --noEmit` and biome pass, and every capacitor test file passes except `capacitor-polarized`, which times out at 8.5s against its 5s limit on an unmodified tree as well.
