### PR TITLE
fix: error when pinLabels names a pin missing from the footprint

### DIFF
--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -507,7 +507,28 @@ export class Port extends PrimitiveComponent<typeof portProps> {
 
     const pcbMatches = matchedComponents.filter((c) => c.isPcbPrimitive)
 
-    if (pcbMatches.length === 0) return
+    if (pcbMatches.length === 0) {
+      const parentHasPcbPrimitives = Boolean(
+        parentNormalComponent
+          ?.getDescendants()
+          .some((child) => child.isPcbPrimitive),
+      )
+      if (parentHasPcbPrimitives) {
+        const portName = this.props.name ?? "unknown"
+        const aliases = this.getNameAndAliases().filter(
+          (alias) => alias !== portName,
+        )
+        const aliasMsg =
+          aliases.length > 0 ? ` (aliases: ${aliases.join(", ")})` : ""
+        db.source_invalid_component_property_error.insert({
+          source_component_id: parentNormalComponent?.source_component_id || "",
+          property_name: "pinLabels",
+          message: `Port "${portName}"${aliasMsg} on ${parentNormalComponent?.getDisplayName() ?? "component"} does not match any pad in the footprint.`,
+          error_type: "source_invalid_component_property_error",
+        })
+      }
+      return
+    }
 
     let matchCenter: { x: number; y: number } | null = null
 

--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -511,7 +511,7 @@ export class Port extends PrimitiveComponent<typeof portProps> {
       const parentHasPcbPrimitives = Boolean(
         parentNormalComponent
           ?.getDescendants()
-          .some((child) => child.isPcbPrimitive),
+          .some((child: PrimitiveComponent) => child.isPcbPrimitive),
       )
       if (parentHasPcbPrimitives) {
         const portName = this.props.name ?? "unknown"

--- a/tests/components/primitive-components/unroutable-pin-label.test.tsx
+++ b/tests/components/primitive-components/unroutable-pin-label.test.tsx
@@ -33,7 +33,7 @@ test("a component with no footprint does not error for unmapped ports", async ()
 
   await circuit.renderUntilSettled()
 
-  expect(circuit.db.source_invalid_component_property_error.list()).toHaveLength(
-    0,
-  )
+  expect(
+    circuit.db.source_invalid_component_property_error.list(),
+  ).toHaveLength(0)
 })

--- a/tests/components/primitive-components/unroutable-pin-label.test.tsx
+++ b/tests/components/primitive-components/unroutable-pin-label.test.tsx
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("pinLabels naming a pin the footprint lacks emits an invalid-property error", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{ pin1: ["A"], pin99: ["Z"] }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_invalid_component_property_error.list()
+  expect(errors).toHaveLength(1)
+  expect(errors[0]?.property_name).toBe("pinLabels")
+  expect(errors[0]?.message).toContain("Z")
+})
+
+test("a component with no footprint does not error for unmapped ports", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <solderjumper name="SJ1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_invalid_component_property_error.list()).toHaveLength(
+    0,
+  )
+})


### PR DESCRIPTION
## Summary

\`pinLabels={{ pin99: [\"Z\"] }}\` on a footprint that has no pin 99 created a ninth source port with zero errors (\`#2863\`). Connecting to \`.U1 > .Z\` then failed as a missing PCB trace, which points at routing instead of the typo.

This emits \`source_invalid_component_property_error\` on \`pinLabels\` when the parent has PCB pads and this port matches none. Components with no footprint (bare \`<solderjumper />\`) stay silent.

Prior attempts \`#2864\` and \`#3261\` were withdrawn or stale-closed.

## Test plan

- [x] \`bun test tests/components/primitive-components/unroutable-pin-label.test.tsx\`
- [x] \`bun test tests/repros/repro27-chip-pinlabels.test.tsx\`
- [x] jumper/solderjumper regressions

Fixes #2863