### PR TITLE
fix: send unbroken copper-pour SRJ on raw remote autorouting paths

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -829,10 +829,32 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     return false
   }
 
+  /**
+   * Build Simple Route JSON while the source component tree is still available.
+   * Remote raw-Circuit-JSON payloads are assembled during PcbTraceRender, before
+   * PcbCopperPourRender, so unbroken-pour intent only exists on the component.
+   */
+  _buildRemoteAutoroutingSimpleRouteJson(
+    autorouterConfig: AutorouterConfig,
+  ): SimpleRouteJson {
+    const props = this._parsedProps as SubcircuitGroupProps
+    const preferredTraceWidth =
+      props.defaultTraceWidth ?? props.nominalTraceWidth
+    const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
+      db: this.root!.db,
+      minTraceWidth: Number(props.minTraceWidth ?? 0.15),
+      nominalTraceWidth:
+        preferredTraceWidth != null ? Number(preferredTraceWidth) : undefined,
+      subcircuit_id: this.subcircuit_id,
+      subcircuitComponent: this,
+    })
+    simpleRouteJson.allowViaInPad = autorouterConfig.allowViaInPad
+    return simpleRouteJson
+  }
+
   async _runEffectMakeHttpAutoroutingRequest() {
     const { db } = this.root!
     const debug = Debug("tscircuit:core:_runEffectMakeHttpAutoroutingRequest")
-    const props = this._parsedProps as SubcircuitGroupProps
 
     const autorouterConfig = this._getAutorouterConfig()
 
@@ -858,49 +880,26 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
       },
     )
 
-    if (serverMode === "solve-endpoint") {
-      // Legacy solve endpoint mode
-      if (this.props.autorouter?.inputFormat === "simplified") {
-        const preferredTraceWidth =
-          props.defaultTraceWidth ?? props.nominalTraceWidth
-        const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
-          db,
-          minTraceWidth: Number(props.minTraceWidth ?? 0.15),
-          nominalTraceWidth:
-            preferredTraceWidth != null
-              ? Number(preferredTraceWidth)
-              : undefined,
-          subcircuit_id: this.subcircuit_id,
-          subcircuitComponent: this,
-        })
-        simpleRouteJson.allowViaInPad = autorouterConfig.allowViaInPad
+    const simpleRouteJson =
+      this._buildRemoteAutoroutingSimpleRouteJson(autorouterConfig)
 
