### PR TITLE
fix: propagate routing progress and cancellation through circuit wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,38 @@ circuit.add(
 circuit.getCircuitJson()
 ```
 
+## Routing progress and cancellation
+
+`renderUntilSettled()` waits for asynchronous routing and emits routing progress
+on the circuit, including routing inside isolated subcircuits:
+
+```tsx
+const controller = new AbortController()
+circuit.on("autorouting:progress", (event) => {
+  console.log(event.phase, event.progress)
+})
+
+const rendering = circuit.renderUntilSettled({ signal: controller.signal })
+// For example, a Cancel button can call:
+// controller.abort(new Error("Canceled by user"))
+await rendering
+```
+
+For isolated routing, `isolatedSubcircuitPath` identifies the render context from
+outermost to innermost subcircuit. Combine it with `subcircuit_id` when tracking
+concurrent phases; the IDs inside each isolated circuit remain local to its JSON.
+
+Aborting rejects the render with `signal.reason`, stops the active local router,
+and prevents later routing phases from starting. Remote requests and polling are
+aborted locally; cancellation does not delete an already submitted server job.
+Local cancellation is cooperative: a synchronous solver step must return before
+the event loop can process cancellation.
+
+For a manual loop using `circuit.render()`, call
+`circuit.cancelRendering(reason)` to stop routing. Cancellation is terminal for
+that circuit; create a new `Circuit` to restart. The optional signal is detached
+after a completed render, so aborting it later does not cancel that circuit.
+
 ## Non-React Usage
 
 ```tsx

--- a/lib/IIsolatedCircuit.ts
+++ b/lib/IIsolatedCircuit.ts
@@ -2,6 +2,7 @@ import type { RenderPhase } from "lib/components/base-components/Renderable"
 import type { RootCircuitEventName } from "lib/events"
 
 export interface IIsolatedCircuit {
+  readonly _renderAbortSignal: AbortSignal
   emit(event: RootCircuitEventName, ...args: any[]): void
   on(event: RootCircuitEventName, listener: (...args: any[]) => void): void
   isDoneRendering(): boolean

--- a/lib/IsolatedCircuit.ts
+++ b/lib/IsolatedCircuit.ts
@@ -13,6 +13,7 @@ import { Group } from "./components/primitive-components/Group"
 import type { RootCircuitEventName } from "./events"
 import { createInstanceFromReactElement } from "./fiber/create-instance-from-react-element"
 import { isAssemblyDeviceContainer } from "./components/base-components/is-assembly-device-container"
+import { abortableDelay } from "./utils/abortable-delay"
 
 export class IsolatedCircuit {
   firstChild: PrimitiveComponent | null = null
@@ -78,6 +79,12 @@ export class IsolatedCircuit {
   projectUrl?: string
 
   _hasRenderedAtleastOnce = false
+  private readonly _renderAbortController = new AbortController()
+
+  /** Captured by routing effects, including effects started with render(). */
+  get _renderAbortSignal(): AbortSignal {
+    return this._renderAbortController.signal
+  }
   private _asyncEffectIdsByPhase = new Map<RenderPhase, Set<string>>()
   private _asyncEffectPhaseById = new Map<string, RenderPhase>()
   private _hasUnrenderedUpdatesFromAsyncEffects = false
@@ -202,6 +209,7 @@ export class IsolatedCircuit {
   }
 
   render() {
+    this._renderAbortSignal.throwIfAborted()
     if (!this.firstChild) {
       this._guessRootComponent()
     }
@@ -213,7 +221,29 @@ export class IsolatedCircuit {
     this._hasRenderedAtleastOnce = true
   }
 
-  async renderUntilSettled(): Promise<void> {
+  /**
+   * Stop rendering and cancel active autorouting. A canceled circuit cannot be
+   * resumed; create a new Circuit to start another render.
+   */
+  cancelRendering(reason?: unknown): void {
+    this._renderAbortController.abort(reason)
+  }
+
+  async renderUntilSettled({
+    signal,
+  }: { signal?: AbortSignal } = {}): Promise<void> {
+    const onAbort = () => this.cancelRendering(signal?.reason)
+    if (signal?.aborted) onAbort()
+    signal?.addEventListener("abort", onAbort, { once: true })
+    try {
+      await this._renderUntilSettled()
+    } finally {
+      signal?.removeEventListener("abort", onAbort)
+    }
+  }
+
+  private async _renderUntilSettled(): Promise<void> {
+    this._renderAbortSignal.throwIfAborted()
     const existing = this.db.source_project_metadata.list()?.[0]
     if (!existing) {
       this.db.source_project_metadata.insert({
@@ -225,10 +255,11 @@ export class IsolatedCircuit {
     this.render()
 
     while (!this.isDoneRendering()) {
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      await abortableDelay(100, this._renderAbortSignal)
       this.render()
     }
 
+    this._renderAbortSignal.throwIfAborted()
     this.emit("renderComplete")
   }
 

--- a/lib/components/base-components/Renderable.ts
+++ b/lib/components/base-components/Renderable.ts
@@ -315,9 +315,12 @@ export abstract class Renderable implements IRenderable {
         }
       })
       .catch((error) => {
-        console.error(
-          `Async effect error in ${asyncEffect.phase} "${effectName}":\n${error.stack}`,
-        )
+        const signal = this._getRootCircuit()?._renderAbortSignal
+        if (!signal?.aborted || error !== signal.reason) {
+          console.error(
+            `Async effect error in ${asyncEffect.phase} "${effectName}":\n${error.stack}`,
+          )
+        }
         asyncEffect.complete = true
 
         // HACK: emit to the root circuit component that an async effect has completed
@@ -328,7 +331,7 @@ export abstract class Renderable implements IRenderable {
             effectName,
             componentDisplayName: this.getString(),
             phase: asyncEffect.phase,
-            error: error.toString(),
+            error: String(error),
           })
         }
       })

--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -33,6 +33,7 @@ import { AutorouterError } from "lib/errors/AutorouterError"
 import type { AutorouterOptions } from "lib/utils/autorouting/CapacityMeshAutorouter"
 import { FanoutAutorouter } from "lib/utils/autorouting/FanoutAutorouter"
 import type { GenericLocalAutorouter } from "lib/utils/autorouting/GenericLocalAutorouter"
+import { abortableDelay } from "lib/utils/abortable-delay"
 import type {
   SimpleRouteBounds,
   SimpleRouteJson,
@@ -831,6 +832,8 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
 
   async _runEffectMakeHttpAutoroutingRequest() {
     const { db } = this.root!
+    const signal = this.root!._renderAbortSignal
+    signal.throwIfAborted()
     const debug = Debug("tscircuit:core:_runEffectMakeHttpAutoroutingRequest")
     const props = this._parsedProps as SubcircuitGroupProps
 
@@ -846,7 +849,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         // @ts-ignore
         options.headers["Tscircuit-Core-Version"] = this.root?.getCoreVersion()!
       }
-      return fetch(url, options)
+      return fetch(url, { ...options, signal })
     }
 
     // Only include source and pcb elements
@@ -888,6 +891,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             },
           },
         ).then((r) => r.json())
+        signal.throwIfAborted()
         this._asyncAutoroutingResult = autorouting_result
         this._markDirty("PcbTraceRender")
         return
@@ -906,6 +910,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
           },
         },
       ).then((r) => r.json())
+      signal.throwIfAborted()
       this._asyncAutoroutingResult = autorouting_result
       this._markDirty("PcbTraceRender")
       return
@@ -931,6 +936,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
 
     // Poll until job is complete
     while (true) {
+      signal.throwIfAborted()
       const { autorouting_job: job } = (await fetchWithDebug(
         `${serverUrl}/autorouting/jobs/get`,
         {
@@ -954,6 +960,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
           finished_at?: string
         }
       }
+      signal.throwIfAborted()
       if (job.is_finished) {
         const { autorouting_job_output } = await fetchWithDebug(
           `${serverUrl}/autorouting/jobs/get_output`,
@@ -966,6 +973,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
           },
         ).then((r) => r.json())
 
+        signal.throwIfAborted()
         this._asyncAutoroutingResult = {
           output_pcb_traces: autorouting_job_output.output_pcb_traces,
         }
@@ -986,7 +994,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       }
 
       // Wait before polling again
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      await abortableDelay(100, signal)
     }
   }
 
@@ -995,6 +1003,8 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
    */
   async _runLocalAutorouting() {
     const { db } = this.root!
+    const signal = this.root!._renderAbortSignal
+    signal.throwIfAborted()
     const props = this._parsedProps as SubcircuitGroupProps
     const debug = Debug("tscircuit:core:_runLocalAutorouting")
     debug(`[${this.getString()}] starting local autorouting`)
@@ -1300,6 +1310,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         phaseStageCount,
       },
     ] of routingStages.entries()) {
+      signal.throwIfAborted()
       if (!usesPreviousStageOutput) {
         previousStageOutputSimpleRouteJson = undefined
       }
@@ -1546,6 +1557,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       const cachedResult = cacheKey
         ? await getCachedLocalAutoroutingPhaseResult({ cacheEngine, cacheKey })
         : null
+      signal.throwIfAborted()
       const cacheDisabledReason = phaseAutorouterConfig.algorithmFn
         ? "custom_algorithm"
         : !localAutorouterStrategy.cacheable
@@ -1585,8 +1597,10 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         simpleRouteJson,
       })
       let autorouter: GenericLocalAutorouter | undefined
