### PR TITLE
chore: update capacity-autorouter to 0.0.887

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/bga-fanout-solver": "github:tscircuit/bga-fanout-solver#247c835cb8d69b65e53891dcf869731079415b39",
-    "@tscircuit/capacity-autorouter": "^0.0.886",
+    "@tscircuit/capacity-autorouter": "^0.0.887",
     "@tscircuit/checks": "^0.0.184",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
Updates `@tscircuit/capacity-autorouter` from `^0.0.886` to `^0.0.887`, the latest npm release at the time of this update.

Validation: 48 targeted autorouting tests passed (151 assertions), `bunx tsc --noEmit` passed, and `git diff --check` passed. The full suite and Linux snapshot validation are left to CI.
