### PR TITLE
fix: omit null group anchor_alignment and subcircuit_id

### DIFF
--- a/lib/components/primitive-components/Group/Group.ts
+++ b/lib/components/primitive-components/Group/Group.ts
@@ -539,7 +539,9 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
             trace_clearance: props.autorouter.traceClearance,
           }
         : undefined,
-      anchor_alignment: props.pcbAnchorAlignment ?? null,
+      // circuit-json declares this as `ninePointAnchor.default("center")`, so a
+      // `null` fails validation while omitting it lets the schema default apply.
+      anchor_alignment: props.pcbAnchorAlignment ?? undefined,
     })
     this.pcb_group_id = pcb_group.pcb_group_id
 
@@ -2243,7 +2245,10 @@ export class Group<Props extends z.ZodType<any, any, any> = typeof groupProps>
     const { _parsedProps: props } = this
     const schematic_group = db.schematic_group.insert({
       is_subcircuit: this.isSubcircuit,
-      subcircuit_id: this.subcircuit_id!,
+      // `subcircuit_id` is `string | null` on the component but
+      // `z.string().optional()` on the schema, so `null` fails validation.
+      // A group outside any subcircuit simply has none.
+      subcircuit_id: this.subcircuit_id ?? undefined,
       name: this.name,
       center: this._getGlobalSchematicPositionBeforeLayout(),
       width: 0,

--- a/tests/components/primitive-components/group-circuit-json-nulls.test.tsx
+++ b/tests/components/primitive-components/group-circuit-json-nulls.test.tsx
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import * as CJ from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("groups do not emit null anchor_alignment / subcircuit_id", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <group name="G1" pcbX={4}>
+        <resistor name="R1" resistance="1k" footprint="0402" />
+      </group>
+      <group name="G2" pcbX={-6} pcbAnchorAlignment="top_left">
+        <resistor name="R2" resistance="1k" footprint="0402" />
+      </group>
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const pcbGroups = circuitJson.filter(
+    (e: any) => e.type === "pcb_group",
+  ) as any[]
+  const schematicGroups = circuitJson.filter(
+    (e: any) => e.type === "schematic_group",
+  ) as any[]
+
+  expect(pcbGroups.length).toBeGreaterThan(0)
+  expect(schematicGroups.length).toBeGreaterThan(0)
+
+  for (const group of pcbGroups) {
+    expect(group.anchor_alignment).not.toBeNull()
+  }
+
+  for (const group of schematicGroups) {
+    expect(group.subcircuit_id).not.toBeNull()
+  }
+
+  const explicit = pcbGroups.find((g) => g.anchor_alignment === "top_left")
+  expect(explicit).toBeDefined()
+
+  for (const group of [...pcbGroups, ...schematicGroups]) {
+    const schema = (CJ as any)[group.type]
+    const result = schema.safeParse(group)
+    const relevantIssues = result.success
+      ? []
+      : result.error.issues
+          .filter((i: any) =>
+            ["anchor_alignment", "subcircuit_id"].includes(String(i.path[0])),
+          )
+          .map((i: any) => `${i.path.join(".")}: ${i.message}`)
+    expect(relevantIssues).toEqual([])
+  }
+})

--- a/tests/components/primitive-components/group-subcircuit-id.test.tsx
+++ b/tests/components/primitive-components/group-subcircuit-id.test.tsx
@@ -34,7 +34,7 @@ test("Subcircuit group should have subcircuit_id", async () => {
   expect(circuit.db.pcb_group.list()).toMatchInlineSnapshot(`
 [
   {
-    "anchor_alignment": null,
+    "anchor_alignment": undefined,
     "anchor_position": {
       "x": 0,
       "y": 0,

--- a/tests/groups/group-outline.test.tsx
+++ b/tests/groups/group-outline.test.tsx
@@ -26,7 +26,7 @@ test("group with outline specified", async () => {
   expect(pcb_groups).toMatchInlineSnapshot(`
     [
       {
-        "anchor_alignment": null,
+        "anchor_alignment": undefined,
         "anchor_position": {
           "x": 0,
           "y": 0,

--- a/tests/groups/group-schematic-box.test.tsx
+++ b/tests/groups/group-schematic-box.test.tsx
@@ -33,7 +33,7 @@ test("group schematic box", () => {
         "schematic_group_id": "schematic_group_0",
         "show_as_schematic_box": true,
         "source_group_id": "source_group_0",
-        "subcircuit_id": null,
+        "subcircuit_id": undefined,
         "type": "schematic_group",
         "width": 0.4,
       },

--- a/tests/repros/repro158-pcb-group-size.test.tsx
+++ b/tests/repros/repro158-pcb-group-size.test.tsx
@@ -20,7 +20,7 @@ test("repro158: PCB group size", async () => {
   expect(pcb_groups).toMatchInlineSnapshot(`
     [
       {
-        "anchor_alignment": null,
+        "anchor_alignment": undefined,
         "anchor_position": {
           "x": 0,
           "y": 0,


### PR DESCRIPTION
## Summary

\`<group />\` wrote \`pcb_group.anchor_alignment: null\` and \`schematic_group.subcircuit_id: null\`. circuit-json types those as an optional enum (default \`"center"\`) and \`z.string().optional()\`, so \`null\` fails \`any_circuit_element\` (\`#2845\`).

Write \`undefined\` instead. An explicit \`pcbAnchorAlignment=\"top_left\"\` is preserved.

Prior attempts \`#2846\` and \`#3041\` were closed without merging.

## Test plan

- [x] \`bun test tests/components/primitive-components/group-circuit-json-nulls.test.tsx\`

Fixes #2845