### PR TITLE
fix: report unparseable unit values instead of emitting NaN

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent.ts
@@ -132,6 +132,19 @@ export type PortMap<T extends string> = {
  * }
  */
 
+/**
+ * circuit-JSON field name -> the prop the user wrote, where the two differ by
+ * more than snake_case/camelCase.
+ */
+const NAN_CHECKED_SOURCE_FIELD_TO_PROP: Record<string, string> = {
+  current_rating_amps: "currentRating",
+  voltage_rating_volts: "voltageRating",
+  max_voltage_rating: "maxVoltageRating",
+  max_current_rating: "maxCurrentRating",
+  load_capacitance: "loadCapacitance",
+  max_resistance: "maxResistance",
+}
+
 export class NormalComponent<
     ZodProps extends z.ZodType = any,
     PortNames extends string = never,
@@ -727,12 +740,41 @@ export class NormalComponent<
   }
 
   /**
+   * Reports props that parsed into `NaN`.
+   *
+   * Unit-bearing props (`resistance`, `capacitance`, ...) are declared as a
+   * zod transform that accepts a string, so a typo like `resistance="abc"`
+   * passes validation and becomes `NaN`. Nothing downstream checked for that,
+   * so it silently reached circuit JSON and rendered as "NaNpΩ".
+   */
+  _reportNaNSourceValues(): void {
+    if (!this.source_component_id) return
+    const { db } = this.root!
+    const sourceComponent = db.source_component.get(this.source_component_id)
+    if (!sourceComponent) return
+
+    for (const [key, value] of Object.entries(sourceComponent)) {
+      if (typeof value !== "number" || !Number.isNaN(value)) continue
+      const propName =
+        NAN_CHECKED_SOURCE_FIELD_TO_PROP[key] ??
+        key.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
+      const rawValue = (this.props as Record<string, unknown>)?.[propName]
+      this._reportInvalidComponentPropertyError(
+        propName,
+        `Invalid ${propName} value for ${this.componentName} "${this.name}": ${JSON.stringify(rawValue)} could not be parsed as a number.`,
+      )
+    }
+  }
+
+  /**
    * After ports have their source_port_id assigned, create
    * source_component_internal_connection records so that the connectivity
    * map (and therefore DRC) knows which pins are internally connected.
    */
   doInitialSourceParentAttachment(): void {
     const { db } = this.root!
+
+    this._reportNaNSourceValues()
 
     const internallyConnectedSourcePortIds = this._getInternallyConnectedPins()
       .map((ports) =>

--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -180,7 +180,7 @@ export abstract class PrimitiveComponent<
   cad_component_id: string | null = null
   _reportedInvalidPcbCalcWarnings = new Set<string>()
 
-  private _reportInvalidComponentPropertyError(
+  protected _reportInvalidComponentPropertyError(
     propertyName: string,
     message: string,
   ): void {

--- a/tests/components/base-components/unparseable-value-error.test.tsx
+++ b/tests/components/base-components/unparseable-value-error.test.tsx
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("unparseable unit values are reported instead of rendering NaN", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="40mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="abc" footprint="0402" pcbX={-12} />
+      <capacitor name="C1" capacitance="xyz" footprint="0402" pcbX={-6} />
+      <fuse name="F1" currentRating="bad" footprint="0402" pcbX={6} />
+      <resistor name="R9" resistance="1k" footprint="0402" pcbX={12} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.source_invalid_component_property_error.list()
+  const byProperty = Object.fromEntries(
+    errors.map((e) => [e.property_name, e.message]),
+  )
+
+  expect(Object.keys(byProperty).sort()).toEqual([
+    "capacitance",
+    "currentRating",
+    "resistance",
+  ])
+  expect(byProperty.resistance).toContain('"abc"')
+  expect(byProperty.resistance).toContain("R1")
+  expect(byProperty.currentRating).toContain("F1")
+  expect(errors).toHaveLength(3)
+  expect(errors.some((e) => e.message.includes("R9"))).toBe(false)
+})
+
+test("valid values raise no property errors", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <capacitor name="C1" capacitance="1uF" footprint="0402" pcbX={5} />
+      <fuse name="F1" currentRating="2A" voltageRating="32V" footprint="0402" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  expect(circuit.db.source_invalid_component_property_error.list()).toEqual([])
+})


### PR DESCRIPTION
## Summary

Typos like `resistance=\"abc\"` parse through the unit transform as `NaN` and render as `NaNpΩ` on the schematic with zero errors (`#2855`). Omitting `resistance` already fails validation; misspelling it did not.

After source insert, numeric `NaN` fields on `source_component` now emit `source_invalid_component_property_error` (same path as bad `calc()` expressions). A valid sibling on the same board is not flagged.

Prior attempt `#2856` was closed without merging.

## Test plan

- [x] `bun test tests/components/base-components/unparseable-value-error.test.tsx`

Fixes #2855