### PR TITLE
fix: report non-positive physical dimensions

### DIFF
--- a/lib/components/normal-components/Board_doInitialPcbPlacementDesignRuleChecks.ts
+++ b/lib/components/normal-components/Board_doInitialPcbPlacementDesignRuleChecks.ts
@@ -3,6 +3,60 @@ import type { AnyCircuitElement } from "circuit-json"
 import type { Renderable } from "../base-components/Renderable"
 import type { Board } from "./Board"
 
+/**
+ * Physical dimensions that must be greater than zero, per element type.
+ *
+ * A negative or zero size is silently accepted today: `<hole diameter="-2mm" />`
+ * produces `hole_diameter: -2` with no error, and a `<board width="0mm" />`
+ * renders an empty board. Nothing downstream rejects it, so the mistake only
+ * surfaces as a confusing render or an unmanufacturable export.
+ */
+const POSITIVE_DIMENSION_FIELDS: Record<string, string[]> = {
+  pcb_board: ["width", "height"],
+  pcb_hole: ["hole_diameter", "hole_width", "hole_height"],
+  pcb_plated_hole: [
+    "hole_diameter",
+    "outer_diameter",
+    "hole_width",
+    "hole_height",
+    "outer_width",
+    "outer_height",
+    "rect_pad_width",
+    "rect_pad_height",
+  ],
+  pcb_via: ["hole_diameter", "outer_diameter"],
+  pcb_smtpad: ["width", "height", "radius"],
+}
+
+const reportNonPositiveDimensions = ({
+  board,
+  elements,
+}: {
+  board: Board
+  elements: AnyCircuitElement[]
+}) => {
+  const { db } = board.root!
+
+  for (const element of elements as any[]) {
+    const fields = POSITIVE_DIMENSION_FIELDS[element.type]
+    if (!fields) continue
+
+    for (const field of fields) {
+      const value = element[field]
+      if (typeof value !== "number" || Number.isNaN(value)) continue
+      if (value > 0) continue
+
+      const label =
+        element.name ?? element[`${element.type}_id`] ?? element.type
+      db.pcb_placement_error.insert({
+        error_type: "pcb_placement_error",
+        message: `${element.type} "${label}" has ${field}=${value}mm, which must be greater than zero.`,
+        subcircuit_id: board.subcircuit_id ?? undefined,
+      })
+    }
+  }
+}
+
 const resetPcbTraceRenderInSubtree = (renderable: Renderable) => {
   if (renderable._pcbTraceRenderWaitingForPlacementChecks) {
     renderable.renderPhaseStates.PcbTraceRender.initialized = false
@@ -27,15 +81,21 @@ export const Board_doInitialPcbPlacementDesignRuleChecks = (board: Board) => {
   board._pcbPlacementDrcErrorCount = null
   board._pcbPlacementDrcCheckError = null
   board._pcbPlacementDrcChecksPending = false
-  if (placementDrcChecksDisabled || drcChecksDisabled) {
-    board._pcbPlacementDrcErrorCount = 0
-    return
-  }
 
   const { db } = board.root!
   const subcircuitCircuitJson = db
     .subtree({ subcircuit_id: board.subcircuit_id })
     .toArray()
+  reportNonPositiveDimensions({
+    board,
+    elements: subcircuitCircuitJson,
+  })
+
+  if (placementDrcChecksDisabled || drcChecksDisabled) {
+    board._pcbPlacementDrcErrorCount = 0
+    return
+  }
+
   const existingPlacementDiagnostics = db.toArray()
 
   board._pcbPlacementDrcChecksPending = true

--- a/tests/components/normal-components/non-positive-dimension-error.test.tsx
+++ b/tests/components/normal-components/non-positive-dimension-error.test.tsx
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("non-positive physical dimensions are reported", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <hole name="H1" diameter="-2mm" pcbX={-5} pcbY={0} />
+      <via
+        name="V1"
+        pcbX={5}
+        pcbY={0}
+        holeDiameter="-0.3mm"
+        outerDiameter="0.6mm"
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} pcbY={5} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.pcb_placement_error.list()
+  expect(errors.length).toBe(2)
+
+  const messages = errors.map((e) => e.message).join("\n")
+  expect(messages).toContain("pcb_hole")
+  expect(messages).toContain("hole_diameter=-2mm")
+  expect(messages).toContain("pcb_via")
+  expect(messages).toContain("must be greater than zero")
+  expect(messages).not.toContain("pcb_smtpad")
+})
+
+test("a zero-size board is reported", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="0mm" height="0mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.pcb_placement_error.list()
+  expect(errors.some((e) => String(e.message).includes("pcb_board"))).toBe(true)
+})
+
+test("valid dimensions raise no non-positive placement errors", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm">
+      <hole name="H1" diameter="2mm" pcbX={-8} pcbY={0} />
+      <via
+        name="V1"
+        pcbX={8}
+        pcbY={0}
+        holeDiameter="0.3mm"
+        outerDiameter="0.6mm"
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} pcbY={8} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.pcb_placement_error
+    .list()
+    .filter((e) => String(e.message).includes("greater than zero"))
+
+  expect(errors).toEqual([])
+})


### PR DESCRIPTION
## Summary

Negative and zero physical dimensions (\`<hole diameter=\"-2mm\" />\`, via hole diameter, \`<board width=\"0mm\" />\`) were accepted with no error and written into circuit JSON (\`#2857\`). Those geometries are unmanufacturable and downstream exporters cannot reason about them.

Placement DRC now walks hole/via/pad/board size fields and emits \`pcb_placement_error\` when a numeric dimension is \u22640. Valid pads on the same board are not flagged.

The check runs even when other placement DRC is disabled, because this is input validation, not a clearance rule.

Prior attempt \`#2858\` was closed without merging.

## Test plan

- [x] \`bun test tests/components/normal-components/non-positive-dimension-error.test.tsx\`

Fixes #2857