+      let removeAbortListener: (() => void) | undefined
 
       try {
+        signal.throwIfAborted()
         let traces: SimplifiedPcbTrace[]
         if (cachedResult) {
           debug(`[${this.getString()}] using cached local autorouting result`)
@@ -1622,15 +1636,25 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
           if (!autorouter) {
             throw new Error("Failed to create local autorouter")
           }
+          signal.throwIfAborted()
           const activeAutorouter = autorouter
           const routingPromise = new Promise<SimplifiedPcbTrace[]>(
             (resolve, reject) => {
+              const onAbort = () => {
+                activeAutorouter.stop()
+                reject(signal.reason)
+              }
+              signal.addEventListener("abort", onAbort, { once: true })
+              removeAbortListener = () =>
+                signal.removeEventListener("abort", onAbort)
               activeAutorouter.on("complete", (event) => {
+                if (signal.aborted) return
                 debug(`[${this.getString()}] local autorouting complete`)
                 resolve(event.traces)
               })
 
               activeAutorouter.on("error", (event) => {
+                if (signal.aborted) return
                 debug(
                   `[${this.getString()}] local autorouting error: ${event.error.message}`,
                 )
@@ -1640,6 +1664,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
           )
 
           activeAutorouter.on("progress", (event) => {
+            if (signal.aborted) return
             this.root?.emit("autorouting:progress", {
               subcircuit_id: this.subcircuit_id,
               componentDisplayName: this.getString(),
@@ -1659,6 +1684,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
           activeAutorouter.start()
           traces = await routingPromise
         }
+        signal.throwIfAborted()
 
         let transformedSimpleRouteJson =
           autorouter?.getOutputSimpleRouteJson?.()
@@ -1740,6 +1766,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             },
           })
         }
+        signal.throwIfAborted()
 
         this.root?.emit("autorouting:end", {
           type: "autorouting:end",
@@ -1755,6 +1782,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
           ...autoroutingMetadata,
           simpleRouteJson: outputSimpleRouteJson,
         })
+        signal.throwIfAborted()
 
         // Create source_traces for interconnect ports that were connected via
         // off-board paths during routing. This allows DRC to understand that
@@ -1822,6 +1850,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
           )
         }
       } catch (error) {
+        if (signal.aborted) throw signal.reason
         const { db } = this.root!
         // Record the error
         db.pcb_autorouting_error.insert({
@@ -1850,11 +1879,13 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
 
         throw error
       } finally {
+        removeAbortListener?.()
         // Ensure the autorouter is stopped
         autorouter?.stop()
       }
     }
 
+    signal.throwIfAborted()
     // Store the result
     this._asyncAutoroutingResult = {
       output_pcb_traces: outputTraces as any,

--- a/lib/components/primitive-components/Group/Subcircuit/Subcircuit_doInitialRenderIsolatedSubcircuits.ts
+++ b/lib/components/primitive-components/Group/Subcircuit/Subcircuit_doInitialRenderIsolatedSubcircuits.ts
@@ -1,5 +1,6 @@
 import type { AnyCircuitElement } from "circuit-json"
 import { IsolatedCircuit } from "lib/IsolatedCircuit"
+import type { AutoroutingExecutionMetadata } from "lib/events"
 import type { ISubcircuit } from "./ISubcircuit"
 
 /**
@@ -48,8 +49,10 @@ export function Subcircuit_doInitialRenderIsolatedSubcircuits(
   subcircuit._normalComponentNameMap = null
 
   const parentRoot = subcircuit.root!
+  const signal = parentRoot._renderAbortSignal
 
   subcircuit._queueAsyncEffect("render-isolated-subcircuit", async () => {
+    signal.throwIfAborted()
     // Check cache again (might have been populated while waiting to execute)
     const cachedResult = cachedSubcircuits?.get(propHash)
     if (cachedResult) {
@@ -62,19 +65,24 @@ export function Subcircuit_doInitialRenderIsolatedSubcircuits(
     const pendingRenderPromise = pendingSubcircuitRenders?.get(propHash)
     if (pendingRenderPromise) {
       // Another subcircuit is already rendering - wait for it
-      subcircuit._isolatedCircuitJson = await pendingRenderPromise
+      const circuitJson = await pendingRenderPromise
+      signal.throwIfAborted()
+      subcircuit._isolatedCircuitJson = circuitJson
       return
     }
 
     // We're the first - create promise and register it
     let resolveRender!: (json: AnyCircuitElement[]) => void
-    let rejectRender!: (error: Error) => void
+    let rejectRender!: (error: unknown) => void
     const renderPromise = new Promise<AnyCircuitElement[]>(
       (resolve, reject) => {
         resolveRender = resolve
         rejectRender = reject
       },
     )
+    // The owning effect awaits the render below; the shared promise may have
+    // no duplicate subscribers when cancellation rejects it.
+    void renderPromise.catch(() => {})
     pendingSubcircuitRenders?.set(propHash, renderPromise)
 
     try {
@@ -88,12 +96,40 @@ export function Subcircuit_doInitialRenderIsolatedSubcircuits(
         pendingSubcircuitRenders,
       })
 
+      const forwardedListeners = [
+        "autorouting:start",
+        "autorouting:progress",
+        "autorouting:end",
+        "autorouting:error",
+        "solver:started",
+        "solver:ended",
+      ] as const
+      const removeForwardedListeners = forwardedListeners.map((eventName) => {
+        const listener = (event: AutoroutingExecutionMetadata) => {
+          if (signal.aborted) return
+          parentRoot.emit(eventName, {
+            ...event,
+            isolatedSubcircuitPath: [
+              subcircuit._renderId,
+              ...(event.isolatedSubcircuitPath ?? []),
+            ],
+          })
+        }
+        isolatedCircuit.on(eventName, listener)
+        return () => isolatedCircuit.removeListener(eventName, listener)
+      })
+
       for (const child of childrenToRender) {
         isolatedCircuit.add(child)
       }
 
       // Render until all async effects complete (including nested isolated subcircuits)
-      await isolatedCircuit.renderUntilSettled()
+      try {
+        await isolatedCircuit.renderUntilSettled({ signal })
+      } finally {
+        for (const removeListener of removeForwardedListeners) removeListener()
+      }
+      signal.throwIfAborted()
 
       const circuitJson = isolatedCircuit.getCircuitJson()
 
@@ -106,7 +142,7 @@ export function Subcircuit_doInitialRenderIsolatedSubcircuits(
       resolveRender(circuitJson)
     } catch (error) {
       // Reject so waiting subcircuits don't hang forever
-      rejectRender(error instanceof Error ? error : new Error(String(error)))
+      rejectRender(error)
       throw error
     } finally {
       // Clean up the pending render entry

--- a/lib/events/index.ts
+++ b/lib/events/index.ts
@@ -30,6 +30,8 @@ export type AutoroutingCacheDisabledReason =
   | "no_cache_engine"
 
 export interface AutoroutingExecutionMetadata {
+  /** Render IDs from outermost to innermost isolated subcircuit. */
+  isolatedSubcircuitPath?: string[]
   routingPhaseIndex?: number | null
   phaseOrdinal?: number
   phaseCount?: number
@@ -110,6 +112,7 @@ export interface PackingErrorEvent {
 }
 
 export interface SolverStartedEvent {
+  isolatedSubcircuitPath?: AutoroutingExecutionMetadata["isolatedSubcircuitPath"]
   type: "solver:started"
   solverName: keyof typeof SOLVERS
   solverParams: any
@@ -119,6 +122,7 @@ export interface SolverStartedEvent {
 }
 
 export interface SolverEndedEvent {
+  isolatedSubcircuitPath?: AutoroutingExecutionMetadata["isolatedSubcircuitPath"]
   type: "solver:ended"
   solverName: keyof typeof SOLVERS
   componentName: string

--- a/lib/utils/abortable-delay.ts
+++ b/lib/utils/abortable-delay.ts
@@ -1,0 +1,19 @@
+/** Wait between cooperative work cycles without retaining a timer after abort. */
+export const abortableDelay = (
+  milliseconds: number,
+  signal?: AbortSignal,
+): Promise<void> => {
+  signal?.throwIfAborted()
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer)
+      signal?.removeEventListener("abort", onAbort)
+      reject(signal?.reason)
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort)
+      resolve()
+    }, milliseconds)
+    signal?.addEventListener("abort", onAbort, { once: true })
+  })
+}

--- a/lib/utils/autorouting/CapacityMeshAutorouter.ts
+++ b/lib/utils/autorouting/CapacityMeshAutorouter.ts
@@ -140,9 +140,11 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
     error: [],
     progress: [],
   }
-  private cycleCount = 0
+  private stepCount = 0
+  private runId = 0
+  private cycleInProgress = false
   private stepDelay: number
