### PR TITLE
Parse inductor inductance before writing Circuit JSON

### DIFF
--- a/lib/components/normal-components/Inductor.ts
+++ b/lib/components/normal-components/Inductor.ts
@@ -44,7 +44,7 @@ export class Inductor extends NormalComponent<
     const source_component = db.source_component.insert({
       name: this.name,
       ftype: FTYPE.simple_inductor,
-      inductance: this.props.inductance,
+      inductance: props.inductance,
       max_current_rating:
         props.maxCurrentRating === undefined
           ? undefined

--- a/tests/components/normal-components/inductor-inductance-parsing.test.tsx
+++ b/tests/components/normal-components/inductor-inductance-parsing.test.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import type { SourceSimpleInductor } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const inductanceOf = (circuit: any, name: string) =>
+  circuit.db.source_component
+    .list()
+    .find(
+      (sourceComponent: any): sourceComponent is SourceSimpleInductor =>
+        sourceComponent.ftype === "simple_inductor" &&
+        sourceComponent.name === name,
+    )?.inductance
+
+test("inductor unit strings reach Circuit JSON as numeric henries", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <inductor name="L1" inductance="10uH" footprint="0402" />
+      <inductor name="L2" inductance="4.7mH" footprint="0402" />
+      <inductor name="L3" inductance={0.001} footprint="0402" />
+    </board>,
+  )
+
+  circuit.render()
+
+  for (const name of ["L1", "L2", "L3"]) {
+    expect(typeof inductanceOf(circuit, name)).toBe("number")
+  }
+
+  expect(inductanceOf(circuit, "L1")).toBeCloseTo(0.00001, 12)
+  expect(inductanceOf(circuit, "L2")).toBeCloseTo(0.0047, 12)
+  expect(inductanceOf(circuit, "L3")).toBeCloseTo(0.001, 12)
+})

--- a/tests/components/normal-components/inductor.test.tsx
+++ b/tests/components/normal-components/inductor.test.tsx
@@ -21,7 +21,7 @@ test("<inductor /> component", async () => {
 
   expect(circuit.db.source_component.getWhere({ name: "U1" })).toMatchObject({
     ftype: "simple_inductor",
-    inductance: "10",
+    inductance: 10,
     max_current_rating: 2,
   })
 


### PR DESCRIPTION
`Inductor.doInitialSourceRender` writes `inductance: this.props.inductance`, the raw prop, while every neighbouring field reads the destructured `props`, which is `this._parsedProps`. So `inductance="10uH"` reaches Circuit JSON as the string `"10uH"` even though `SourceSimpleInductor.inductance` is typed as a number in henries, and `Resistor` one file over already does `resistance: props.resistance` correctly. Fixes #3111.

One character of the fix, but it changes an assertion that was encoding the bug: `tests/components/normal-components/inductor.test.tsx` expected `inductance: "10"` as a string. That is updated to `10`. Worth a look, since it is the one place this PR changes an existing expectation rather than adding one.

The new test covers a unit-suffixed string, a decimal unit string and a plain number. It asserts the type is `number` first and then compares with `toBeCloseTo`, because `format-si-unit` returns `0.000009999999999999999` for `10uH` and `1.0000000000000001e-7` for `100nH`. That float behaviour is upstream and untouched here.

Validation: `bunx tsc --noEmit` and biome pass. Reverting the one-word fix makes the new test fail with `Received: "string"`.
