### PR TITLE
fix: emit ccw_rotation for hole_with_polygon_pad plated holes

### DIFF
--- a/lib/components/primitive-components/PlatedHole.ts
+++ b/lib/components/primitive-components/PlatedHole.ts
@@ -352,6 +352,7 @@ export class PlatedHole extends PrimitiveComponent<typeof platedHoleProps> {
         hole_width: props.holeWidth,
         hole_height: props.holeHeight,
         pad_outline: padOutline,
+        ccw_rotation: finalRotationDegrees,
         hole_offset_x:
           typeof props.holeOffsetX === "number"
             ? props.holeOffsetX

--- a/tests/repros/repro183-hole-with-polygon-pad-rotation.test.tsx
+++ b/tests/repros/repro183-hole-with-polygon-pad-rotation.test.tsx
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("hole_with_polygon_pad emits ccw_rotation like the rect-pad variant", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip
+        name="U1"
+        pcbRotation={90}
+        footprint={
+          <footprint>
+            <platedhole
+              portHints={["pin1"]}
+              pcbX={3}
+              pcbY={0}
+              shape="hole_with_polygon_pad"
+              holeShape="circle"
+              holeDiameter={1}
+              holeOffsetX={0}
+              holeOffsetY={0}
+              padOutline={[
+                { x: -2, y: -0.5 },
+                { x: 2, y: -0.5 },
+                { x: 2, y: 0.5 },
+                { x: -2, y: 0.5 },
+              ]}
+            />
+            <platedhole
+              portHints={["pin2"]}
+              pcbX={-3}
+              pcbY={0}
+              shape="circular_hole_with_rect_pad"
+              holeDiameter={1}
+              rectPadWidth={4}
+              rectPadHeight={1}
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const holes = circuit.db.pcb_plated_hole.list()
+  const polygonHole = holes.find((h) => h.shape === "hole_with_polygon_pad")
+  const rectHole = holes.find((h) => h.shape === "circular_hole_with_rect_pad")
+
+  expect(polygonHole).toBeDefined()
+  expect(rectHole).toBeDefined()
+
+  expect(rectHole!.rect_ccw_rotation).toBe(90)
+  expect(polygonHole!.ccw_rotation).toBe(90)
+})


### PR DESCRIPTION
Fixes #3647

## What changed

The `hole_with_polygon_pad` branch of `PlatedHole.ts` now emits `ccw_rotation: finalRotationDegrees`, matching every other plated hole shape in the same method (`rect_ccw_rotation` / `hole_ccw_rotation`), which already derive the rotation from the component's PCB transform.

## Why

A chip with `pcbRotation={90}` rotates its hole positions and its `circular_hole_with_rect_pad` copper (`rect_ccw_rotation: 90`) but left the identical polygon-pad bar unrotated. `circuit-json` documents `ccw_rotation` on `PcbHoleWithPolygonPad` and consumers (circuit-to-svg, 3d-viewer, exporters, DRC checks) apply it, so the emitter is the missing source of the field. `checkCopperToBoardEdgeClearance` in @tscircuit/checks even has a fallback for the absent field today.

## Tests

Added `tests/repros/repro183-hole-with-polygon-pad-rotation.test.tsx`: a chip with `pcbRotation={90}` and both a polygon-pad and a rect-pad plated hole; the rect assertion passes on `main`, the polygon `ccw_rotation` assertion fails on `main` and passes with the fix. Targeted suites pass, `tsc --noEmit` clean, `biome format` clean.

Related follow-ups for consumers that ignore the field are tracked in tscircuit/circuit-to-svg#709, tscircuit/circuit-json-to-gerber#155 and tscircuit/checks#260 (separate PRs).