-  private timeoutId?: number
+  private timeoutId?: ReturnType<typeof setTimeout>
 
   constructor(input: SimpleRouteJson, options: AutorouterOptions = {}) {
     this.input = input
@@ -203,10 +205,19 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
     if (this.isRouting) return
 
     this.isRouting = true
-    this.cycleCount = 0
+    this.stepCount = 0
+    this.runId++
 
-    // Start the routing process with steps
-    void this.runCycleAndQueueNextCycle()
+    // A restarted run must wait for an outstanding asynchronous step to settle.
+    if (!this.cycleInProgress) this.queueNextCycle(0)
+  }
+
+  private queueNextCycle(delay: number): void {
+    const runId = this.runId
+    this.timeoutId = setTimeout(() => {
+      this.timeoutId = undefined
+      void this.runCycleAndQueueNextCycle(runId)
+    }, delay)
   }
 
   private async stepSolver(): Promise<void> {
@@ -224,54 +235,59 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
   /**
    * Execute the next routing step and schedule the following one if needed
    */
-  private async runCycleAndQueueNextCycle(): Promise<void> {
-    if (!this.isRouting) return
+  private async runCycleAndQueueNextCycle(runId: number): Promise<void> {
+    if (!this.isRouting || runId !== this.runId) return
 
+    this.cycleInProgress = true
     try {
       // If already solved or failed, complete the routing
       if (this.solver.solved || this.solver.failed) {
-        if (this.solver.failed) {
-          this.emitEvent({
-            type: "error",
-            error: new AutorouterError(this.solver.error || "Routing failed"),
-          })
-        } else {
-          this.emitEvent({
-            type: "complete",
-            traces:
-              this.solver.getOutputSimplifiedPcbTraces() as SimplifiedPcbTrace[],
-          })
-        }
+        const event: AutorouterCompleteEvent | AutorouterErrorEvent = this
+          .solver.failed
+          ? {
+              type: "error",
+              error: new AutorouterError(this.solver.error || "Routing failed"),
+            }
+          : {
+              type: "complete",
+              traces:
+                this.solver.getOutputSimplifiedPcbTraces() as SimplifiedPcbTrace[],
+            }
         this.isRouting = false
+        this.emitEvent(event)
         return
       }
 
-      // Execute one step of the solver
-      // Execute for 10ms to allow the solver to make progress
+      // Yield between 250 ms slices. An individual step cannot be interrupted.
       const startTime = Date.now()
       const startIterations = this.solver.iterations
       while (
         Date.now() - startTime < 250 &&
+        this.isRouting &&
+        runId === this.runId &&
         !this.solver.failed &&
         !this.solver.solved
       ) {
         await this.stepSolver()
+        if (!this.isRouting || runId !== this.runId) return
+        this.stepCount++
       }
+      if (!this.isRouting || runId !== this.runId) return
+
       const iterationsPerSecond =
         ((this.solver.iterations - startIterations) /
-          (Date.now() - startTime)) *
+          Math.max(1, Date.now() - startTime)) *
         1000
-      this.cycleCount++
 
       // Get visualization data if available
       const debugGraphics = this.solver?.preview() || undefined
 
       // Report progress
-      const progress = this.solver.progress
+      const progress = this.solver.solved ? 1 : this.solver.progress
 
       this.emitEvent({
         type: "progress",
-        steps: this.cycleCount,
+        steps: this.stepCount,
         iterationsPerSecond,
         progress,
         phase:
@@ -281,22 +297,11 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
               this.solver.getSolverName()),
         debugGraphics,
       })
-
-      // Schedule the next step
-      if (this.stepDelay > 0) {
-        this.timeoutId = setTimeout(
-          () => void this.runCycleAndQueueNextCycle(),
-          this.stepDelay,
-        ) as unknown as number
-      } else {
-        // Use setImmediate or setTimeout with 0 to prevent blocking the event loop
-        this.timeoutId = setTimeout(
-          () => void this.runCycleAndQueueNextCycle(),
-          0,
-        ) as unknown as number
-      }
     } catch (error) {
+      if (runId !== this.runId) return
+
       // Handle any errors during the step
+      this.isRouting = false
       this.emitEvent({
         type: "error",
         error:
@@ -304,7 +309,10 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
             ? new AutorouterError(error.message)
             : new AutorouterError(String(error)),
       })
-      this.isRouting = false
+    } finally {
+      this.cycleInProgress = false
+      // Progress and terminal listeners may stop or restart routing.
+      if (this.isRouting) this.queueNextCycle(this.stepDelay)
     }
   }
 
@@ -312,9 +320,8 @@ export class TscircuitAutorouter implements GenericLocalAutorouter {
    * Stop the routing process if it's in progress
    */
   stop(): void {
-    if (!this.isRouting) return
-
     this.isRouting = false
+    this.runId++
     if (this.timeoutId !== undefined) {
       clearTimeout(this.timeoutId)
       this.timeoutId = undefined

--- a/lib/utils/autorouting/FanoutAutorouter.ts
+++ b/lib/utils/autorouting/FanoutAutorouter.ts
@@ -580,7 +580,11 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
         steps: fanoutSolver.iterations,
         progress: fanoutSolver.solved ? 1 : fanoutSolver.progress,
         phase: this.options.mode,
-        debugGraphics: fanoutSolver.visualize(),
+        // Full visualizations rebuild the routing geometry and are expensive
+        // on dense boards. Use the solver's streaming preview between steps.
+        debugGraphics: fanoutSolver.solved
+          ? fanoutSolver.visualize()
+          : fanoutSolver.preview(),
       })
       // Progress handlers may stop or restart this router.
       if (!this.isRouting || this.runId !== runId) return

--- a/lib/utils/autorouting/FanoutAutorouter.ts
+++ b/lib/utils/autorouting/FanoutAutorouter.ts
@@ -373,6 +373,7 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
   isRouting = false
   private outputSimpleRouteJson?: SimpleRouteJson
   private startTimeoutId?: number
+  private runId = 0
   private eventHandlers: {
     complete: Array<(event: AutorouterCompleteEvent) => void>
     error: Array<(event: AutorouterErrorEvent) => void>
@@ -502,11 +503,7 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
     )
   }
 
-  private solveFanout(): {
-    downstreamSimpleRouteJson: SimpleRouteJson
-    fanoutTraces: SimplifiedPcbTrace[]
-    debugGraphics: AutorouterProgressEvent["debugGraphics"]
-  } {
+  private createFanoutSolver(): FanoutSolver {
     const fanoutSolverOptions = this.getFanoutSolverOptions()
     const fanoutSolver = new FanoutSolver(
       this.input as unknown as ConstructorParameters<typeof FanoutSolver>[0],
@@ -523,7 +520,13 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
       solverParams: solverConstructorArgs[0],
       solverConstructorArgs,
     })
-    fanoutSolver.solve()
+    return fanoutSolver
+  }
+
+  private getFanoutResult(fanoutSolver: FanoutSolver): {
+    downstreamSimpleRouteJson: SimpleRouteJson
+    fanoutTraces: SimplifiedPcbTrace[]
+  } {
     if (fanoutSolver.failed) {
       throw new Error(
         getFanoutSpaceErrorMessage({
@@ -532,8 +535,7 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
           componentIds: new Set(
             fanoutSolver.preparedBuses.map((bus) => bus.componentId),
           ),
-          sharedBoundary:
-            this.options.fanoutBounds ?? fanoutSolverOptions.sharedBoundary,
+          sharedBoundary: this.options.fanoutBounds,
           componentNamesById: this.options.componentNamesById,
         }),
       )
@@ -550,30 +552,52 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
         ),
       }),
       fanoutTraces,
-      debugGraphics: fanoutSolver.visualize(),
     }
   }
 
