### PR TITLE
fix: make getString render ids stable per circuit

### DIFF
--- a/lib/IsolatedCircuit.ts
+++ b/lib/IsolatedCircuit.ts
@@ -20,6 +20,12 @@ export class IsolatedCircuit {
   db: CircuitJsonUtilObjects
   root: IsolatedCircuit | null = null
   isRootCircuit = false
+  /**
+   * Lowest PrimitiveComponent `_renderId` in this circuit. Cached so
+   * `getString()` can emit ids relative to the tree instead of the
+   * process-global construction counter (core#2848).
+   */
+  _renderIdOrigin?: number
 
   /**
    * Optional cache for isolated subcircuit circuit JSON, keyed by prop hash.
@@ -159,6 +165,30 @@ export class IsolatedCircuit {
     }
 
     return findBoard(this.children) as (PrimitiveComponent & BoardI) | undefined
+  }
+
+  /**
+   * `_renderId` is a process-global counter and must stay unique for css-select
+   * identity. User-facing strings should not leak that counter, so this offsets
+   * it against the lowest id in the circuit.
+   */
+  getCircuitRelativeRenderId(renderId: string): string {
+    if (this._renderIdOrigin === undefined) {
+      let lowest = Number.POSITIVE_INFINITY
+      const visit = (node: PrimitiveComponent) => {
+        const value = Number(node._renderId)
+        if (Number.isFinite(value)) lowest = Math.min(lowest, value)
+        for (const child of node.children) {
+          visit(child as PrimitiveComponent)
+        }
+      }
+      for (const child of this.children) visit(child)
+      this._renderIdOrigin = Number.isFinite(lowest) ? lowest : 0
+    }
+
+    const relative = Number(renderId) - this._renderIdOrigin
+    if (!Number.isFinite(relative) || relative < 0) return renderId
+    return `${relative}`
   }
 
   _guessRootComponent() {

--- a/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
+++ b/lib/components/base-components/PrimitiveComponent/PrimitiveComponent.ts
@@ -1422,22 +1422,24 @@ export abstract class PrimitiveComponent<
 
   getString(): string {
     const { lowercaseComponentName: cname, _parsedProps: props, parent } = this
+    const id =
+      this.root?.getCircuitRelativeRenderId(this._renderId) ?? this._renderId
     if (props?.pinNumber !== undefined && parent?.props?.name && props?.name) {
-      return `<${cname}#${this._renderId}(pin:${props.pinNumber} .${parent?.props.name}>.${props.name}) />`
+      return `<${cname}#${id}(pin:${props.pinNumber} .${parent?.props.name}>.${props.name}) />`
     }
     if (parent?.props?.name && props?.name) {
-      return `<${cname}#${this._renderId}(.${parent?.props.name}>.${props?.name}) />`
+      return `<${cname}#${id}(.${parent?.props.name}>.${props?.name}) />`
     }
     if (props?.from && props?.to) {
-      return `<${cname}#${this._renderId}(from:${props.from} to:${props?.to}) />`
+      return `<${cname}#${id}(from:${props.from} to:${props?.to}) />`
     }
     if (props?.name) {
-      return `<${cname}#${this._renderId} name=".${props?.name}" />`
+      return `<${cname}#${id} name=".${props?.name}" />`
     }
     if (props?.portHints) {
-      return `<${cname}#${this._renderId}(${props.portHints.map((ph: string) => `.${ph}`).join(", ")}) />`
+      return `<${cname}#${id}(${props.portHints.map((ph: string) => `.${ph}`).join(", ")}) />`
     }
-    return `<${cname}#${this._renderId} />`
+    return `<${cname}#${id} />`
   }
 
   getDisplayName(): string {

--- a/tests/components/base-components/render-id-is-circuit-stable.test.tsx
+++ b/tests/components/base-components/render-id-is-circuit-stable.test.tsx
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const buildAndGetWarning = async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <resistor name="R1" resistance="10k" footprint="0402" />
+      <resistor name="R2" resistance="10k" footprint="0402" />
+      <trace from=".R1 > .pin1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const warning = circuit
+    .getCircuitJson()
+    .find((e: any) => e.type === "source_unnamed_trace_warning") as any
+
+  return warning?.message as string | undefined
+}
+
+test("warning messages are identical for identical circuits", async () => {
+  // getString() used to embed the process-global _renderId, so rendering the
+  // same unnamed-trace board three times in one process produced drifting
+  // "trace#14" / "trace#36" / "trace#58" warning text. Snapshot/diff consumers
+  // then saw spurious changes even though the circuit JSON was otherwise identical.
+  const messages = [
+    await buildAndGetWarning(),
+    await buildAndGetWarning(),
+    await buildAndGetWarning(),
+  ]
+
+  for (const message of messages) {
+    expect(message).toBeDefined()
+    expect(message).toContain("is missing a name")
+  }
+
+  expect(new Set(messages).size).toBe(1)
+})
+
+test("render ids stay distinct within a circuit", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-5} />
+      <resistor name="R2" resistance="2k" footprint="0402" pcbX={5} />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const strings = (circuit.selectAll("resistor") as any[]).map((r) =>
+    r.getString(),
+  )
+
+  expect(strings.length).toBe(2)
+  expect(new Set(strings).size).toBe(2)
+})


### PR DESCRIPTION
## Summary

Rendering the same unnamed-trace board three times in one process used to produce three different warnings:

```
<trace#14(from:.R1 > .pin1 to:.R2 > .pin1) /> is missing a name. ...
<trace#36(...) /> is missing a name. ...
<trace#58(...) /> is missing a name. ...
```

`getString()` embeds `_renderId`, which comes from a module-level counter that never resets. The number reflects how many components the process has constructed, not anything about the circuit. Snapshot/diff/cache consumers then see spurious changes; the identifier is also useless as a handle (`trace#14` cannot be looked up).

`_renderId` itself has to stay process-unique (`cssSelectPrimitiveComponentAdapter` compares it for identity). This offsets the **display** id against the lowest id in the circuit, memoized on `IsolatedCircuit._renderIdOrigin`. Falls back to the raw id when the offset cannot be computed (no root yet, non-numeric id).

## Test plan

- [x] `bun test tests/components/base-components/render-id-is-circuit-stable.test.tsx`
- [x] unnamed-trace warning fixtures still pass
- [x] `bunx tsc --noEmit`

Fixes #2848