### PR TITLE
fix: report library footprints that resolve with no pads

### DIFF
--- a/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
+++ b/lib/components/base-components/NormalComponent/NormalComponent_doInitialPcbFootprintStringRender.ts
@@ -239,6 +239,18 @@ export function NormalComponent_doInitialPcbFootprintStringRender(
             `Footprint resolver returned no circuit elements for "${footprint}".`,
           )
         }
+        const hasPcbGeometry = circuitJson.some(
+          (element) =>
+            element.type === "pcb_smtpad" ||
+            element.type === "pcb_plated_hole" ||
+            element.type === "pcb_hole" ||
+            element.type === "pcb_via",
+        )
+        if (!hasPcbGeometry) {
+          throw new Error(
+            `Footprint resolver returned no PCB geometry (pads or holes) for "${footprint}".`,
+          )
+        }
         const fpComponents = createComponentsFromCircuitJson(
           {
             componentName: component.name,

--- a/tests/footprint/footprint-library-map-jlcpcb-no-pads-error.test.tsx
+++ b/tests/footprint/footprint-library-map-jlcpcb-no-pads-error.test.tsx
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("jlcpcb footprint JSON without pads reports a load error", async () => {
+  const { circuit } = getTestFixture({
+    platform: {
+      footprintLibraryMap: {
+        jlcpcb: async () => ({
+          footprintCircuitJson: [
+            {
+              type: "cad_component",
+              cad_component_id: "cad_component_0",
+              pcb_component_id: "pcb_component_0",
+              source_component_id: "source_component_0",
+              position: { x: 0, y: 0, z: 0 },
+              rotation: { x: 0, y: 0, z: 0 },
+              layer: "top",
+            },
+          ],
+        }),
+      },
+    },
+  })
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <chip name="J1" footprint="jlcpcb:C19268734" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const errors = circuit.db.external_footprint_load_error.list()
+  expect(errors).toHaveLength(1)
+  expect(errors[0]?.message).toContain("jlcpcb:C19268734")
+  expect(errors[0]?.message).toMatch(/no pads|no PCB geometry/i)
+  expect(circuit.db.pcb_smtpad.list()).toHaveLength(0)
+  expect(circuit.db.pcb_plated_hole.list()).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary

\`footprint=\"jlcpcb:C19268734\"\` can resolve to a non-empty Circuit JSON payload that still has **no pads or holes**. Core treated any non-empty array as success, so the build exited cleanly with zero \`pcb_smtpad\` / \`pcb_plated_hole\` / \`pcb_port\` and no \`external_footprint_load_error\` ([tscircuit/tscircuit#4048](https://github.com/tscircuit/tscircuit/issues/4048)).

Empty arrays already error. This extends that check: after a library resolver returns elements, require at least one \`pcb_smtpad\`, \`pcb_plated_hole\`, \`pcb_hole\`, or \`pcb_via\`. CAD-only payloads now emit \`external_footprint_load_error\`. Real JLCPCB JSON that includes pads (USB-C C165948 fixture) still loads.

## Test plan

- [x] \`bun test tests/footprint/footprint-library-map-jlcpcb-no-pads-error.test.tsx\`
- [x] existing jlcpcb cadModel fixtures still pass