### PR TITLE
fix: report a trace that connects a port to itself

### DIFF
--- a/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
+++ b/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
@@ -121,6 +121,24 @@ export function Trace__findConnectedPorts(trace: Trace):
     return { allPortsFound: false }
   }
 
+  const resolvedPorts = portsWithSelectors
+    .map(({ port }) => port)
+    .filter((port): port is Port => port != null)
+  // Port→net traces resolve to a single port and must stay valid. Only flag
+  // when two or more selectors collapse onto the same port.
+  if (resolvedPorts.length >= 2 && new Set(resolvedPorts).size === 1) {
+    const subcircuit = trace.getSubcircuit()
+    const sourceGroup = subcircuit.getGroup()
+    throw new TraceConnectionError({
+      error_type: "source_trace_not_connected_error",
+      message: `${trace.getString()} connects a port to itself; both ends resolve to the same port. Did you mean to connect two different pins?`,
+      subcircuit_id: subcircuit.subcircuit_id ?? undefined,
+      source_group_id: sourceGroup?.source_group_id ?? undefined,
+      source_trace_id: trace.source_trace_id ?? undefined,
+      selectors_not_found: portSelectors,
+    })
+  }
+
   return {
     allPortsFound: true,
     portsWithSelectors,

--- a/tests/components/primitive-components/self-connecting-trace.test.tsx
+++ b/tests/components/primitive-components/self-connecting-trace.test.tsx
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("a trace connecting a port to itself emits source_trace_not_connected_error", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <trace from=".R1 > .pin1" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_trace_not_connected_error.list()
+  expect(errors).toHaveLength(1)
+  expect(errors[0]?.message).toMatch(/itself/)
+
+  const traces = circuit.db.source_trace.list()
+  expect(
+    traces.some(
+      (trace) =>
+        trace.connected_source_port_ids.length === 2 &&
+        trace.connected_source_port_ids[0] ===
+          trace.connected_source_port_ids[1],
+    ),
+  ).toBe(false)
+})

--- a/tests/components/primitive-components/self-connecting-trace.test.tsx
+++ b/tests/components/primitive-components/self-connecting-trace.test.tsx
@@ -5,9 +5,13 @@ test("a trace connecting a port to itself emits source_trace_not_connected_error
   const { circuit } = getTestFixture()
 
   circuit.add(
-    <board width="20mm" height="20mm">
-      <resistor name="R1" resistance="1k" footprint="0402" />
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={8} />
+      <net name="VCC" />
       <trace from=".R1 > .pin1" to=".R1 > .pin1" />
+      <trace from=".R1 > .pin2" to=".R2 > .pin1" />
+      <trace from=".R2 > .pin2" to="net.VCC" />
     </board>,
   )
 
@@ -15,15 +19,33 @@ test("a trace connecting a port to itself emits source_trace_not_connected_error
 
   const errors = circuit.db.source_trace_not_connected_error.list()
   expect(errors).toHaveLength(1)
-  expect(errors[0]?.message).toMatch(/itself/)
+  expect(errors[0]?.message).toMatch(/connects a port to itself/)
 
   const traces = circuit.db.source_trace.list()
+  expect(traces).toHaveLength(2)
   expect(
     traces.some(
       (trace) =>
         trace.connected_source_port_ids.length === 2 &&
-        trace.connected_source_port_ids[0] ===
-          trace.connected_source_port_ids[1],
+        new Set(trace.connected_source_port_ids).size === 1,
     ),
   ).toBe(false)
+})
+
+test("a trace from a port to a net is not flagged as a self-connection", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <net name="VCC" />
+      <trace from=".R1 > .pin1" to="net.VCC" />
+      <trace from=".R1 > .pin2" to="net.VCC" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_trace_not_connected_error.list()).toHaveLength(0)
+  expect(circuit.db.source_trace.list().length).toBeGreaterThan(0)
 })


### PR DESCRIPTION
## Summary

`<trace from=".R1 > .pin1" to=".R1 > .pin1" />` was accepted silently and inserted a `source_trace` listing the same port twice (`#2859`). The only hint was an unrelated missing-trace warning on the *other* pin.

Two or more selectors that collapse onto the same port now emit `source_trace_not_connected_error` (`connects a port to itself`) and do not insert that duplicate-port `source_trace`.

A single resolved port plus a net (`from=".R1 > .pin1" to="net.VCC"`) stays valid, as do ordinary two-pin traces on the same board.

Prior attempts `#2860`, `#3005`, and `#3256` were closed without merging.

## Test plan

- [x] `bun test tests/components/primitive-components/self-connecting-trace.test.tsx`

Fixes #2859