-  private startFanout(): void {
+  private runFanoutCycle(fanoutSolver: FanoutSolver, runId: number): void {
+    if (!this.isRouting || this.runId !== runId) return
     try {
-      const { downstreamSimpleRouteJson, fanoutTraces, debugGraphics } =
-        this.solveFanout()
-      if (!this.isRouting) return
-      this.outputSimpleRouteJson = downstreamSimpleRouteJson
-
+      const cycleStart = performance.now()
+      let cycleSteps = 0
+      // Yield between slices so timers, UI updates and cancellation can run.
+      // A synchronous solver step itself cannot be interrupted.
+      while (
+        !fanoutSolver.solved &&
+        !fanoutSolver.failed &&
+        this.isRouting &&
+        this.runId === runId &&
+        cycleSteps < 1000 &&
+        performance.now() - cycleStart < 250
+      ) {
+        fanoutSolver.step()
+        cycleSteps++
+      }
+      if (!this.isRouting || this.runId !== runId) return
+      if (fanoutSolver.failed) this.getFanoutResult(fanoutSolver)
       this.emitEvent({
         type: "progress",
-        steps: 1,
-        progress: 1,
+        steps: fanoutSolver.iterations,
+        progress: fanoutSolver.solved ? 1 : fanoutSolver.progress,
         phase: this.options.mode,
-        debugGraphics,
+        debugGraphics: fanoutSolver.visualize(),
       })
-      this.isRouting = false
-      this.emitEvent({
-        type: "complete",
-        traces: fanoutTraces,
-      })
+      // Progress handlers may stop or restart this router.
+      if (!this.isRouting || this.runId !== runId) return
+      if (fanoutSolver.solved) {
+        const { downstreamSimpleRouteJson, fanoutTraces } =
+          this.getFanoutResult(fanoutSolver)
+        this.outputSimpleRouteJson = downstreamSimpleRouteJson
+        this.isRouting = false
+        this.emitEvent({ type: "complete", traces: fanoutTraces })
+      } else {
+        this.startTimeoutId = setTimeout(() => {
+          this.startTimeoutId = undefined
+          this.runFanoutCycle(fanoutSolver, runId)
+        }, 0) as unknown as number
+      }
     } catch (caughtError) {
+      if (!this.isRouting || this.runId !== runId) return
       this.isRouting = false
       this.emitEvent({
         type: "error",
@@ -588,13 +612,28 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
   start(): void {
     if (this.isRouting) return
     this.isRouting = true
+    this.outputSimpleRouteJson = undefined
+    const runId = ++this.runId
     this.startTimeoutId = setTimeout(() => {
       this.startTimeoutId = undefined
-      this.startFanout()
+      try {
+        this.runFanoutCycle(this.createFanoutSolver(), runId)
+      } catch (caughtError) {
+        if (!this.isRouting || this.runId !== runId) return
+        this.isRouting = false
+        this.emitEvent({
+          type: "error",
+          error:
+            caughtError instanceof Error
+              ? caughtError
+              : new Error(String(caughtError)),
+        })
+      }
     }, 0) as unknown as number
   }
 
   stop(): void {
+    this.runId++
     if (this.startTimeoutId !== undefined) {
       clearTimeout(this.startTimeoutId)
       this.startTimeoutId = undefined
@@ -641,7 +680,10 @@ export class FanoutAutorouter implements GenericLocalAutorouter {
   }
 
   solveSync(): SimplifiedPcbTrace[] {
-    const { downstreamSimpleRouteJson, fanoutTraces } = this.solveFanout()
+    const fanoutSolver = this.createFanoutSolver()
+    fanoutSolver.solve()
+    const { downstreamSimpleRouteJson, fanoutTraces } =
+      this.getFanoutResult(fanoutSolver)
     this.outputSimpleRouteJson = downstreamSimpleRouteJson
     return fanoutTraces
   }

--- a/lib/utils/autorouting/GenericLocalAutorouter.ts
+++ b/lib/utils/autorouting/GenericLocalAutorouter.ts
@@ -29,7 +29,13 @@ export interface GenericLocalAutorouter {
   input: SimpleRouteJson
   isRouting: boolean
 
+  /** Start cooperative routing, yielding between work slices for progress and cancellation. */
   start(): void
+  /**
+   * Cancel the current run and release scheduled work. After stop returns, the
+   * canceled run must not emit progress, complete, or error events. A synchronous
+   * solver step already in progress can only be stopped when that step returns.
+   */
   stop(): void
 
   on(event: "complete", callback: (ev: AutorouterCompleteEvent) => void): void

--- a/tests/features/autorouting-abort-active-phase.test.tsx
+++ b/tests/features/autorouting-abort-active-phase.test.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { ControllableAutorouter } from "tests/fixtures/controllable-autorouter"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+
+test("render cancellation stops the active phase and ignores late router events", async () => {
+  const { circuit } = getTestFixture()
+  const controller = new AbortController()
+  const reason = new Error("Canceled during phase progress")
+  const routers: ControllableAutorouter[] = []
+  const events: string[] = []
+  const algorithmFn = async (input: SimpleRouteJson) => {
+    const router = new ControllableAutorouter(input)
+    routers.push(router)
+    router.onStart = () =>
+      router.emit({ type: "progress", steps: 1, progress: 0.25 })
+    return router
+  }
+  circuit.on("autorouting:start", () => events.push("start"))
+  circuit.on("autorouting:end", () => events.push("end"))
+  circuit.on("autorouting:error", () => events.push("error"))
+  circuit.on("renderComplete", () => events.push("render_complete"))
+  circuit.on("autorouting:progress", () => {
+    events.push("progress")
+    controller.abort(reason)
+  })
+  circuit.add(
+    <board width={16} height={12} autorouter={{ algorithmFn }}>
+      <resistor name="A1" resistance="1k" footprint="0402" pcbX={-5} pcbY={2} />
+      <resistor name="A2" resistance="1k" footprint="0402" pcbX={5} pcbY={2} />
+      <resistor
+        name="B1"
+        resistance="1k"
+        footprint="0402"
+        pcbX={-5}
+        pcbY={-2}
+      />
+      <resistor name="B2" resistance="1k" footprint="0402" pcbX={5} pcbY={-2} />
+      <trace from="A1.pin1" to="A2.pin1" routingPhaseIndex={0} />
+      <trace from="B1.pin1" to="B2.pin1" routingPhaseIndex={1} />
+    </board>,
+  )
+
+  await expect(
+    circuit.renderUntilSettled({ signal: controller.signal }),
+  ).rejects.toBe(reason)
+  expect(routers).toHaveLength(1)
+  expect(routers[0]!.isRouting).toBe(false)
+  expect(routers[0]!.stopCount).toBeGreaterThan(0)
+  routers[0]!.emit({ type: "progress", steps: 2, progress: 1 })
+  routers[0]!.emit({ type: "complete", traces: [] })
+  routers[0]!.emit({ type: "error", error: new Error("Late error") })
+  expect(events).toEqual(["start", "progress"])
+  expect(circuit.db.pcb_autorouting_error.list()).toHaveLength(0)
+  expect(circuit.db.pcb_trace.list()).toHaveLength(0)
+  expect(() => circuit.render()).toThrow(reason)
+})

--- a/tests/features/autorouting-abort-at-phase-end.test.tsx
+++ b/tests/features/autorouting-abort-at-phase-end.test.tsx
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import type { Group } from "lib/components/primitive-components/Group/Group"
+import { ControllableAutorouter } from "tests/fixtures/controllable-autorouter"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { abortableDelay } from "lib/utils/abortable-delay"
+
+test("canceling a phase end event prevents publishing the routing result", async () => {
+  const { circuit } = getTestFixture()
+  const reason = new Error("Cancel before publishing routing")
+  circuit.on("autorouting:end", () => circuit.cancelRendering(reason))
+  circuit.add(
+    <board
+      width={16}
+      height={12}
+      autorouter={{
+        algorithmFn: async (input) => {
+          const router = new ControllableAutorouter(input)
+          router.onStart = () => router.emit({ type: "complete", traces: [] })
+          return router
+        },
+      }}
+    >
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={5} />
+      <trace from="R1.pin1" to="R2.pin1" />
+    </board>,
+  )
+  await expect(circuit.renderUntilSettled()).rejects.toBe(reason)
+  await abortableDelay(0)
+  const board = circuit.firstChild as Group
+  expect(board._asyncAutoroutingResult).toBeNull()
+  expect(circuit.db.pcb_autorouting_error.list()).toHaveLength(0)
+})

--- a/tests/features/autorouting-abort-at-phase-start.test.tsx
+++ b/tests/features/autorouting-abort-at-phase-start.test.tsx
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { ControllableAutorouter } from "tests/fixtures/controllable-autorouter"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("canceling the phase start event prevents creating its autorouter", async () => {
+  const { circuit } = getTestFixture()
+  const reason = new Error("Cancel before phase initialization")
+  let factoryCalled = false
+  circuit.on("autorouting:start", () => circuit.cancelRendering(reason))
+  circuit.add(
+    <board
+      width={16}
+      height={12}
+      autorouter={{
+        algorithmFn: async (input) => {
+          factoryCalled = true
+          return new ControllableAutorouter(input)
+        },
+      }}
+    >
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={5} />
+      <trace from="R1.pin1" to="R2.pin1" />
+    </board>,
+  )
+  await expect(circuit.renderUntilSettled()).rejects.toBe(reason)
+  expect(factoryCalled).toBe(false)
+  expect(circuit.db.pcb_autorouting_error.list()).toHaveLength(0)
+})

--- a/tests/features/autorouting-abort-pending-cache.test.tsx
+++ b/tests/features/autorouting-abort-pending-cache.test.tsx
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { abortableDelay } from "lib/utils/abortable-delay"
+
+test("a cache result received after cancellation cannot start or complete routing", async () => {
+  const requested = Promise.withResolvers<void>()
+  const cacheResult = Promise.withResolvers<string>()
+  const { circuit } = getTestFixture({
+    platform: {
+      localCacheEngine: {
+        getItem: (key) => {
+          if (!key.startsWith("routes:")) return null
+          requested.resolve()
+          return cacheResult.promise
+        },
+        setItem: () => {},
+      },
+    },
+  })
+  const reason = new Error("Cancel pending routing cache lookup")
+  const events: string[] = []
+  circuit.on("autorouting:start", () => events.push("start"))
+  circuit.on("autorouting:end", () => events.push("end"))
+  circuit.on("autorouting:error", () => events.push("error"))
+  circuit.on("solver:started", () => events.push("solver"))
+  circuit.add(
+    <board width={16} height={12}>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={5} />
+      <trace from="R1.pin1" to="R2.pin1" />
+    </board>,
+  )
+  const rendering = circuit.renderUntilSettled()
+  await requested.promise
+  events.length = 0
+  circuit.cancelRendering(reason)
+  await expect(rendering).rejects.toBe(reason)
+  cacheResult.resolve(JSON.stringify({ traces: [] }))
+  await abortableDelay(0)
+  expect(events).toEqual([])
+  expect(circuit.db.pcb_autorouting_error.list()).toHaveLength(0)
+  expect(circuit.db.pcb_trace.list()).toHaveLength(0)
+})

--- a/tests/features/autorouting-abort-pending-factory.test.tsx
+++ b/tests/features/autorouting-abort-pending-factory.test.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { ControllableAutorouter } from "tests/fixtures/controllable-autorouter"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { abortableDelay } from "lib/utils/abortable-delay"
+
+test("cancellation stops a router created after its async factory was canceled", async () => {
+  const { circuit } = getTestFixture()
+  const created = Promise.withResolvers<ControllableAutorouter>()
+  const factory = Promise.withResolvers<ControllableAutorouter>()
+  const reason = new Error("Canceled pending router factory")
+  circuit.add(
+    <board
+      width={16}
+      height={12}
+      autorouter={{
+        algorithmFn: async (input) => {
+          created.resolve(new ControllableAutorouter(input))
+          return factory.promise
+        },
+      }}
+    >
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={5} />
+      <trace from="R1.pin1" to="R2.pin1" />
+    </board>,
+  )
+
+  const rendering = circuit.renderUntilSettled()
+  const router = await created.promise
+  circuit.cancelRendering(reason)
+  await expect(rendering).rejects.toBe(reason)
+  factory.resolve(router)
+  await abortableDelay(0)
+  expect(router.startCount).toBe(0)
+  expect(router.stopCount).toBe(1)
+  expect(circuit.db.pcb_autorouting_error.list()).toHaveLength(0)
+})

--- a/tests/features/remote-autorouting-abort-request.test.tsx
+++ b/tests/features/remote-autorouting-abort-request.test.tsx
@@ -1,0 +1,58 @@
+import { expect, spyOn, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("cancelRendering aborts an active remote autorouting request", async () => {
+  const { circuit } = getTestFixture()
+  const requested = Promise.withResolvers<AbortSignal>()
+  const requestAborted = Promise.withResolvers<unknown>()
+  const reason = new Error("Cancel remote autorouting")
+  const originalFetch = globalThis.fetch
+  const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+    Object.assign(
+      (url: RequestInfo | URL, init?: RequestInit) => {
+        if (!String(url).startsWith("http://autorouter.test/")) {
+          return originalFetch(url, init)
+        }
+        const signal = init!.signal!
+        requested.resolve(signal)
+        return new Promise<Response>((resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              requestAborted.resolve(signal.reason)
+              reject(signal.reason)
+            },
+            { once: true },
+          )
+        })
+      },
+      { preconnect: originalFetch.preconnect },
+    ),
+  )
+  circuit.add(
+    <board
+      width={16}
+      height={12}
+      autorouter={{
+        serverUrl: "http://autorouter.test",
+        serverMode: "solve-endpoint",
+        inputFormat: "simplified",
+      }}
+    >
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={5} />
+      <trace from="R1.pin1" to="R2.pin1" />
+    </board>,
+  )
+  try {
+    const rendering = circuit.renderUntilSettled()
+    const signal = await requested.promise
+    circuit.cancelRendering(reason)
+    await expect(rendering).rejects.toBe(reason)
+    expect(await requestAborted.promise).toBe(reason)
+    expect(signal.aborted).toBe(true)
+    expect(circuit.db.pcb_trace.list()).toHaveLength(0)
+  } finally {
+    fetchSpy.mockRestore()
+  }
+})

--- a/tests/features/remote-autorouting-abort-stale-job.test.tsx
+++ b/tests/features/remote-autorouting-abort-stale-job.test.tsx
@@ -1,0 +1,75 @@
+import { expect, spyOn, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { abortableDelay } from "lib/utils/abortable-delay"
+
+test("a remote job response received after cancellation cannot resume polling or record errors", async () => {
+  const { circuit } = getTestFixture()
+  const requested = Promise.withResolvers<void>()
+  const jobResponse = Promise.withResolvers<Response>()
+  const requests: string[] = []
+  const originalFetch = globalThis.fetch
+  const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+    Object.assign(
+      (url: RequestInfo | URL, init?: RequestInit) => {
+        if (!String(url).startsWith("http://autorouter.test/")) {
+          return originalFetch(url, init)
+        }
+        const pathname = new URL(String(url)).pathname
+        requests.push(pathname)
+        if (pathname.endsWith("/create")) {
+          return Promise.resolve(
+            Response.json({
+              autorouting_job: {
+                autorouting_job_id: "job_1",
+              },
+            }),
+          )
+        }
+        requested.resolve()
+        // Model a response racing with abort, including fetch shims that do not
+        // implement AbortSignal. Core must discard it before inspecting errors.
+        return jobResponse.promise
+      },
+      { preconnect: originalFetch.preconnect },
+    ),
+  )
+  circuit.add(
+    <board
+      width={16}
+      height={12}
+      autorouter={{
+        serverUrl: "http://autorouter.test",
+        serverMode: "job",
+      }}
+    >
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={5} />
+      <trace from="R1.pin1" to="R2.pin1" />
+    </board>,
+  )
+  try {
+    const rendering = circuit.renderUntilSettled()
+    await requested.promise
+    const reason = new Error("Cancel while polling")
+    circuit.cancelRendering(reason)
+    await expect(rendering).rejects.toBe(reason)
+    jobResponse.resolve(
+      Response.json({
+        autorouting_job: {
+          autorouting_job_id: "job_1",
+          is_finished: false,
+          has_error: true,
+          error: { message: "Stale job failure" },
+        },
+      }),
+    )
+    await abortableDelay(0)
+    expect(requests).toEqual([
+      "/autorouting/jobs/create",
+      "/autorouting/jobs/get",
+    ])
+    expect(circuit.db.pcb_autorouting_error.list()).toHaveLength(0)
+  } finally {
+    fetchSpy.mockRestore()
+  }
+})

--- a/tests/fixtures/controllable-autorouter.ts
+++ b/tests/fixtures/controllable-autorouter.ts
@@ -1,0 +1,64 @@
+import type {
+  AutorouterCompleteEvent,
+  AutorouterErrorEvent,
+  AutorouterEvent,
+  AutorouterProgressEvent,
+  GenericLocalAutorouter,
+} from "lib/utils/autorouting/GenericLocalAutorouter"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+
+/** An event-driven router whose lifecycle tests control without routing geometry. */
+export class ControllableAutorouter implements GenericLocalAutorouter {
+  isRouting = false
+  startCount = 0
+  stopCount = 0
+  onStart?: () => void
+  private listeners = new Map<
+    AutorouterEvent["type"],
+    Array<(event: AutorouterEvent) => void>
+  >()
+
+  constructor(public input: SimpleRouteJson) {}
+
+  start(): void {
+    this.isRouting = true
+    this.startCount++
+    this.onStart?.()
+  }
+
+  stop(): void {
+    this.isRouting = false
+    this.stopCount++
+  }
+
+  on(
+    event: "complete",
+    callback: (event: AutorouterCompleteEvent) => void,
+  ): void
+  on(event: "error", callback: (event: AutorouterErrorEvent) => void): void
+  on(
+    event: "progress",
+    callback: (event: AutorouterProgressEvent) => void,
+  ): void
+  on(
+    event: AutorouterEvent["type"],
+    callback:
+      | ((event: AutorouterCompleteEvent) => void)
+      | ((event: AutorouterErrorEvent) => void)
+      | ((event: AutorouterProgressEvent) => void),
+  ): void {
+    const listeners = this.listeners.get(event) ?? []
+    listeners.push(callback as (event: AutorouterEvent) => void)
+    this.listeners.set(event, listeners)
+  }
+
+  emit(event: AutorouterEvent): void {
+    for (const listener of this.listeners.get(event.type) ?? []) listener(event)
+  }
+
+  solveSync(): never {
+    throw new Error(
+      "This fixture only supports controlled asynchronous routing",
+    )
+  }
+}

--- a/tests/fixtures/create-steppable-fanout-autorouter.ts
+++ b/tests/fixtures/create-steppable-fanout-autorouter.ts
@@ -28,6 +28,7 @@ export const createSteppableFanoutAutorouter = (stepsToSolve = 2501) => {
       throw new Error("The asynchronous wrapper must use step()")
     },
     visualize: () => ({ points: [] }),
+    preview: () => ({ points: [] }),
     getOutput: () => ({ simpleRouteJson: input, fanoutTraces: [] }),
   }
   spyOn(

--- a/tests/fixtures/create-steppable-fanout-autorouter.ts
+++ b/tests/fixtures/create-steppable-fanout-autorouter.ts
@@ -1,0 +1,38 @@
+import { spyOn } from "bun:test"
+import type { FanoutSolver } from "@tscircuit/fanout-solver"
+import { FanoutAutorouter } from "lib/utils/autorouting/FanoutAutorouter"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+
+export const createSteppableFanoutAutorouter = (stepsToSolve = 2501) => {
+  const input: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.2,
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+    obstacles: [],
+    connections: [],
+  }
+  const autorouter = new FanoutAutorouter(input, { mode: "fanout" })
+  const solver = {
+    solved: false,
+    failed: false,
+    error: undefined as string | undefined,
+    iterations: 0,
+    progress: 0,
+    preparedBuses: [],
+    step() {
+      this.iterations++
+      this.progress = this.iterations / stepsToSolve
+      this.solved = this.iterations >= stepsToSolve
+    },
+    solve() {
+      throw new Error("The asynchronous wrapper must use step()")
+    },
+    visualize: () => ({ points: [] }),
+    getOutput: () => ({ simpleRouteJson: input, fanoutTraces: [] }),
+  }
+  spyOn(
+    autorouter as unknown as { createFanoutSolver: () => FanoutSolver },
+    "createFanoutSolver",
+  ).mockReturnValue(solver as unknown as FanoutSolver)
+  return { autorouter, solver }
+}

--- a/tests/root-circuit/render-until-settled-abort-listener-cleanup.test.tsx
+++ b/tests/root-circuit/render-until-settled-abort-listener-cleanup.test.tsx
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("a completed render detaches the caller's cancellation signal", async () => {
+  const { circuit } = getTestFixture()
+  const controller = new AbortController()
+  circuit.add(<board width={10} height={10} />)
+  await circuit.renderUntilSettled({ signal: controller.signal })
+  controller.abort(new Error("This completed render must not be canceled"))
+  expect(() => circuit.render()).not.toThrow()
+  expect(circuit.isDoneRendering()).toBe(true)
+})

--- a/tests/root-circuit/render-until-settled-preaborted.test.tsx
+++ b/tests/root-circuit/render-until-settled-preaborted.test.tsx
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("an already aborted render does not start rendering", async () => {
+  const { circuit } = getTestFixture()
+  const controller = new AbortController()
+  const reason = new Error("Canceled before rendering")
+  circuit.add(<board width={10} height={10} />)
+  controller.abort(reason)
+  await expect(
+    circuit.renderUntilSettled({ signal: controller.signal }),
+  ).rejects.toBe(reason)
+  expect(circuit.db.toArray()).toHaveLength(0)
+})

--- a/tests/subcircuits/subcircuit-isolated-render-abort.test.tsx
+++ b/tests/subcircuits/subcircuit-isolated-render-abort.test.tsx
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { ControllableAutorouter } from "tests/fixtures/controllable-autorouter"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { abortableDelay } from "lib/utils/abortable-delay"
+
+test("isolated subcircuits forward routing progress and cancel with their parent", async () => {
+  const { circuit } = getTestFixture()
+  const controller = new AbortController()
+  const reason = new Error("Cancel isolated routing")
+  const routers: ControllableAutorouter[] = []
+  const events: string[] = []
+  circuit.on("autorouting:start", () => events.push("start"))
+  circuit.on("autorouting:progress", () => {
+    events.push("progress")
+    controller.abort(reason)
+  })
+  circuit.on("autorouting:end", () => events.push("end"))
+  circuit.on("autorouting:error", () => events.push("error"))
+  circuit.add(
+    <board width={20} height={20}>
+      <subcircuit name="S1" _subcircuitCachingEnabled>
+        <group
+          subcircuit
+          autorouter={{
+            algorithmFn: async (input) => {
+              const router = new ControllableAutorouter(input)
+              routers.push(router)
+              router.onStart = () =>
+                router.emit({ type: "progress", steps: 1, progress: 0.5 })
+              return router
+            },
+          }}
+        >
+          <resistor name="R1" resistance="1k" footprint="0402" pcbX={-4} />
+          <resistor name="R2" resistance="1k" footprint="0402" pcbX={4} />
+          <trace from="R1.pin1" to="R2.pin1" />
+        </group>
+      </subcircuit>
+    </board>,
+  )
+
+  await expect(
+    circuit.renderUntilSettled({ signal: controller.signal }),
+  ).rejects.toBe(reason)
+  await abortableDelay(0)
+  expect(events).toEqual(["start", "progress"])
+  expect(routers).toHaveLength(1)
+  expect(routers[0]!.isRouting).toBe(false)
+  expect(routers[0]!.stopCount).toBeGreaterThan(0)
+  expect(circuit.pendingSubcircuitRenders!.size).toBe(0)
+  expect(circuit.cachedSubcircuits!.size).toBe(0)
+})

--- a/tests/subcircuits/subcircuit-isolated-routing-event-scope.test.tsx
+++ b/tests/subcircuits/subcircuit-isolated-routing-event-scope.test.tsx
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test"
+import type {
+  AutoroutingEndEvent,
+  AutoroutingProgressEvent,
+  AutoroutingStartEvent,
+} from "lib/events"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+import { ControllableAutorouter } from "tests/fixtures/controllable-autorouter"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("sibling and nested isolated routing retain local IDs with distinct event scopes", async () => {
+  const { circuit } = getTestFixture()
+  const started = Promise.withResolvers<void>()
+  const routers: ControllableAutorouter[] = []
+  const starts: AutoroutingStartEvent[] = []
+  const progress: AutoroutingProgressEvent[] = []
+  const ends: AutoroutingEndEvent[] = []
+  const algorithmFn = async (input: SimpleRouteJson) => {
+    const router = new ControllableAutorouter(input)
+    routers.push(router)
+    router.onStart = () =>
+      router.emit({ type: "progress", steps: 1, progress: 0.5 })
+    return router
+  }
+  const routingGroup = (resistance: string) => (
+    <group subcircuit autorouter={{ algorithmFn }}>
+      <resistor name="R1" resistance={resistance} footprint="0402" pcbX={-4} />
+      <resistor name="R2" resistance={resistance} footprint="0402" pcbX={4} />
+      <trace from="R1.pin1" to="R2.pin1" />
+    </group>
+  )
+  circuit.on("autorouting:start", (event) => starts.push(event))
+  circuit.on("autorouting:progress", (event) => {
+    progress.push(event)
+    if (progress.length === 2) started.resolve()
+  })
+  circuit.on("autorouting:end", (event) => ends.push(event))
+  circuit.add(
+    <board width={30} height={30}>
+      <subcircuit name="S1" _subcircuitCachingEnabled>
+        {routingGroup("1k")}
+      </subcircuit>
+      <subcircuit name="S2" _subcircuitCachingEnabled>
+        <subcircuit name="Nested" _subcircuitCachingEnabled>
+          {routingGroup("2k")}
+        </subcircuit>
+      </subcircuit>
+    </board>,
+  )
+
+  const rendering = circuit.renderUntilSettled()
+  await started.promise
+  for (const router of routers) router.emit({ type: "complete", traces: [] })
+  await rendering
+
+  expect(starts).toHaveLength(2)
+  expect(progress).toHaveLength(2)
+  expect(ends).toHaveLength(2)
+  expect(starts.map((event) => event.subcircuit_id)).toEqual([
+    "subcircuit_source_group_0",
+    "subcircuit_source_group_0",
+  ])
+  expect(
+    starts.map((event) => event.isolatedSubcircuitPath?.length).sort(),
+  ).toEqual([1, 2])
+  expect(starts[0].isolatedSubcircuitPath?.[0]).not.toBe(
+    starts[1].isolatedSubcircuitPath?.[0],
+  )
+  for (const start of starts) {
+    const router = routers.find(
+      (router) => router.input === start.simpleRouteJson,
+    )
+    expect(router).toBeDefined()
+    const matchingProgress = progress.filter(
+      (event) =>
+        JSON.stringify(event.isolatedSubcircuitPath) ===
+        JSON.stringify(start.isolatedSubcircuitPath),
+    )
+    const matchingEnd = ends.filter(
+      (event) =>
+        JSON.stringify(event.isolatedSubcircuitPath) ===
+        JSON.stringify(start.isolatedSubcircuitPath),
+    )
+    expect(matchingProgress).toHaveLength(1)
+    expect(matchingEnd).toHaveLength(1)
+    expect(matchingProgress[0].subcircuit_id).toBe(start.subcircuit_id)
+    expect(matchingEnd[0].subcircuit_id).toBe(start.subcircuit_id)
+    expect(matchingEnd[0].simpleRouteJson.connections).toEqual(
+      start.simpleRouteJson.connections,
+    )
+  }
+})

--- a/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-async-restart.test.ts
+++ b/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-async-restart.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import type { AutorouterProgressEvent } from "lib/utils/autorouting/GenericLocalAutorouter"
+import {
+  createCapacityAutorouterFixture,
+  deferred,
+  waitForRoutingTimer,
+} from "./capacity-mesh-autorouter-fixture"
+
+test("restarting waits for the cancelled run's pending step without overlapping it", async () => {
+  const { autorouter, solver } = createCapacityAutorouterFixture()
+  const stepStarted = deferred()
+  const finishStep = deferred()
+  const completed = deferred()
+  const progress: AutorouterProgressEvent[] = []
+  let stepCalls = 0
+  let activeSteps = 0
+  let maxActiveSteps = 0
+  solver.stepAsync = async () => {
+    stepCalls++
+    activeSteps++
+    maxActiveSteps = Math.max(maxActiveSteps, activeSteps)
+    if (stepCalls === 1) {
+      stepStarted.resolve()
+      await finishStep.promise
+    } else {
+      solver.solved = true
+    }
+    solver.iterations++
+    activeSteps--
+  }
+  autorouter.on("progress", (event) => progress.push(event))
+  autorouter.on("complete", completed.resolve)
+  autorouter.on("error", (event) => completed.reject(event.error))
+
+  autorouter.start()
+  await stepStarted.promise
+  autorouter.stop()
+  autorouter.start()
+  await waitForRoutingTimer()
+  const callsBeforeFinishingCancelledStep = stepCalls
+  finishStep.resolve()
+  await completed.promise
+
+  expect(callsBeforeFinishingCancelledStep).toBe(1)
+  expect(stepCalls).toBe(2)
+  expect(maxActiveSteps).toBe(1)
+  expect(progress.map((event) => event.steps)).toEqual([1])
+  expect(autorouter.isRouting).toBe(false)
+})

--- a/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-async-stop.test.ts
+++ b/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-async-stop.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import type { AutorouterEvent } from "lib/utils/autorouting/GenericLocalAutorouter"
+import {
+  createCapacityAutorouterFixture,
+  deferred,
+  waitForRoutingTimer,
+} from "./capacity-mesh-autorouter-fixture"
+
+test("stopping during an asynchronous step suppresses further work and events", async () => {
+  const { autorouter, solver } = createCapacityAutorouterFixture()
+  const stepStarted = deferred()
+  const finishStep = deferred()
+  const events: AutorouterEvent[] = []
+  let stepCalls = 0
+  solver.stepAsync = async () => {
+    stepCalls++
+    stepStarted.resolve()
+    await finishStep.promise
+    solver.iterations++
+    solver.solved = true
+  }
+  autorouter.on("progress", (event) => events.push(event))
+  autorouter.on("complete", (event) => events.push(event))
+  autorouter.on("error", (event) => events.push(event))
+
+  autorouter.start()
+  await stepStarted.promise
+  autorouter.stop()
+  finishStep.resolve()
+  await waitForRoutingTimer()
+
+  expect(stepCalls).toBe(1)
+  expect(events).toEqual([])
+  expect(autorouter.isRouting).toBe(false)
+})

--- a/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-completion-restart.test.ts
+++ b/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-completion-restart.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import {
+  createCapacityAutorouterFixture,
+  deferred,
+} from "./capacity-mesh-autorouter-fixture"
+
+test("a completion listener can restart the router without losing the new run", async () => {
+  const { autorouter, solver } = createCapacityAutorouterFixture()
+  const restartedRunCompleted = deferred()
+  const routingDuringCompletion: boolean[] = []
+  let completions = 0
+  autorouter.on("complete", () => {
+    routingDuringCompletion.push(autorouter.isRouting)
+    completions++
+    if (completions === 1) {
+      autorouter.start()
+    } else {
+      restartedRunCompleted.resolve()
+    }
+  })
+  autorouter.on("error", (event) => restartedRunCompleted.reject(event.error))
+
+  autorouter.start()
+  await restartedRunCompleted.promise
+
+  expect(completions).toBe(2)
+  expect(solver.iterations).toBe(1)
+  expect(routingDuringCompletion).toEqual([false, false])
+  expect(autorouter.isRouting).toBe(false)
+})

--- a/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-fixture.ts
+++ b/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-fixture.ts
@@ -1,0 +1,49 @@
+import { TscircuitAutorouter } from "lib/utils/autorouting/CapacityMeshAutorouter"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+
+export const createCapacityAutorouterFixture = () => {
+  const input: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.2,
+    obstacles: [],
+    connections: [],
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+  }
+  const autorouter = new TscircuitAutorouter(input)
+  const solver = {
+    solved: false,
+    failed: false,
+    error: undefined as string | undefined,
+    iterations: 0,
+    progress: 0,
+    step() {
+      this.iterations++
+      this.solved = true
+    },
+    stepAsync: undefined as (() => Promise<void>) | undefined,
+    getOutputSimplifiedPcbTraces() {
+      return []
+    },
+    getCurrentPhase() {
+      return "test_phase"
+    },
+    preview() {
+      return undefined
+    },
+  }
+  ;(autorouter as unknown as { solver: typeof solver }).solver = solver
+  return { autorouter, solver }
+}
+
+export const deferred = () => {
+  let resolve!: () => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+export const waitForRoutingTimer = () =>
+  new Promise<void>((resolve) => setTimeout(resolve, 10))

--- a/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-output-error.test.ts
+++ b/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-output-error.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import {
+  createCapacityAutorouterFixture,
+  deferred,
+} from "./capacity-mesh-autorouter-fixture"
+
+test("an output failure reports an error after ending the routing run", async () => {
+  const { autorouter, solver } = createCapacityAutorouterFixture()
+  const failed = deferred()
+  const errors: Error[] = []
+  let routingDuringError: boolean | undefined
+  let completions = 0
+  solver.getOutputSimplifiedPcbTraces = () => {
+    throw new Error("cannot extract routing output")
+  }
+  autorouter.on("complete", () => completions++)
+  autorouter.on("error", (event) => {
+    errors.push(event.error)
+    routingDuringError = autorouter.isRouting
+    failed.resolve()
+  })
+
+  autorouter.start()
+  await failed.promise
+
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toContain("cannot extract routing output")
+  expect(completions).toBe(0)
+  expect(routingDuringError).toBe(false)
+})

--- a/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-progress-cancel-incomplete.test.ts
+++ b/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-progress-cancel-incomplete.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import type { AutorouterProgressEvent } from "lib/utils/autorouting/GenericLocalAutorouter"
+import {
+  createCapacityAutorouterFixture,
+  deferred,
+  waitForRoutingTimer,
+} from "./capacity-mesh-autorouter-fixture"
+
+test("incomplete routing yields progress and can be cancelled between slices", async () => {
+  const { autorouter, solver } = createCapacityAutorouterFixture()
+  const stopped = deferred()
+  const progress: AutorouterProgressEvent[] = []
+  let completions = 0
+  solver.stepAsync = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 130))
+    solver.iterations++
+    solver.progress = 0.1
+  }
+  autorouter.on("progress", (event) => {
+    progress.push(event)
+    autorouter.stop()
+    stopped.resolve()
+  })
+  autorouter.on("complete", () => completions++)
+  autorouter.on("error", (event) => stopped.reject(event.error))
+
+  autorouter.start()
+  await stopped.promise
+  await waitForRoutingTimer()
+
+  expect(progress).toHaveLength(1)
+  expect(progress[0].progress).toBe(0.1)
+  expect(progress[0].steps).toBe(solver.iterations)
+  expect(solver.solved).toBe(false)
+  expect(completions).toBe(0)
+  expect(autorouter.isRouting).toBe(false)
+  expect(
+    (autorouter as unknown as { timeoutId?: unknown }).timeoutId,
+  ).toBeUndefined()
+})

--- a/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-progress-stop.test.ts
+++ b/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-progress-stop.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import {
+  createCapacityAutorouterFixture,
+  deferred,
+  waitForRoutingTimer,
+} from "./capacity-mesh-autorouter-fixture"
+
+test("a progress listener can stop routing without leaving a scheduled cycle", async () => {
+  const { autorouter } = createCapacityAutorouterFixture()
+  const stopped = deferred()
+  let completions = 0
+  autorouter.on("progress", () => {
+    autorouter.stop()
+    stopped.resolve()
+  })
+  autorouter.on("complete", () => completions++)
+  autorouter.on("error", (event) => stopped.reject(event.error))
+
+  autorouter.start()
+  await stopped.promise
+  await waitForRoutingTimer()
+
+  expect(completions).toBe(0)
+  expect(autorouter.isRouting).toBe(false)
+  expect(
+    (autorouter as unknown as { timeoutId?: unknown }).timeoutId,
+  ).toBeUndefined()
+})

--- a/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-progress.test.ts
+++ b/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-progress.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import type { AutorouterProgressEvent } from "lib/utils/autorouting/GenericLocalAutorouter"
+import {
+  createCapacityAutorouterFixture,
+  deferred,
+} from "./capacity-mesh-autorouter-fixture"
+
+test("routing reports cumulative steps between slices and reaches full progress", async () => {
+  const { autorouter, solver } = createCapacityAutorouterFixture()
+  const completed = deferred()
+  const progress: AutorouterProgressEvent[] = []
+  let routingDuringCompletion: boolean | undefined
+  solver.stepAsync = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 130))
+    solver.iterations++
+    solver.progress = solver.iterations / 5
+    solver.solved = solver.iterations === 4
+  }
+  autorouter.on("progress", (event) => progress.push(event))
+  autorouter.on("complete", () => {
+    routingDuringCompletion = autorouter.isRouting
+    completed.resolve()
+  })
+  autorouter.on("error", (event) => completed.reject(event.error))
+
+  autorouter.start()
+  await completed.promise
+
+  expect(progress.length).toBeGreaterThanOrEqual(2)
+  expect(progress[0].steps).toBeLessThan(4)
+  expect(progress.at(-1)?.steps).toBe(4)
+  expect(progress.at(-1)?.progress).toBe(1)
+  expect(progress.every((event) => event.phase === "test_phase")).toBe(true)
+  expect(
+    progress.every((event) => Number.isFinite(event.iterationsPerSecond)),
+  ).toBe(true)
+  expect(routingDuringCompletion).toBe(false)
+})

