### PR TITLE
fix: emit schema-valid circuit JSON for board-level holes

### DIFF
--- a/lib/components/primitive-components/Hole.ts
+++ b/lib/components/primitive-components/Hole.ts
@@ -8,6 +8,7 @@ import type {
   PcbHoleRect,
   PcbHoleCircle,
 } from "circuit-json"
+import { optionalId } from "lib/utils/optional-id"
 
 export class Hole extends PrimitiveComponent<typeof holeProps> {
   pcb_hole_id: string | null = null
@@ -52,9 +53,10 @@ export class Hole extends PrimitiveComponent<typeof holeProps> {
     const position = this._getGlobalPcbPositionBeforeLayout()
     const soldermaskMargin = props.solderMaskMargin
     const isCoveredWithSolderMask = props.coveredWithSolderMask ?? false
-    const pcb_component_id =
+    const pcb_component_id = optionalId(
       this.parent?.pcb_component_id ??
-      this.getPrimitiveContainer()?.pcb_component_id
+        this.getPrimitiveContainer()?.pcb_component_id,
+    )
 
     this.emitSolderMaskMarginWarning(isCoveredWithSolderMask, soldermaskMargin)
 

--- a/lib/components/primitive-components/PlatedHole.ts
+++ b/lib/components/primitive-components/PlatedHole.ts
@@ -13,6 +13,7 @@ import type {
 } from "circuit-json"
 import { decomposeTSR } from "transformation-matrix"
 import { selectPortForPcbPrimitive } from "./Port/selectPortForPcbPrimitive"
+import { optionalId } from "lib/utils/optional-id"
 
 export class PlatedHole extends PrimitiveComponent<typeof platedHoleProps> {
   pcb_plated_hole_id: string | null = null
@@ -125,9 +126,10 @@ export class PlatedHole extends PrimitiveComponent<typeof platedHoleProps> {
     const { db } = this.root!
     const { _parsedProps: props } = this
     const position = this._getGlobalPcbPositionBeforeLayout()
-    const pcb_component_id =
+    const pcb_component_id = optionalId(
       this.parent?.pcb_component_id ??
-      this.getPrimitiveContainer()?.pcb_component_id!
+        this.getPrimitiveContainer()?.pcb_component_id,
+    )
     const subcircuit = this.getSubcircuit()
     const platedHoleLayers = this.getAvailablePcbLayers()
     const soldermaskMargin = props.solderMaskMargin
@@ -265,6 +267,8 @@ export class PlatedHole extends PrimitiveComponent<typeof platedHoleProps> {
         rect_pad_width: props.rectPadWidth,
         rect_pad_height: props.rectPadHeight,
         shape: "circular_hole_with_rect_pad" as const,
+        hole_shape: "circle" as const,
+        pad_shape: "rect" as const,
         port_hints: this.getNameAndAliases(),
         x: position.x,
         y: position.y,

--- a/lib/utils/optional-id.ts
+++ b/lib/utils/optional-id.ts
@@ -1,0 +1,13 @@
+/**
+ * Normalizes an id that may be `null` into `undefined`.
+ *
+ * `PrimitiveComponent` initialises its id fields to `null`
+ * (`pcb_component_id: string | null = null`), but circuit-json types every id
+ * as `z.string().optional()` — which accepts `undefined` and rejects `null`.
+ *
+ * Primitives placed directly on a board have no owning `pcb_component`, so the
+ * `null` was reaching circuit JSON and making the whole element fail
+ * `any_circuit_element.parse()`.
+ */
+export const optionalId = (id: string | null | undefined): string | undefined =>
+  id ?? undefined

--- a/tests/components/primitive-components/hole-board-level-circuit-json-validity.test.tsx
+++ b/tests/components/primitive-components/hole-board-level-circuit-json-validity.test.tsx
@@ -40,17 +40,6 @@ test("board-level holes produce valid circuit json", async () => {
 
   for (const hole of holes) {
     const result = any_circuit_element.safeParse(hole)
-    expect({
-      type: hole.type,
-      shape: hole.shape ?? hole.hole_shape,
-      pcb_component_id: hole.pcb_component_id,
-      valid: result.success,
-      issues: result.success ? undefined : result.error.issues.slice(0, 3),
-    }).toEqual({
-      type: hole.type,
-      shape: hole.shape ?? hole.hole_shape,
-      pcb_component_id: hole.pcb_component_id,
-      valid: true,
-    })
+    expect(result.success).toBe(true)
   }
 })

--- a/tests/components/primitive-components/hole-board-level-circuit-json-validity.test.tsx
+++ b/tests/components/primitive-components/hole-board-level-circuit-json-validity.test.tsx
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("board-level holes produce valid circuit json", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <hole name="H1" pcbX={-5} pcbY={5} diameter="1mm" />
+      <platedhole
+        name="PH1"
+        pcbX={5}
+        pcbY={-5}
+        shape="circle"
+        holeDiameter="0.5mm"
+        outerDiameter="0.9mm"
+      />
+      <chip name="U1" footprint="dip8" pcbX={0} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const holes = circuitJson.filter(
+    (e: any) => e.type === "pcb_hole" || e.type === "pcb_plated_hole",
+  ) as any[]
+
+  expect(holes.length).toBeGreaterThan(0)
+
+  const boardLevelHoles = holes.filter(
+    (h) => h.pcb_component_id == null || h.pcb_component_id === undefined,
+  )
+  expect(boardLevelHoles.length).toBeGreaterThan(0)
+
+  for (const hole of boardLevelHoles) {
+    expect(hole.pcb_component_id).toBeUndefined()
+  }
+
+  for (const hole of holes) {
+    const result = any_circuit_element.safeParse(hole)
+    expect({
+      type: hole.type,
+      shape: hole.shape ?? hole.hole_shape,
+      pcb_component_id: hole.pcb_component_id,
+      valid: result.success,
+      issues: result.success ? undefined : result.error.issues.slice(0, 3),
+    }).toEqual({
+      type: hole.type,
+      shape: hole.shape ?? hole.hole_shape,
+      pcb_component_id: hole.pcb_component_id,
+      valid: true,
+    })
+  }
+})

--- a/tests/components/primitive-components/plated-hole-pill-rotated2.test.tsx
+++ b/tests/components/primitive-components/plated-hole-pill-rotated2.test.tsx
@@ -33,7 +33,7 @@ test("PlatedHole pill shape", () => {
       ],
       "outer_height": 4,
       "outer_width": 2,
-      "pcb_component_id": null,
+      "pcb_component_id": undefined,
       "pcb_group_id": undefined,
       "pcb_plated_hole_id": "pcb_plated_hole_0",
       "pcb_port_id": undefined,


### PR DESCRIPTION
## Summary

Board-level \`<hole />\` / \`<platedhole />\` wrote \`pcb_component_id: null\`. circuit-json types that field as \`z.string().optional()\`, which accepts \`undefined\` and rejects \`null\`, so \`any_circuit_element.safeParse\` failed (\`#2843\`).

Normalize missing owner ids with \`optionalId()\`. DIP \`circular_hole_with_rect_pad\` plated holes also now set the required \`hole_shape\` / \`pad_shape\` fields (the pill variants already did).

Footprint holes that belong to a component still keep their string \`pcb_component_id\`.

Prior attempts \`#2844\` and \`#3039\` were closed without merging.

## Test plan

- [x] \`bun test tests/components/primitive-components/hole-board-level-circuit-json-validity.test.tsx\`

Fixes #2843