### PR TITLE
Fix child cadmodel rotation and size parity

### DIFF
--- a/lib/components/primitive-components/CadModel.ts
+++ b/lib/components/primitive-components/CadModel.ts
@@ -7,6 +7,7 @@ import { distance } from "circuit-json"
 import { decomposeTSR } from "transformation-matrix"
 import { getFileExtension } from "../base-components/NormalComponent/utils/getFileExtension"
 import { constructAssetUrl } from "lib/utils/constructAssetUrl"
+import { normalizeDegrees } from "@tscircuit/math-utils"
 
 const rotation = z.union([z.number(), z.string()])
 const rotation3 = z.object({ x: rotation, y: rotation, z: rotation })
@@ -120,16 +121,18 @@ export class CadModel extends PrimitiveComponent<typeof cadmodelProps> {
       rotation: {
         x: Number(rotationOffset.x),
         y: (layer === "top" ? 0 : 180) + Number(rotationOffset.y),
-        z:
+        z: normalizeDegrees(
           layer === "bottom"
-            ? -(accumulatedRotation + Number(rotationOffset.z)) + 180
+            ? -(accumulatedRotation + Number(rotationOffset.z))
             : accumulatedRotation + Number(rotationOffset.z),
+        ),
       },
       pcb_component_id: parent.pcb_component_id,
       model_board_normal_direction: props.modelBoardNormalDirection,
       model_origin_alignment: "center_of_component_on_board_surface",
       anchor_alignment: "center_of_component_on_board_surface",
       model_origin_position: props.modelOriginPosition,
+      size: props.size ? point3.parse(props.size) : undefined,
       source_component_id: parent.source_component_id,
       model_unit_to_mm_scale_factor:
         typeof props.modelUnitToMmScale === "number"

--- a/tests/components/primitive-components/cadmodel-bottom-layer-rotation.test.tsx
+++ b/tests/components/primitive-components/cadmodel-bottom-layer-rotation.test.tsx
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import { normalizeDegrees } from "@tscircuit/math-utils"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("child cadmodel and object cadModel emit the same top and bottom rotations", () => {
+  for (const layer of ["bottom", "top"] as const) {
+    for (const [pcbRotation, offsetZ, topZ, bottomZ] of [
+      [0, 0, 0, 0],
+      [90, 0, 90, 270],
+      [180, 0, 180, 180],
+      [270, 0, 270, 90],
+      [90, 30, 120, 240],
+      [0, -45, 315, 45],
+      [270, 450, 0, 0],
+    ]) {
+      const { circuit } = getTestFixture()
+      const modelUrl = "https://example.com/model.step"
+      const rotationOffset = { x: 0, y: 0, z: offsetZ }
+      circuit.add(
+        <board width={20} height={20} routingDisabled>
+          <resistor
+            name="R_CHILD"
+            resistance={1000}
+            footprint="0402"
+            pcbX={0}
+            pcbY={0}
+            layer={layer}
+            pcbRotation={pcbRotation}
+            cadModel={
+              <cadmodel modelUrl={modelUrl} rotationOffset={rotationOffset} />
+            }
+          />
+          <resistor
+            name="R_OBJECT"
+            resistance={1000}
+            footprint="0402"
+            pcbX={0}
+            pcbY={0}
+            layer={layer}
+            pcbRotation={pcbRotation}
+            cadModel={{ stepUrl: modelUrl, rotationOffset }}
+          />
+        </board>,
+      )
+      circuit.render()
+
+      const cadComponents = circuit.db.cad_component.list()
+      expect(cadComponents).toHaveLength(2)
+      for (const cad of cadComponents) {
+        const rotation = cad.rotation
+        if (!rotation) throw new Error("CAD model did not emit a rotation")
+        expect(rotation.x).toBeCloseTo(0, 5)
+        expect(rotation.y).toBeCloseTo(layer === "bottom" ? 180 : 0, 5)
+        // Compare orientations, not whether equivalent angles use 0..360.
+        expect(normalizeDegrees(rotation.z)).toBeCloseTo(
+          layer === "bottom" ? bottomZ : topZ,
+          5,
+        )
+      }
+    }
+  }
+})

--- a/tests/components/primitive-components/cadmodel-size.test.tsx
+++ b/tests/components/primitive-components/cadmodel-size.test.tsx
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("child cadmodel preserves authored size in millimeters like object cadModel", () => {
+  const expectedSize = { x: 6, y: 4, z: 20 }
+  for (const size of [
+    expectedSize,
+    { x: "0.6cm", y: "4mm", z: "0.02m" },
+    undefined,
+  ]) {
+    const { circuit } = getTestFixture()
+    const modelUrl = "https://example.com/model.step"
+    circuit.add(
+      <board width={20} height={20} routingDisabled>
+        <resistor
+          name="R_CHILD"
+          resistance={1000}
+          footprint="0402"
+          pcbX={0}
+          pcbY={0}
+          cadModel={<cadmodel modelUrl={modelUrl} size={size} />}
+        />
+        <resistor
+          name="R_OBJECT"
+          resistance={1000}
+          footprint="0402"
+          pcbX={0}
+          pcbY={0}
+          cadModel={{
+            stepUrl: modelUrl,
+            size: size ? expectedSize : undefined,
+          }}
+        />
+      </board>,
+    )
+    circuit.render()
+
+    const cadComponents = circuit.db.cad_component.list()
+    expect(cadComponents).toHaveLength(2)
+    for (const cad of cadComponents) {
+      expect(cad.size).toEqual(size ? expectedSize : undefined)
+    }
+  }
+})


### PR DESCRIPTION
## Summary

Make child `<cadmodel>` elements agree with the object-form `cadModel` API:

- Remove the extra bottom-layer Z half-turn. The existing Y=180 rotation already performs the layer flip; adding Z=180 changes which in-plane axis is reversed.
- Normalize emitted Z with the existing `normalizeDegrees` helper.
- Preserve authored `size` in `cad_component`, converting unit-bearing distances to millimeters.

This is independent of the enclosure/mounting-hardware work. The branch starts at upstream `main` (`1fc6c2c4`) and changes only `CadModel.ts` and two standalone regression files. No new dependencies or local package links.

## Test-first commit stack

1. `176a8fcd` — regression tests only, intentionally failing on upstream code.
2. `2ebeb3bd` — the fixes, with the same tests passing.

Command run before and after the fix:

```sh
bun test \
  ./tests/components/primitive-components/cadmodel-bottom-layer-rotation.test.tsx \
  ./tests/components/primitive-components/cadmodel-size.test.tsx
```

Observed failures before the fix:

```text
Bottom-layer rotation: expected 0, received 180
Authored size: expected { x: 6, y: 4, z: 20 }, received undefined
0 pass, 2 fail
```

The rotation assertion normalizes both positive and negative angle representations, so its failure isolates the erroneous half-turn rather than canonicalization. It covers both layers, all four right-angle placements, and additional authored rotation offsets.

The size regression covers numeric dimensions, SI-unit strings, and omission. Both regressions inspect emitted Circuit JSON from child and object-form CAD declarations and use only the existing upstream fixture infrastructure.

## Validation

- Both new regressions and adjacent CAD primitive tests: **8 passed, 0 failed**.
- `bunx tsc --noEmit`
- Biome formatting for changed files.
- `bun run build` and `bun run smoke-test:dist`
- `INPUT_PACKAGE_TYPE=internal_lib bunx @tscircuit/dependency-check`

The full sharded suite is left to GitHub Actions.