--- a/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-queued-stop.test.ts
+++ b/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-queued-stop.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test"
+import type { AutorouterEvent } from "lib/utils/autorouting/GenericLocalAutorouter"
+import {
+  createCapacityAutorouterFixture,
+  waitForRoutingTimer,
+} from "./capacity-mesh-autorouter-fixture"
+
+test("routing can be cancelled before its first scheduled step", async () => {
+  const { autorouter, solver } = createCapacityAutorouterFixture()
+  const events: AutorouterEvent[] = []
+  autorouter.on("progress", (event) => events.push(event))
+  autorouter.on("complete", (event) => events.push(event))
+  autorouter.on("error", (event) => events.push(event))
+
+  autorouter.start()
+  autorouter.stop()
+  await waitForRoutingTimer()
+
+  expect(solver.iterations).toBe(0)
+  expect(events).toEqual([])
+  expect(autorouter.isRouting).toBe(false)
+})

--- a/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-stale-error.test.ts
+++ b/tests/utils/autorouting/capacity-mesh-autorouter/capacity-mesh-autorouter-stale-error.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import {
+  createCapacityAutorouterFixture,
+  deferred,
+} from "./capacity-mesh-autorouter-fixture"
+
+test("an asynchronous rejection from a cancelled run does not fail its replacement", async () => {
+  const { autorouter, solver } = createCapacityAutorouterFixture()
+  const stepStarted = deferred()
+  const finishStep = deferred()
+  const completed = deferred()
+  const errors: Error[] = []
+  let stepCalls = 0
+  solver.stepAsync = async () => {
+    stepCalls++
+    if (stepCalls === 1) {
+      stepStarted.resolve()
+      await finishStep.promise
+    }
+    solver.iterations++
+    solver.solved = true
+  }
+  autorouter.on("complete", completed.resolve)
+  autorouter.on("error", (event) => errors.push(event.error))
+
+  autorouter.start()
+  await stepStarted.promise
+  autorouter.stop()
+  autorouter.start()
+  finishStep.reject(new Error("cancelled step rejected"))
+  await completed.promise
+
+  expect(stepCalls).toBe(2)
+  expect(errors).toEqual([])
+  expect(autorouter.isRouting).toBe(false)
+})

