### PR TITLE
Fix fuse symbol label showing bare unit when voltageRating is missing

### DIFF
--- a/lib/components/normal-components/Fuse.ts
+++ b/lib/components/normal-components/Fuse.ts
@@ -30,7 +30,11 @@ export class Fuse extends NormalComponent<typeof fuseProps, PassivePorts> {
 
     const voltage = parseAndConvertSiUnit(rawVoltage, "V").value
 
-    return `${formatSiUnit(current)}A / ${formatSiUnit(voltage)}V`
+    const parts: string[] = []
+    if (current != null) parts.push(`${formatSiUnit(current)}A`)
+    if (voltage != null) parts.push(`${formatSiUnit(voltage)}V`)
+
+    return parts.join(" / ")
   }
 
   doInitialSourceRender() {
@@ -45,8 +49,12 @@ export class Fuse extends NormalComponent<typeof fuseProps, PassivePorts> {
     let display_voltage_rating: string | undefined
 
     if (props.schShowRatings !== false) {
-      display_current_rating = `${formatSiUnit(currentRating)}A`
-      display_voltage_rating = `${formatSiUnit(voltageRating)}V`
+      if (currentRating != null) {
+        display_current_rating = `${formatSiUnit(currentRating)}A`
+      }
+      if (voltageRating != null) {
+        display_voltage_rating = `${formatSiUnit(voltageRating)}V`
+      }
     }
 
     const source_component = db.source_component.insert({

--- a/tests/components/normal-components/fuse-missing-ratings.test.tsx
+++ b/tests/components/normal-components/fuse-missing-ratings.test.tsx
@@ -1,0 +1,38 @@
+import { test, expect } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Regression for https://github.com/tscircuit/core/issues/2833
+test("<fuse /> without voltageRating omits the voltage segment", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="12mm" height="10mm">
+      <fuse name="F1" currentRating="1A" footprint="0402" />
+      <fuse name="F2" currentRating="1A" voltageRating="32V" footprint="0402" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const sourceComponents = circuit.db.source_component.list()
+  const byName = Object.fromEntries(sourceComponents.map((c: any) => [c.name, c]))
+
+  expect(byName.F1.display_current_rating).toBe("1A")
+  expect(byName.F1.display_voltage_rating).toBeUndefined()
+  expect(byName.F2.display_current_rating).toBe("1A")
+  expect(byName.F2.display_voltage_rating).toBe("32V")
+
+  const schematicComponents = circuit.db.schematic_component.list()
+  const sourceIdToName = Object.fromEntries(
+    sourceComponents.map((c: any) => [c.source_component_id, c.name]),
+  )
+  const displayValues = Object.fromEntries(
+    schematicComponents.map((c: any) => [
+      sourceIdToName[c.source_component_id],
+      c.symbol_display_value,
+    ]),
+  )
+
+  expect(displayValues.F1).toBe("1A")
+  expect(displayValues.F2).toBe("1A / 32V")
+})


### PR DESCRIPTION
Fixes #2833.

A fuse without voltageRating rendered its label as "1A / V" - a dangling unit with no value.

Reproduced with a test fixture, then fixed both display paths that compose the fuse label so the voltage segment is omitted when no rating is present. Added a regression test; fuse suite 4/4 green, no snapshot changes.

---
*This PR was prepared by an AI assistant operated on behalf of a human (see profile bio). The fix and regression tests were implemented and verified by the assistant; submission is human-authorized.*