### PR TITLE
fix: treat documented schSize small as the sm compact symbol

### DIFF
--- a/lib/components/normal-components/Capacitor.ts
+++ b/lib/components/normal-components/Capacitor.ts
@@ -30,10 +30,13 @@ export class Capacitor extends NormalComponent<
   _adjustSilkscreenTextAutomatically = true
   get config() {
     const baseSymbolName = this.props.symbolName ?? "capacitor"
+    const schSize = this.props.schSize
     const compactSize =
-      this.props.schSize === "sm" || this.props.schSize === "xs"
-        ? this.props.schSize
-        : undefined
+      schSize === "xs" || schSize === "sm"
+        ? schSize
+        : schSize === "small"
+          ? "sm"
+          : undefined
     const compactSymbolName =
       compactSize && baseSymbolName === "capacitor"
         ? (`capacitor_${compactSize}` as BaseSymbolName)

--- a/lib/components/normal-components/Resistor.ts
+++ b/lib/components/normal-components/Resistor.ts
@@ -15,10 +15,13 @@ export class Resistor extends NormalComponent<
 
   get config() {
     const baseSymbolName = this.props.symbolName ?? "boxresistor"
+    const schSize = this.props.schSize
     const compactSize =
-      this.props.schSize === "sm" || this.props.schSize === "xs"
-        ? this.props.schSize
-        : undefined
+      schSize === "xs" || schSize === "sm"
+        ? schSize
+        : schSize === "small"
+          ? "sm"
+          : undefined
     const compactSymbolName =
       compactSize &&
       (baseSymbolName === "boxresistor" || baseSymbolName === "resistor")

--- a/tests/components/normal-components/passive-sch-size-small-alias.test.tsx
+++ b/tests/components/normal-components/passive-sch-size-small-alias.test.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("documented schSize small selects the sm compact resistor and capacitor symbols", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="10mm">
+      <resistor name="R_SMALL" resistance="1k" schSize="small" schX={0} schY={3} />
+      <capacitor
+        name="C_SMALL"
+        capacitance="1uF"
+        schSize="small"
+        schX={0}
+        schY={0}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  expect(
+    circuit.db.schematic_component
+      .list()
+      .map(({ symbol_name }) => symbol_name),
+  ).toEqual(["boxresistor_sm_right", "capacitor_sm_right"])
+})

--- a/tests/components/normal-components/passive-sch-size-small-alias.test.tsx
+++ b/tests/components/normal-components/passive-sch-size-small-alias.test.tsx
@@ -6,7 +6,13 @@ test("documented schSize small selects the sm compact resistor and capacitor sym
 
   circuit.add(
     <board width="20mm" height="10mm">
-      <resistor name="R_SMALL" resistance="1k" schSize="small" schX={0} schY={3} />
+      <resistor
+        name="R_SMALL"
+        resistance="1k"
+        schSize="small"
+        schX={0}
+        schY={3}
+      />
       <capacitor
         name="C_SMALL"
         capacitance="1uF"
@@ -20,8 +26,6 @@ test("documented schSize small selects the sm compact resistor and capacitor sym
   circuit.render()
 
   expect(
-    circuit.db.schematic_component
-      .list()
-      .map(({ symbol_name }) => symbol_name),
+    circuit.db.schematic_component.list().map(({ symbol_name }) => symbol_name),
   ).toEqual(["boxresistor_sm_right", "capacitor_sm_right"])
 })


### PR DESCRIPTION
## Summary

Capacitor docs still list `schSize=\"small\"`, but core only selected compact premade symbols for `\"sm\"` and `\"xs\"`. `small` emitted the default `capacitor_right` / `boxresistor_right` geometry (`#3108`).

This maps `small` onto the existing `sm` symbols. Polarized capacitors still keep `capacitor_polarized`.

## Test plan

- [x] `bun test tests/components/normal-components/passive-sch-size-small-alias.test.tsx`
- [x] `bun test tests/components/normal-components/passive-sch-size.test.tsx`
- [x] `bunx tsc --noEmit`

Fixes #3108