--- a/tests/utils/autorouting/fanout-autorouter-cancel-before-start.test.ts
+++ b/tests/utils/autorouting/fanout-autorouter-cancel-before-start.test.ts
@@ -1,0 +1,44 @@
+import { expect, spyOn, test } from "bun:test"
+import { FanoutSolver } from "@tscircuit/fanout-solver"
+import { FanoutAutorouter } from "lib/utils/autorouting/FanoutAutorouter"
+
+test("stopping fanout before start or from solver-started runs no solver steps", async () => {
+  const step = spyOn(FanoutSolver.prototype, "step")
+  const events: string[] = []
+  let solverStarted = false
+  const autorouter = new FanoutAutorouter(
+    {
+      layerCount: 2,
+      minTraceWidth: 0.2,
+      bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+      obstacles: [],
+      connections: [],
+    },
+    {
+      mode: "fanout",
+      fanoutBounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+      onSolverStarted: () => {
+        solverStarted = true
+        autorouter.stop()
+      },
+    },
+  )
+  autorouter.on("progress", () => events.push("progress"))
+  autorouter.on("complete", () => events.push("complete"))
+  autorouter.on("error", () => events.push("error"))
+  try {
+    autorouter.start()
+    autorouter.stop()
+    await Bun.sleep(20)
+    expect(solverStarted).toBe(false)
+    autorouter.start()
+    await Bun.sleep(20)
+    expect(solverStarted).toBe(true)
+    expect(step).not.toHaveBeenCalled()
+    expect(events).toEqual([])
+    expect(autorouter.isRouting).toBe(false)
+  } finally {
+    autorouter.stop()
+    step.mockRestore()
+  }
+})

