### PR TITLE
fix: do not crash render on empty connections targets

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -2207,10 +2207,20 @@ export class NormalComponent<
       for (const [pinName, target] of Object.entries(props.connections)) {
         const targets = Array.isArray(target) ? target : [target]
         for (const targetPath of targets) {
+          const selector = String(targetPath).trim()
+          if (!selector) {
+            this.root?.db.source_invalid_component_property_error.insert({
+              source_component_id: this.source_component_id || "",
+              property_name: "connections",
+              message: `Empty connections target for ${this.getDisplayName()} pin "${pinName}".`,
+              error_type: "source_invalid_component_property_error",
+            })
+            continue
+          }
           this.add(
             new Trace({
               from: `.${this.name} > .${pinName}`,
-              to: String(targetPath),
+              to: selector,
             }),
           )
         }

--- a/tests/components/normal-components/empty-connections-target.test.tsx
+++ b/tests/components/normal-components/empty-connections-target.test.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("empty connections target does not crash render", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <capacitor
+        name="C1"
+        capacitance="1uF"
+        footprint="0402"
+        connections={{ pin1: "", pin2: ".R1 > .pin1" }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_invalid_component_property_error.list()
+  expect(errors).toHaveLength(1)
+  expect(errors[0]?.property_name).toBe("connections")
+  expect(errors[0]?.message).toMatch(/C1/)
+  expect(errors[0]?.message).toMatch(/pin1/)
+})


### PR DESCRIPTION
## Summary

\`connections={{ pin1: \"\" }}\` aborted the whole render with a raw css-what error (\`Expected name, found .\`) that named neither the component nor the pin (\`#2865\`).

Empty or whitespace-only targets now emit \`source_invalid_component_property_error\` on \`connections\` and are skipped. Valid siblings such as \`pin2: \".R1 > .pin1\"\` still connect.

Prior attempts \`#2866\`, \`#3004\`, \`#3034\`, \`#3255\`, and \`#3428\` were closed without merging.

## Test plan

- [x] \`bun test tests/components/normal-components/empty-connections-target.test.tsx\`

Fixes #2865