### PR TITLE
fix: keep small cutouts as routing obstacles

### DIFF
--- a/lib/utils/obstacles/fillCircleWithRects.ts
+++ b/lib/utils/obstacles/fillCircleWithRects.ts
@@ -22,10 +22,16 @@ export function fillCircleWithRects(
   const { rectHeight = 0.1 } = options
   const rects: Rect[] = []
 
-  const numSlices = Math.ceil((radius * 2) / rectHeight)
+  // A circle smaller than one band would put its only sample outside the
+  // circle (making halfWidth NaN), so cap the band to the circle's diameter.
+  const diameter = radius * 2
+  const bandHeight = Math.min(rectHeight, diameter)
+  if (bandHeight <= 0) return []
+
+  const numSlices = Math.ceil(diameter / bandHeight)
 
   for (let i = 0; i < numSlices; i++) {
-    const y = center.y - radius + (i + 0.5) * rectHeight
+    const y = center.y - radius + (i + 0.5) * bandHeight
     const dy = y - center.y
 
     // Using circle equation x^2 + y^2 = r^2 to find width at this y
@@ -38,7 +44,7 @@ export function fillCircleWithRects(
           y: y,
         },
         width: halfWidth * 2,
-        height: rectHeight,
+        height: bandHeight,
       })
     }
   }

--- a/lib/utils/obstacles/fillPolygonWithRects.ts
+++ b/lib/utils/obstacles/fillPolygonWithRects.ts
@@ -30,8 +30,13 @@ export function fillPolygonWithRects(
   const minY = Math.min(...yCoords)
   const maxY = Math.max(...yCoords)
 
-  for (let y = minY; y < maxY; y += rectHeight) {
-    const scanlineY = y + rectHeight / 2
+  // A polygon shorter than one band would put its only scanline above maxY and
+  // produce no rects at all, so cap the band to the polygon's vertical extent.
+  const bandHeight = Math.min(rectHeight, maxY - minY)
+  if (bandHeight <= 0) return []
+
+  for (let y = minY; y < maxY; y += bandHeight) {
+    const scanlineY = y + bandHeight / 2
     const intersections: number[] = []
 
     for (let i = 0; i < polygon.length; i++) {
@@ -64,7 +69,7 @@ export function fillPolygonWithRects(
               y: scanlineY,
             },
             width,
-            height: rectHeight,
+            height: bandHeight,
           })
         }
       }

--- a/tests/utils/autorouting/small-cutout-obstacles.test.ts
+++ b/tests/utils/autorouting/small-cutout-obstacles.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { fillCircleWithRects } from "lib/utils/obstacles/fillCircleWithRects"
+import { fillPolygonWithRects } from "lib/utils/obstacles/fillPolygonWithRects"
+import { getObstaclesFromCircuitJson } from "lib/utils/obstacles/getObstaclesFromCircuitJson"
+
+test("a polygon cutout thinner than the sampling band still produces an obstacle", () => {
+  const circuitJson = [
+    {
+      type: "pcb_cutout",
+      pcb_cutout_id: "thin-slot",
+      shape: "polygon",
+      points: [
+        { x: 0, y: 0 },
+        { x: 2, y: 0 },
+        { x: 2, y: 0.2 },
+        { x: 0, y: 0.2 },
+      ],
+    },
+  ] as unknown as AnyCircuitElement[]
+
+  const obstacles = getObstaclesFromCircuitJson(circuitJson)
+
+  expect(obstacles).toHaveLength(1)
+  expect(obstacles[0]).toMatchObject({
+    type: "rect",
+    center: { x: 1, y: 0.1 },
+    width: 2,
+    height: 0.2,
+    connectedTo: [],
+  })
+  expect(obstacles[0]!.layers.length).toBeGreaterThan(0)
+})
+
+test("a circular cutout smaller than the sampling band still produces an obstacle", () => {
+  const circuitJson = [
+    {
+      type: "pcb_cutout",
+      pcb_cutout_id: "small-circle",
+      shape: "circle",
+      center: { x: 0, y: 0 },
+      radius: 0.1,
+    },
+  ] as unknown as AnyCircuitElement[]
+
+  const obstacles = getObstaclesFromCircuitJson(circuitJson)
+
+  expect(obstacles).toHaveLength(1)
+  expect(obstacles[0]).toMatchObject({
+    type: "rect",
+    center: { x: 0, y: 0 },
+    connectedTo: [],
+  })
+  expect(obstacles[0]!.width).toBeGreaterThan(0)
+  expect(obstacles[0]!.height).toBeGreaterThan(0)
+  expect(obstacles[0]!.layers.length).toBeGreaterThan(0)
+})
+
+test("fillPolygonWithRects caps the band to a short polygon's height", () => {
+  const rects = fillPolygonWithRects(
+    [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 2, y: 0.2 },
+      { x: 0, y: 0.2 },
+    ],
+    { rectHeight: 0.6 },
+  )
+
+  expect(rects).toHaveLength(1)
+  expect(rects[0]).toMatchObject({
+    center: { x: 1, y: 0.1 },
+    width: 2,
+    height: 0.2,
+  })
+})
+
+test("fillCircleWithRects caps the band to a small circle's diameter", () => {
+  const rects = fillCircleWithRects(
+    { center: { x: 0, y: 0 }, radius: 0.1 },
+    { rectHeight: 0.6 },
+  )
+
+  expect(rects).toHaveLength(1)
+  expect(rects[0]!.center).toEqual({ x: 0, y: 0 })
+  expect(rects[0]!.width).toBeCloseTo(0.2, 10)
+  expect(rects[0]!.height).toBeCloseTo(0.2, 10)
+})
+
+test("shapes taller than the band are unaffected", () => {
+  const tallPolygon = fillPolygonWithRects(
+    [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 2, y: 2 },
+      { x: 0, y: 2 },
+    ],
+    { rectHeight: 0.6 },
+  )
+  expect(tallPolygon).toHaveLength(3)
+  for (const rect of tallPolygon) {
+    expect(rect.height).toBeCloseTo(0.6, 10)
+  }
+
+  const largeCircle = fillCircleWithRects(
+    { center: { x: 0, y: 0 }, radius: 1 },
+    { rectHeight: 0.6 },
+  )
+  expect(largeCircle).toHaveLength(3)
+  for (const rect of largeCircle) {
+    expect(rect.height).toBeCloseTo(0.6, 10)
+  }
+})
+
+test("degenerate shapes produce no rects and terminate", () => {
+  expect(
+    fillPolygonWithRects(
+      [
+        { x: 0, y: 0 },
+        { x: 2, y: 0 },
+        { x: 1, y: 0 },
+      ],
+      { rectHeight: 0.6 },
+    ),
+  ).toEqual([])
+
+  expect(
+    fillCircleWithRects(
+      { center: { x: 0, y: 0 }, radius: 0 },
+      { rectHeight: 0.6 },
+    ),
+  ).toEqual([])
+})