--- a/tests/utils/autorouting/fanout-autorouter-cancel-final-progress.test.ts
+++ b/tests/utils/autorouting/fanout-autorouter-cancel-final-progress.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { createSteppableFanoutAutorouter } from "tests/fixtures/create-steppable-fanout-autorouter"
+
+test("stopping fanout from its final progress handler suppresses completion", async () => {
+  const { autorouter } = createSteppableFanoutAutorouter(1)
+  const events: string[] = []
+  autorouter.on("complete", () => events.push("complete"))
+  autorouter.on("error", () => events.push("error"))
+  await new Promise<void>((resolve) => {
+    autorouter.on("progress", () => {
+      events.push("progress")
+      autorouter.stop()
+      resolve()
+    })
+    autorouter.start()
+  })
+  await Bun.sleep(20)
+  expect(events).toEqual(["progress"])
+  expect(autorouter.isRouting).toBe(false)
+  expect(autorouter.getOutputSimpleRouteJson()).toBeUndefined()
+})

--- a/tests/utils/autorouting/fanout-autorouter-cancel.test.ts
+++ b/tests/utils/autorouting/fanout-autorouter-cancel.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { createSteppableFanoutAutorouter } from "tests/fixtures/create-steppable-fanout-autorouter"
+
+test("a timer can cancel fanout between slices without further work or events", async () => {
+  const { autorouter, solver } = createSteppableFanoutAutorouter()
+  const events: string[] = []
+  autorouter.on("complete", () => events.push("complete"))
+  autorouter.on("error", () => events.push("error"))
+  await new Promise<void>((resolve) => {
+    autorouter.on("progress", () => {
+      events.push("progress")
+      setTimeout(() => {
+        autorouter.stop()
+        resolve()
+      }, 0)
+    })
+    autorouter.start()
+  })
+  const stepsAtStop = solver.iterations
+  await Bun.sleep(20)
+  expect(stepsAtStop).toBeGreaterThan(0)
+  expect(solver.solved).toBe(false)
+  expect(solver.iterations).toBe(stepsAtStop)
+  expect(events).toEqual(["progress"])
+  expect(autorouter.isRouting).toBe(false)
+  expect(autorouter.getOutputSimpleRouteJson()).toBeUndefined()
+})

