### PR TITLE
fix: parse scientific notation in simulation graph values

### DIFF
--- a/lib/utils/simulation/parseSimulationGraphValue.ts
+++ b/lib/utils/simulation/parseSimulationGraphValue.ts
@@ -18,8 +18,11 @@ export const parseSimulationGraphValue = (
   if (typeof value === "number") return value
 
   const trimmed = value.trim()
+  // The exponent is part of the numeric value, so it must be consumed before
+  // the SI prefix. It requires at least one digit so unit strings that merely
+  // start with "e" (e.g. "1eV") keep falling through to the prefix group.
   const match = trimmed.match(
-    /^([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*([pnumµkKMG]?)/,
+    /^([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)\s*([pnumµkKMG]?)/,
   )
   if (!match) return undefined
 

--- a/tests/features/spice-analysis/graph-independent-axes-scientific-notation-overrides.test.tsx
+++ b/tests/features/spice-analysis/graph-independent-axes-scientific-notation-overrides.test.tsx
@@ -1,0 +1,107 @@
+import { expect, test } from "bun:test"
+import type { SpiceEngine } from "@tscircuit/props"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import "tests/fixtures/simulation-matcher"
+import { isGraphScopeTrace } from "./isGraphScopeTrace"
+
+const timestamps_ms = Array.from({ length: 4 }, (_, index) => index)
+
+const fakeSpiceEngine: SpiceEngine = {
+  async simulate() {
+    return {
+      simulationResultCircuitJson: [
+        {
+          type: "simulation_transient_voltage_graph",
+          simulation_experiment_id: "fake",
+          name: "V_SCIENTIFIC",
+          timestamps_ms,
+          voltage_levels: [1, 2, 3, 4],
+          time_per_step: 1,
+          start_time_ms: 0,
+          end_time_ms: 3,
+        },
+        {
+          type: "simulation_transient_current_graph",
+          simulation_experiment_id: "fake",
+          name: "I_SCIENTIFIC",
+          timestamps_ms,
+          current_levels: [0.001, 0.002, 0.003, 0.004],
+          time_per_step: 1,
+          start_time_ms: 0,
+          end_time_ms: 3,
+        },
+      ],
+    }
+  },
+}
+
+// Scientific-notation strings must emit the same scales and offset divisions as
+// the equivalent numeric props in
+// graph-independent-axes-numeric-overrides.test.tsx
+test("graphIndependentAxes accepts scientific notation graph overrides", async () => {
+  const { circuit } = getTestFixture({
+    platform: {
+      spiceEngineMap: {
+        fake: fakeSpiceEngine,
+      },
+    },
+  })
+
+  circuit.add(
+    <board width="10mm" height="10mm" schMaxTraceDistance={10} routingDisabled>
+      <voltagesource name="V1" voltage="4V" schX={-3} />
+      <ammeter
+        name="I_SCIENTIFIC"
+        color="#8a35d7"
+        graphDisplayName="I scientific"
+        graphCenter={0.002}
+        graphVerticalOffset="+1E-3A"
+        graphCurrentPerDiv="5e-4A"
+        connections={{
+          pos: ".V1 > .pin1",
+          neg: ".R1 > .pin1",
+        }}
+      />
+      <resistor name="R1" resistance="1k" schX={2} />
+      <trace from=".R1 > .pin2" to=".V1 > .pin2" />
+      <voltageprobe
+        name="V_SCIENTIFIC"
+        color="#315cff"
+        connectsTo=".I_SCIENTIFIC > .pos"
+        referenceTo=".V1 > .pin2"
+        graphDisplayName="V scientific"
+        graphCenter={2}
+        graphVerticalOffset="1e0V"
+        graphVoltagePerDiv="5e2mV"
+      />
+      <analogsimulation
+        name="scientific notation independent graph overrides"
+        duration="3ms"
+        timePerStep="1ms"
+        spiceEngine="fake"
+        graphIndependentAxes
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const graphScopeTraces = circuitJson.filter(isGraphScopeTrace)
+
+  expect(graphScopeTraces).toHaveLength(2)
+  expect(graphScopeTraces).toMatchObject([
+    {
+      display_name: "V scientific",
+      display_center_value: 2,
+      display_center_offset_divs: 2,
+      volts_per_div: 0.5,
+    },
+    {
+      display_name: "I scientific",
+      display_center_value: 0.002,
+      display_center_offset_divs: 2,
+      amps_per_div: 0.0005,
+    },
+  ])
+})

--- a/tests/utils/simulation/parse-simulation-graph-value.test.ts
+++ b/tests/utils/simulation/parse-simulation-graph-value.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import { parseSimulationGraphValue } from "lib/utils/simulation/parseSimulationGraphValue"
+
+describe("parseSimulationGraphValue", () => {
+  test("passes through numbers and undefined", () => {
+    expect(parseSimulationGraphValue(undefined)).toBeUndefined()
+    expect(parseSimulationGraphValue(0.001)).toBe(0.001)
+    expect(parseSimulationGraphValue(-2.5)).toBe(-2.5)
+  })
+
+  test("parses plain and signed decimal strings", () => {
+    expect(parseSimulationGraphValue("1V")).toBe(1)
+    expect(parseSimulationGraphValue("2.5V")).toBe(2.5)
+    expect(parseSimulationGraphValue(".5V")).toBe(0.5)
+    expect(parseSimulationGraphValue("+1.25V")).toBe(1.25)
+    expect(parseSimulationGraphValue("-3.5V")).toBe(-3.5)
+  })
+
+  test("applies SI prefixes", () => {
+    expect(parseSimulationGraphValue("1n")).toBe(1e-9)
+    expect(parseSimulationGraphValue("2µF")).toBe(2e-6)
+    expect(parseSimulationGraphValue("-3.5mA")).toBeCloseTo(-0.0035, 12)
+    expect(parseSimulationGraphValue("+1.25kV")).toBe(1250)
+    expect(parseSimulationGraphValue("1K")).toBe(1e3)
+    expect(parseSimulationGraphValue("1M")).toBe(1e6)
+    expect(parseSimulationGraphValue("1G")).toBe(1e9)
+  })
+
+  test("consumes scientific notation as part of the numeric value", () => {
+    expect(parseSimulationGraphValue("1e-3V")).toBeCloseTo(0.001, 12)
+    expect(parseSimulationGraphValue("5e-4A")).toBeCloseTo(0.0005, 12)
+    expect(parseSimulationGraphValue("+1E-3A")).toBeCloseTo(0.001, 12)
+    expect(parseSimulationGraphValue("2e3V")).toBe(2000)
+    expect(parseSimulationGraphValue("1e+2V")).toBe(100)
+    expect(parseSimulationGraphValue(".5e1V")).toBe(5)
+  })
+
+  test("applies the SI prefix after the exponent", () => {
+    expect(parseSimulationGraphValue("5e2mV")).toBeCloseTo(0.5, 12)
+    expect(parseSimulationGraphValue("1e3mA")).toBeCloseTo(1, 12)
+    expect(parseSimulationGraphValue("2e-1kV")).toBeCloseTo(200, 12)
+  })
+
+  test("matches the equivalent numeric prop", () => {
+    expect(parseSimulationGraphValue("1e-3V")).toBe(
+      parseSimulationGraphValue(1e-3),
+    )
+    expect(parseSimulationGraphValue("5e-4A")).toBe(
+      parseSimulationGraphValue(5e-4),
+    )
+  })
+
+  test("does not treat a unit starting with 'e' as an exponent", () => {
+    // "eV" is a unit, not an exponent, because no digits follow the "e"
+    expect(parseSimulationGraphValue("1eV")).toBe(1)
+    expect(parseSimulationGraphValue("5e")).toBe(5)
+    expect(parseSimulationGraphValue("2e+V")).toBe(2)
+  })
+
+  test("returns undefined for unparseable and non-finite values", () => {
+    expect(parseSimulationGraphValue("")).toBeUndefined()
+    expect(parseSimulationGraphValue("abc")).toBeUndefined()
+    expect(parseSimulationGraphValue("1e999V")).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #3732

## Problem

`parseSimulationGraphValue` ends its numeric capture before `e`/`E`, so the exponent is dropped and the remaining characters are treated as a unit. A string graph setting therefore disagrees with the equivalent numeric prop:

```ts
parseSimulationGraphValue("1e-3V") // was 1;   expected 0.001
parseSimulationGraphValue("5e-4A") // was 5;   expected 0.0005
parseSimulationGraphValue("5e2mV") // was 5;   expected 0.5
```

This reaches `volts_per_div` / `amps_per_div` and `display_center_offset_divs` for `graphVoltagePerDiv`, `graphCurrentPerDiv` and `graphVerticalOffset`, via both `VoltageProbe`/`Ammeter` and `getGraphDisplayOverrides`. With `graphVerticalOffset="+1E-3A"` and `graphCurrentPerDiv="5e-4A"` the emitted offset was `0.2` divisions instead of `2`.

## Fix

Consume an optional signed exponent as part of the numeric value, before the SI prefix multiplier is applied:

```diff
-/^([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*([pnumµkKMG]?)/
+/^([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)\s*([pnumµkKMG]?)/
```

The exponent group requires at least one digit, so a string whose unit merely starts with `e` is not misread as an exponent and keeps its existing behaviour — `"1eV"` still parses as `1`, `"5e"` as `5`. `"5e2mV"` parses as `5e2` then applies `m`, giving `0.5`.

Values that overflow to `Infinity` (`"1e999V"`) now return `undefined` through the pre-existing `Number.isFinite` guard, rather than silently parsing as `1`.

## Tests

- `tests/utils/simulation/parse-simulation-graph-value.test.ts` — unit coverage for the three cases in the issue, exponent + SI prefix combinations, equivalence with the numeric prop, the `"1eV"` / `"5e"` non-exponent cases, and the existing decimal / signed / SI-prefixed / invalid inputs.
- `tests/features/spice-analysis/graph-independent-axes-scientific-notation-overrides.test.tsx` — circuit-level regression against a controlled spice engine, mirroring `graph-independent-axes-numeric-overrides.test.tsx` so scientific-notation strings must emit the same scales and offset divisions as the equivalent numeric props.

Both fail on `main` and pass with the fix; on `main` the integration test reproduces the reported `display_center_offset_divs: 0.2`. `bunx tsc --noEmit`, `biome check` and `bun test tests/features/spice-analysis tests/utils` (127 pass, 0 fail) are clean locally.