### PR DESCRIPTION
Closes #3734

## Problem

Both `pcb_cutout` branches in `getObstaclesFromCircuitJson` sample with a 0.6mm band, and a shape shorter than one band produces **no obstacle at all**:

```ts
getObstaclesFromCircuitJson([{
  type: "pcb_cutout", pcb_cutout_id: "thin-slot", shape: "polygon",
  points: [{x:0,y:0},{x:2,y:0},{x:2,y:0.2},{x:0,y:0.2}],
}]) // []

getObstaclesFromCircuitJson([{
  type: "pcb_cutout", pcb_cutout_id: "small-circle", shape: "circle",
  center: {x:0,y:0}, radius: 0.1,
}]) // []
```

Two different failure modes reach the same result:

- **`fillPolygonWithRects`** — the loop starts at `minY` and samples at `y + rectHeight/2`. For a 0.2mm-tall polygon the only scanline is at `0.3`, above `maxY`, so no edge intersections are found.
- **`fillCircleWithRects`** — `numSlices` rounds up to 1 and the sample lands at `dy = 0.2` for `radius = 0.1`, so `Math.sqrt(r² - dy²)` is `NaN`; `NaN > 0` is false and the rect is dropped silently.

`getSimpleRouteJsonFromCircuitJson` then hands the autorouter no obstacle for that cutout.

## Fix

Cap the effective band to the shape's own vertical extent so the first sample is always inside it, and use that band as the emitted rect height:

- polygon: `bandHeight = Math.min(rectHeight, maxY - minY)`
- circle: `bandHeight = Math.min(rectHeight, radius * 2)`

`Math.min` is a no-op whenever the shape is taller than the band, so existing sampling is untouched — including `fillPolygonWithRects`'s other callers (polygon pads and `getUnbrokenCopperPourObstacles`), which pass a smaller interval.

Both helpers now return `[]` for a degenerate zero-extent shape. That also removes a latent hang: without the guard, a capped band of `0` would make `y += bandHeight` loop forever.

The thin slot now yields a single `2 × 0.2` obstacle centred at `(1, 0.1)`, and the small circle a `0.2 × 0.2` obstacle centred at `(0, 0)` — expected centre, board layers and empty `connectedTo` preserved. This remains a rectangular approximation for circles and general polygons.

## Tests

`tests/utils/autorouting/small-cutout-obstacles.test.ts`:

- thin polygon cutout and small circular cutout each produce an obstacle through the full `getObstaclesFromCircuitJson` path, with the expected centre/size, non-empty layers and empty connectivity
- both helpers directly, asserting the band is capped to the shape
- shapes taller than the band are unchanged (3 rects each, all still `0.6` high)
- degenerate zero-height polygon and zero-radius circle return `[]` and terminate

The first four fail on `main` and pass with the fix. `bun test tests/utils/autorouting` (52 pass) and `bun test tests/utils tests/drc tests/pcb-packing` (108 pass) are green, `bunx tsc --noEmit` is clean, and the changed files are `biome` clean.

Heads up: `test (4)` and `test (5)` are currently red on `main` itself (two long-running autorouting cases), so those shards may report failures here that this PR doesn't cause — same as in #3739.