--- a/tests/utils/autorouting/fanout-autorouter-failed-step.test.ts
+++ b/tests/utils/autorouting/fanout-autorouter-failed-step.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { createSteppableFanoutAutorouter } from "tests/fixtures/create-steppable-fanout-autorouter"
+
+test("fanout reports a step failure once and stops scheduling work", async () => {
+  const { autorouter, solver } = createSteppableFanoutAutorouter()
+  const failure = new Error("step failed")
+  solver.step = () => {
+    solver.iterations++
+    throw failure
+  }
+  const events: string[] = []
+  autorouter.on("complete", () => events.push("complete"))
+  autorouter.on("progress", () => events.push("progress"))
+  const error = await new Promise<Error>((resolve) => {
+    autorouter.on("error", ({ error }) => {
+      events.push("error")
+      resolve(error)
+    })
+    autorouter.start()
+  })
+  await Bun.sleep(20)
+  expect(error).toBe(failure)
+  expect(events).toEqual(["error"])
+  expect(solver.iterations).toBe(1)
+  expect(autorouter.isRouting).toBe(false)
+})

--- a/tests/utils/autorouting/fanout-autorouter-progress.test.ts
+++ b/tests/utils/autorouting/fanout-autorouter-progress.test.ts
@@ -1,9 +1,11 @@
-import { expect, test } from "bun:test"
+import { expect, spyOn, test } from "bun:test"
 import type { AutorouterProgressEvent } from "lib/utils/autorouting/GenericLocalAutorouter"
 import { createSteppableFanoutAutorouter } from "tests/fixtures/create-steppable-fanout-autorouter"
 
 test("fanout yields to timers and reports intermediate progress before completion", async () => {
   const { autorouter, solver } = createSteppableFanoutAutorouter()
+  const visualize = spyOn(solver, "visualize")
+  const preview = spyOn(solver, "preview")
   const progress: AutorouterProgressEvent[] = []
   let timerRan = false
   autorouter.on("progress", (event) => {
@@ -27,4 +29,6 @@ test("fanout yields to timers and reports intermediate progress before completio
     progress: 1,
   })
   expect(autorouter.getOutputSimpleRouteJson()).toEqual(autorouter.input)
+  expect(preview).toHaveBeenCalled()
+  expect(visualize).toHaveBeenCalledTimes(1)
 })

--- a/tests/utils/autorouting/fanout-autorouter-progress.test.ts
+++ b/tests/utils/autorouting/fanout-autorouter-progress.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import type { AutorouterProgressEvent } from "lib/utils/autorouting/GenericLocalAutorouter"
+import { createSteppableFanoutAutorouter } from "tests/fixtures/create-steppable-fanout-autorouter"
+
+test("fanout yields to timers and reports intermediate progress before completion", async () => {
+  const { autorouter, solver } = createSteppableFanoutAutorouter()
+  const progress: AutorouterProgressEvent[] = []
+  let timerRan = false
+  autorouter.on("progress", (event) => {
+    progress.push(event)
+    if (progress.length === 1) setTimeout(() => (timerRan = true), 0)
+  })
+  await new Promise<void>((resolve, reject) => {
+    autorouter.on("error", ({ error }) => reject(error))
+    autorouter.on("complete", () => {
+      expect(timerRan).toBe(true)
+      expect(autorouter.isRouting).toBe(false)
+      resolve()
+    })
+    autorouter.start()
+  })
+  expect(progress.length).toBeGreaterThan(1)
+  expect(progress[0]!.progress).toBeGreaterThan(0)
+  expect(progress[0]!.progress).toBeLessThan(1)
+  expect(progress.at(-1)).toMatchObject({
+    steps: solver.iterations,
+    progress: 1,
+  })
+  expect(autorouter.getOutputSimpleRouteJson()).toEqual(autorouter.input)
+})

--- a/tests/utils/autorouting/fanout-autorouter-restart.test.ts
+++ b/tests/utils/autorouting/fanout-autorouter-restart.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { createSteppableFanoutAutorouter } from "tests/fixtures/create-steppable-fanout-autorouter"
+
+test("a fanout restart from progress does not complete the cancelled run", async () => {
+  const { autorouter, solver } = createSteppableFanoutAutorouter(1)
+  const events: string[] = []
+  let restarted = false
+  autorouter.on("progress", () => {
+    events.push("progress")
+    if (restarted) return
+    restarted = true
+    autorouter.stop()
+    solver.iterations = 0
+    solver.solved = false
+    autorouter.start()
+  })
+  await new Promise<void>((resolve, reject) => {
+    autorouter.on("error", ({ error }) => reject(error))
+    autorouter.on("complete", () => {
+      events.push("complete")
+      resolve()
+    })
+    autorouter.start()
+  })
+  await Bun.sleep(20)
+  expect(events).toEqual(["progress", "progress", "complete"])
+  expect(solver.iterations).toBe(1)
+  expect(autorouter.isRouting).toBe(false)
+})


### PR DESCRIPTION
Fanout routing used a blocking `solve()` call, while a stopped capacity router could resume an outstanding async step and publish stale progress or completion. Fanout now advances in bounded slices; both wrappers guard their run lifecycle, yield to the event loop, and report actual step progress. Intermediate fanout graphics use the lightweight `preview()` API; the full visualization is generated only at completion.

Add `renderUntilSettled({ signal })` and `cancelRendering(reason)` so cancellation reaches local routing phases, remote requests/polling, and isolated subcircuits. Aborted phases cannot publish results or start subsequent phases. Isolated circuits forward routing/solver events with `isolatedSubcircuitPath`, preserving local Circuit JSON IDs while distinguishing concurrent render contexts.

Cancellation is cooperative between solver steps. A canceled Circuit is terminal; callers create a new Circuit to restart. Remote cancellation stops client requests and polling, without deleting an already submitted server job. The README documents the API and event scope.

Companion CLI integration: https://github.com/tscircuit/cli/pull/4632 forwards routing timeouts to the new API and tracks concurrent isolated progress separately.

Validation:

- 60 autorouting utility tests passed, including async stop/restart, callback cancellation, progress, and failure regressions.
- 69 root-circuit, subcircuit, and cancellation integration tests passed; one existing test skipped.
- Separate sibling/nested isolated event-scope regression passed.
- Existing fanout, single-layer, plane-termination, sequential-phase, remote-routing, and isolated-render regressions passed.
- `bunx tsc --noEmit`, `bun run build`, formatting, and `git diff --check` passed.

CI note: the initial run's `test (5)` fails the existing `repro-am62l-lpddr4-progressive-fanout.test.tsx` DDR clearance assertion. The exact base commit `d696a754932bb0c15fdcb42c4577d28afb175600` already has the [same failing CI job](https://github.com/tscircuit/core/actions/runs/34164145085/job/101871744068). Its emitted DRC error diff matches [this PR's failure](https://github.com/tscircuit/core/actions/runs/34167491208/job/101881334200) exactly (1,721 compared diff lines after removing timestamps). Independent local runs of both the baseline and final lightweight-preview implementation reproduced the same 93 trace-clearance errors, with identical 1,595-line error arrays. This PR does not alter that board geometry issue.
