### PR TITLE
fix(board): copy per-side finish and assembly onto pcb_board

### DIFF
--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -588,8 +588,8 @@ export class Board
       ...(props.bottomSilkscreenColor !== undefined && {
         bottom_silkscreen_color: props.bottomSilkscreenColor,
       }),
-      ...(props.doubleSidedAssembly !== undefined && {
-        double_sided_assembly: props.doubleSidedAssembly,
+      ...(props.doubleSidedAssembly === true && {
+        double_sided_assembly: true,
       }),
 
       min_trace_width:

--- a/lib/components/normal-components/Board.ts
+++ b/lib/components/normal-components/Board.ts
@@ -573,8 +573,23 @@ export class Board
       ...(props.solderMaskColor !== undefined && {
         solder_mask_color: props.solderMaskColor,
       }),
+      ...(props.topSolderMaskColor !== undefined && {
+        top_solder_mask_color: props.topSolderMaskColor,
+      }),
+      ...(props.bottomSolderMaskColor !== undefined && {
+        bottom_solder_mask_color: props.bottomSolderMaskColor,
+      }),
       ...(props.silkscreenColor !== undefined && {
         silkscreen_color: props.silkscreenColor,
+      }),
+      ...(props.topSilkscreenColor !== undefined && {
+        top_silkscreen_color: props.topSilkscreenColor,
+      }),
+      ...(props.bottomSilkscreenColor !== undefined && {
+        bottom_silkscreen_color: props.bottomSilkscreenColor,
+      }),
+      ...(props.doubleSidedAssembly !== undefined && {
+        double_sided_assembly: props.doubleSidedAssembly,
       }),
 
       min_trace_width:

--- a/tests/components/normal-components/board-finish-props.test.tsx
+++ b/tests/components/normal-components/board-finish-props.test.tsx
@@ -1,0 +1,40 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("board per-side finish and assembly props reach pcb_board", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board
+      width={20}
+      height={20}
+      solderMaskColor="green"
+      topSolderMaskColor="black"
+      bottomSolderMaskColor="red"
+      silkscreenColor="white"
+      topSilkscreenColor="yellow"
+      bottomSilkscreenColor="white"
+      doubleSidedAssembly
+    />,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const pcb_board = circuit.db.pcb_board.list()[0] as {
+    solder_mask_color?: string
+    top_solder_mask_color?: string
+    bottom_solder_mask_color?: string
+    silkscreen_color?: string
+    top_silkscreen_color?: string
+    bottom_silkscreen_color?: string
+    double_sided_assembly?: boolean
+  }
+
+  expect(pcb_board.solder_mask_color).toBe("green")
+  expect(pcb_board.top_solder_mask_color).toBe("black")
+  expect(pcb_board.bottom_solder_mask_color).toBe("red")
+  expect(pcb_board.silkscreen_color).toBe("white")
+  expect(pcb_board.top_silkscreen_color).toBe("yellow")
+  expect(pcb_board.bottom_silkscreen_color).toBe("white")
+  expect(pcb_board.double_sided_assembly).toBe(true)
+})

--- a/tests/components/normal-components/board-finish-props.test.tsx
+++ b/tests/components/normal-components/board-finish-props.test.tsx
@@ -38,3 +38,17 @@ test("board per-side finish and assembly props reach pcb_board", async () => {
   expect(pcb_board.bottom_silkscreen_color).toBe("white")
   expect(pcb_board.double_sided_assembly).toBe(true)
 })
+
+test("default board does not emit double_sided_assembly on pcb_board", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(<board width={20} height={20} />)
+
+  await circuit.renderUntilSettled()
+
+  const pcb_board = circuit.db.pcb_board.list()[0] as {
+    double_sided_assembly?: boolean
+  }
+
+  expect(pcb_board.double_sided_assembly).toBeUndefined()
+})


### PR DESCRIPTION
## Why

`<board>` already accepts `topSolderMaskColor`, `bottomSolderMaskColor`, `topSilkscreenColor`, `bottomSilkscreenColor`, and `doubleSidedAssembly`. Those values never reached `pcb_board`. Fabrication and KiCad paths only saw `solder_mask_color` and `silkscreen_color`.

This copies the missing props onto `pcb_board` at the same insert that already copies the board-wide colors.

Companion schema: https://github.com/tscircuit/circuit-json/pull/766

Fixes #3101

## Scope

- `Board` `pcb_board.insert` in `lib/components/normal-components/Board.ts`
- Regression in `tests/components/normal-components/board-finish-props.test.tsx`

Out of scope: inflating Circuit JSON back into `<board>`, and waiting on a published `circuit-json` release. Extra keys already survive `db.toArray()`.

## Tradeoffs

Rejected rejecting the props as unsupported. Props already document them, and the board-wide color path already serializes.

## Blast radius

Only `<board>` render. Existing `solderMaskColor` / `silkscreenColor` copies are unchanged. Downstream parsers that use the current `circuit-json` zod schema still drop the new keys until #766 lands.

## Verification

Failing before the copy, on `origin/main` plus the new test:

```
Expected: "black"
Received: undefined
(fail) board per-side finish and assembly props reach pcb_board
```

Passing after:

```
bun test tests/components/normal-components/board-finish-props.test.tsx tests/components/normal-components/board-solder-mask-color.test.tsx
2 pass, 0 fail
```