-        const { autorouting_result } = await fetchWithDebug(
-          `${serverUrl}/autorouting/solve`,
-          {
-            method: "POST",
-            body: JSON.stringify({
-              input_simple_route_json: simpleRouteJson,
-              subcircuit_id: this.subcircuit_id!,
-            }),
-            headers: {
-              "Content-Type": "application/json",
-            },
-          },
-        ).then((r) => r.json())
-        this._asyncAutoroutingResult = autorouting_result
-        this._markDirty("PcbTraceRender")
-        return
+    if (serverMode === "solve-endpoint") {
+      // Legacy solve endpoint mode. Always send SRJ built from the live
+      // component tree so unbroken copper-pour obstacles survive. Keep sending
+      // Circuit JSON for servers that still consume the raw-CJ path.
+      const solveBody: Record<string, unknown> = {
+        input_simple_route_json: simpleRouteJson,
+        subcircuit_id: this.subcircuit_id!,
+      }
+      if (this.props.autorouter?.inputFormat !== "simplified") {
+        solveBody.input_circuit_json = pcbAndSourceCircuitJson
       }
 
       const { autorouting_result } = await fetchWithDebug(
         `${serverUrl}/autorouting/solve`,
         {
           method: "POST",
-          body: JSON.stringify({
-            input_circuit_json: pcbAndSourceCircuitJson,
-            subcircuit_id: this.subcircuit_id!,
-          }),
+          body: JSON.stringify(solveBody),
           headers: {
             "Content-Type": "application/json",
           },
@@ -917,6 +916,7 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
         method: "POST",
         body: JSON.stringify({
           input_circuit_json: pcbAndSourceCircuitJson,
+          input_simple_route_json: simpleRouteJson,
           provider: "freerouting",
           autostart: true,
           display_name: this.root?.name,

--- a/tests/features/remote-autorouting-unbroken-copper-pour-intent.test.tsx
+++ b/tests/features/remote-autorouting-unbroken-copper-pour-intent.test.tsx
@@ -1,0 +1,104 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "lib/utils/autorouting/SimpleRouteJson"
+import { getSimpleRouteJsonFromCircuitJson } from "lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson"
+import { getTestAutoroutingServer } from "tests/fixtures/get-test-autorouting-server"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const boardWithUnbrokenPour = (autorouter: {
+  serverUrl: string
+  serverMode: "solve-endpoint" | "job"
+  inputFormat?: "circuit-json" | "simplified"
+}) => (
+  <board width="20mm" height="10mm" layers={4} autorouter={autorouter}>
+    <copperpour layer="inner1" connectsTo="net.GND" unbroken />
+    <copperpour layer="inner2" connectsTo="net.VCC" />
+    <chip
+      footprint="soic10"
+      name="U1"
+      pcbX={5}
+      pcbY={0}
+      connections={{
+        pin2: "net.GND",
+        pin3: "net.VCC",
+      }}
+    />
+    <resistor
+      name="R1"
+      pcbX={-5}
+      pcbY={0}
+      resistance={100}
+      footprint="0402"
+      connections={{ pin1: "net.GND" }}
+    />
+    <trace from=".U1 > .pin1" to=".R1 > .pin2" />
+  </board>
+)
+
+const expectUnbrokenGndPourOnInner1 = (simpleRouteJson: SimpleRouteJson) => {
+  const copperPourObstacles = simpleRouteJson.obstacles.filter(
+    (obstacle) => obstacle.isCopperPour,
+  )
+  const obstacleLayers = new Set(
+    copperPourObstacles.flatMap((obstacle) => obstacle.layers),
+  )
+
+  expect(copperPourObstacles.length).toBeGreaterThan(0)
+  expect(obstacleLayers.has("inner1")).toBe(true)
+  expect(obstacleLayers.has("inner2")).toBe(false)
+}
+
+const expectRawCircuitJsonLosesPourIntent = (circuitJson: unknown[]) => {
+  const { simpleRouteJson } = getSimpleRouteJsonFromCircuitJson({
+    circuitJson: circuitJson as never,
+  })
+  expect(
+    simpleRouteJson.obstacles.some((obstacle) => obstacle.isCopperPour),
+  ).toBe(false)
+}
+
+test("legacy solve endpoint sends unbroken-pour SRJ even without inputFormat=simplified", async () => {
+  const { autoroutingServerUrl, capturedSolveBodies } =
+    getTestAutoroutingServer()
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    boardWithUnbrokenPour({
+      serverUrl: autoroutingServerUrl,
+      serverMode: "solve-endpoint",
+    }),
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(capturedSolveBodies).toHaveLength(1)
+  const body = capturedSolveBodies[0]
+  expect(body.input_simple_route_json).toBeDefined()
+  expect(body.input_circuit_json).toBeDefined()
+  expectUnbrokenGndPourOnInner1(body.input_simple_route_json)
+  expectRawCircuitJsonLosesPourIntent(body.input_circuit_json)
+})
+
+test("autorouting job mode sends unbroken-pour SRJ alongside raw Circuit JSON", async () => {
+  const { autoroutingServerUrl, capturedCreateBodies } =
+    getTestAutoroutingServer({
+      requireDisplayName: true,
+    })
+  const { circuit } = getTestFixture()
+  circuit.name = "unbroken-pour-job"
+
+  circuit.add(
+    boardWithUnbrokenPour({
+      serverUrl: autoroutingServerUrl,
+      serverMode: "job",
+    }),
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(capturedCreateBodies).toHaveLength(1)
+  const body = capturedCreateBodies[0]
+  expect(body.input_simple_route_json).toBeDefined()
+  expect(body.input_circuit_json).toBeDefined()
+  expectUnbrokenGndPourOnInner1(body.input_simple_route_json)
+  expectRawCircuitJsonLosesPourIntent(body.input_circuit_json)
+})

--- a/tests/fixtures/get-test-autorouting-server.tsx
+++ b/tests/fixtures/get-test-autorouting-server.tsx
@@ -17,6 +17,8 @@ export const getTestAutoroutingServer = ({
 } = {}) => {
   let currentJobId = 0
   const jobResults = new Map<string, any>()
+  const capturedSolveBodies: any[] = []
+  const capturedCreateBodies: any[] = []
 
   const server = serve({
     port: 0,
@@ -31,6 +33,7 @@ export const getTestAutoroutingServer = ({
       // Legacy solve endpoint
       if (endpoint === "/autorouting/solve") {
         const body = await req.json()
+        capturedSolveBodies.push(body)
         let simpleRouteJson: SimpleRouteJson | undefined
 
         if (body.input_simple_route_json) {
@@ -83,6 +86,7 @@ export const getTestAutoroutingServer = ({
       // New job-based endpoints
       if (endpoint === "/autorouting/jobs/create") {
         const body = await req.json()
+        capturedCreateBodies.push(body)
         const jobId = `job_${currentJobId++}`
 
         if (requireDisplayName && !body.display_name) {
@@ -213,6 +217,8 @@ export const getTestAutoroutingServer = ({
 
   return {
     autoroutingServerUrl: `http://localhost:${server.port}/`,
+    capturedSolveBodies,
+    capturedCreateBodies,
     close: () => server.stop(),
   }
 }


### PR DESCRIPTION
## Summary

Unbroken copper pours are already `isCopperPour` obstacles on the local autorouter path and on remote calls that send Simple Route JSON (`inputFormat: \"simplified\"`). The raw-Circuit-JSON remote paths lose that intent:

- `auto-cloud` / job mode posts `input_circuit_json`
- the legacy solve endpoint also posts `input_circuit_json` unless `inputFormat: \"simplified\"`

Those payloads are assembled during `PcbTraceRender`, before `PcbCopperPourRender`. The `unbroken` flag currently exists only on the source component, so a raw-CJ autorouting service cannot distinguish an unbroken plane from a normal post-routing pour.

This builds Simple Route JSON from the live subcircuit (same helper as the simplified path) and sends `input_simple_route_json` on both remote paths. Raw Circuit JSON is still included for servers that have not switched.

A hard keepout is not equivalent: unbroken planes must still allow through vias with antipads.

## Tests

`tests/features/remote-autorouting-unbroken-copper-pour-intent.test.tsx`

- legacy solve endpoint without `inputFormat: \"simplified\"` includes inner1 GND pour obstacles in SRJ
- job mode includes the same SRJ field
- reconstructing SRJ from the accompanying Circuit JSON still has no `isCopperPour` obstacles (the raw-CJ gap)

Fixes #3379