### PR TITLE
fix: report non-positive schematic dimensions

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialSchematicComponentRender.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialSchematicComponentRender.ts
@@ -46,6 +46,9 @@ export function NormalComponent_doInitialSchematicComponentRender(
   const { schematicSymbolName } = component.config
   const { _parsedProps: props } = component
 
+  component.reportNonPositiveSchematicDimension("schWidth", props.schWidth)
+  component.reportNonPositiveSchematicDimension("schHeight", props.schHeight)
+
   const hasSymbolChild = component.children.some(
     (c) => c.componentName === "Symbol",
   )

--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -196,6 +196,17 @@ export abstract class PrimitiveComponent<
     })
     this._reportedInvalidPcbCalcWarnings.add(propertyName)
   }
+
+  reportNonPositiveSchematicDimension(
+    propertyName: string,
+    value: unknown,
+  ): void {
+    if (typeof value !== "number" || value > 0 || Number.isNaN(value)) return
+    this._reportInvalidComponentPropertyError(
+      propertyName,
+      `Invalid ${propertyName} for ${this.lowercaseComponentName}: ${value}, which must be greater than zero.`,
+    )
+  }
   fallbackUnassignedName?: string
 
   constructor(props: z.input<ZodProps>) {

--- a/lib/components/primitive-components/SchematicBox/SchematicBox.ts
+++ b/lib/components/primitive-components/SchematicBox/SchematicBox.ts
@@ -25,6 +25,8 @@ export class SchematicBox extends PrimitiveComponent<typeof schematicBoxProps> {
     const { db } = this.root!
     const { _parsedProps: props } = this
     if (props.chipRef) return
+    this.reportNonPositiveSchematicDimension("width", props.width)
+    this.reportNonPositiveSchematicDimension("height", props.height)
 
     const basePadding = 0.6
     const generalPadding = typeof props.padding === "number" ? props.padding : 0

--- a/lib/components/primitive-components/SchematicCircle.ts
+++ b/lib/components/primitive-components/SchematicCircle.ts
@@ -25,6 +25,7 @@ export class SchematicCircle extends PrimitiveComponent<
     if (this.getCollapsedSchematicBoxAncestor()) return
     const { db } = this.root!
     const { _parsedProps: props } = this
+    this.reportNonPositiveSchematicDimension("radius", props.radius)
 
     const globalPos = this._getGlobalSchematicPositionBeforeLayout()
 

--- a/lib/components/primitive-components/SchematicRect.ts
+++ b/lib/components/primitive-components/SchematicRect.ts
@@ -25,6 +25,8 @@ export class SchematicRect extends PrimitiveComponent<
     if (this.getCollapsedSchematicBoxAncestor()) return
     const { db } = this.root!
     const { _parsedProps: props } = this
+    this.reportNonPositiveSchematicDimension("width", props.width)
+    this.reportNonPositiveSchematicDimension("height", props.height)
 
     const globalPos = this._getGlobalSchematicPositionBeforeLayout()
 

--- a/tests/components/primitive-components/negative-schematic-dimensions.test.tsx
+++ b/tests/components/primitive-components/negative-schematic-dimensions.test.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("negative schematic dimensions emit source_invalid_component_property_error", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip name="U1" footprint="soic8" schWidth={-4} schHeight={3} />
+      <schematicbox width={-2} height={2} schX={6} schY={0} />
+      <schematicrect width={-3} height={1} schX={10} schY={0} />
+      <schematiccircle
+        center={{ x: 0, y: 0 }}
+        radius={-1}
+        schX={14}
+        schY={0}
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const errors = circuit.db.source_invalid_component_property_error.list()
+
+  expect(errors.map(({ property_name }) => property_name).sort()).toEqual([
+    "radius",
+    "schWidth",
+    "width",
+    "width",
+  ])
+
+  for (const error of errors) {
+    expect(error.error_type).toBe("source_invalid_component_property_error")
+    expect(error.message).toMatch(/must be greater than zero/)
+  }
+})

--- a/tests/components/primitive-components/negative-schematic-dimensions.test.tsx
+++ b/tests/components/primitive-components/negative-schematic-dimensions.test.tsx
@@ -9,12 +9,7 @@ test("negative schematic dimensions emit source_invalid_component_property_error
       <chip name="U1" footprint="soic8" schWidth={-4} schHeight={3} />
       <schematicbox width={-2} height={2} schX={6} schY={0} />
       <schematicrect width={-3} height={1} schX={10} schY={0} />
-      <schematiccircle
-        center={{ x: 0, y: 0 }}
-        radius={-1}
-        schX={14}
-        schY={0}
-      />
+      <schematiccircle center={{ x: 14, y: 0 }} radius={-1} />
     </board>,
   )
 


### PR DESCRIPTION
## Summary

Negative schematic sizes were accepted with no error (`#2861`):

- `<chip schWidth={-4} />`
- `<schematicbox width={-2} />`
- `<schematicrect width={-3} />`
- `<schematiccircle radius={-1} />`

Each now emits `source_invalid_component_property_error` against the prop the user wrote. Positive values are unchanged.

Prior attempts `#2862` and `#3258` were withdrawn or stale-closed.

## Test plan

- [x] `bun test tests/components/primitive-components/negative-schematic-dimensions.test.tsx`
- [x] `bun test tests/features/spice-model-chip-invalid-mapping.test.tsx`

Fixes #2861