### PR TITLE
fix: name the real component in trace pin-not-found errors

### DIFF
--- a/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
+++ b/lib/components/primitive-components/Trace/Trace__findConnectedPorts.ts
@@ -57,6 +57,11 @@ export function Trace__findConnectedPorts(trace: Trace):
         parentSelector = match?.[1]?.trim() ?? ""
         portToken = match?.[2] ?? selector
       }
+      // Both branches can leave the child combinator behind: ".U1 > .pin1"
+      // yields ".U1 > ". That string doesn't select the component — it
+      // resolves to an arbitrary descendant — so the error message ends up
+      // naming the wrong element and reporting "It has no ports".
+      parentSelector = parentSelector.replace(/[\s>]+$/, "")
       let targetComponent = parentSelector
         ? trace.getSubcircuit().selectOne(parentSelector)
         : null
@@ -95,7 +100,19 @@ export function Trace__findConnectedPorts(trace: Trace):
       const labelList = Array.from(new Set(portNames)).join(", ")
       let detail: string
       if (ports.length === 0) {
-        detail = "It has no ports"
+        // A group is a container, not a component with pins — telling the user
+        // it "has no ports" is true but useless. Point at what they can
+        // actually connect to instead.
+        const namedChildren = targetComponent.children
+          .filter((c) => c.componentName !== "Port" && (c as any).props?.name)
+          .map((c) => `.${(c as any).props.name}`)
+        if (targetComponent.isGroup) {
+          detail = namedChildren.length
+            ? `It is a group, which has no pins of its own. Select a component inside it, e.g. "${namedChildren[0]} > .${portLabel}". It contains [${Array.from(new Set(namedChildren)).join(", ")}]`
+            : "It is a group, which has no pins of its own, and it contains no named components"
+        } else {
+          detail = "It has no ports"
+        }
       } else if (!hasCustomLabels) {
         detail = `It has ${ports.length} pins and no pinLabels (consider adding pinLabels)`
       } else {

--- a/tests/components/base-components/trace-port-selector-errors.test.tsx
+++ b/tests/components/base-components/trace-port-selector-errors.test.tsx
@@ -43,7 +43,7 @@ test("error when component has no ports", () => {
 
   expect(errors.length).toBe(1)
   expect((errors[0] as any).message).toBe(
-    'Could not find port for selector "G1.1". Component "G1" found, but does not have pin "1". It has no ports',
+    'Could not find port for selector "G1.1". Component "G1" found, but does not have pin "1". It is a group, which has no pins of its own, and it contains no named components',
   )
 })
 

--- a/tests/components/normal-components/chip-connections-invalid.test.tsx
+++ b/tests/components/normal-components/chip-connections-invalid.test.tsx
@@ -38,7 +38,7 @@ test("Chip not having name messes up the connections, uses the pin of the first 
     [
       {
         "error_type": "source_trace_not_connected_error",
-        "message": "Could not find port for selector ".unnamed_chip1 > .pin1". Component ".unnamed_chip1 > " not found",
+        "message": "Could not find port for selector ".unnamed_chip1 > .pin1". Component ".unnamed_chip1" not found",
         "selectors_not_found": [
           ".unnamed_chip1 > .pin1",
         ],

--- a/tests/components/primitive-components/trace-group-selector-error.test.tsx
+++ b/tests/components/primitive-components/trace-group-selector-error.test.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("selecting a pin on a group explains that groups have no pins", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <group name="G1">
+        <resistor name="R1" resistance="1k" footprint="0402" />
+        <capacitor name="C1" capacitance="1uF" footprint="0402" pcbX={3} />
+      </group>
+      <resistor name="R2" resistance="1k" footprint="0402" pcbX={8} />
+      <trace from=".G1 > .pin1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const error = circuit
+    .getCircuitJson()
+    .find((e: any) => String(e.type).includes("error")) as any
+
+  expect(error).toBeDefined()
+
+  // On main, ".G1 >" resolves to the group's first child, so the message
+  // names R1 (which does have pin1) instead of the group. After stripping
+  // the combinator, the target is the group and the message should say so.
+  expect(error.message).toContain('Component "G1" found')
+  expect(error.message).not.toContain("It has no ports")
+  expect(error.message).toContain("It is a group")
+  expect(error.message).toContain(".R1")
+  expect(error.message).toContain(".C1")
+  expect(error.message).toContain('".R1 > .pin1"')
+})
+
+test("a chip with a missing pin still lists pins, not the group wording", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm" routingDisabled>
+      <chip name="U1" footprint="soic8" pcbX={0} />
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={-8} />
+      <trace from=".R1 > .pin1" to=".U1 > .NOPE" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const error = circuit
+    .getCircuitJson()
+    .find((e: any) => String(e.type).includes("error")) as any
+
+  expect(error).toBeDefined()
+  expect(error.message).not.toContain("It is a group")
+  expect(error.message).toContain("pins")
+})

--- a/tests/components/primitive-components/trace-missing-port-error-message.test.tsx
+++ b/tests/components/primitive-components/trace-missing-port-error-message.test.tsx
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("missing-pin error names the component and lists its pins", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pcbX={0}
+        pinLabels={{ pin1: ["VCC"], pin2: ["GND"] }}
+      />
+      <trace from=".U1 > .VCC" to=".U1 > .NOPE" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const error = circuit
+    .getCircuitJson()
+    .find((e: any) => String(e.type).includes("error")) as any
+
+  expect(error).toBeDefined()
+
+  // The parent selector used to keep the child combinator (".U1 > "), which
+  // selects an arbitrary descendant rather than the chip — so the message
+  // named the wrong element and claimed it had no ports.
+  expect(error.message).toContain('Component "U1" found')
+  expect(error.message).not.toContain('".U1 > "')
+  expect(error.message).not.toContain("It has no ports")
+  expect(error.message).toContain("VCC")
+  expect(error.message).toContain("GND")
+})
+
+test("missing-component error reports the component selector without the combinator", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="30mm" routingDisabled>
+      <resistor name="R1" resistance="1k" footprint="0402" pcbX={0} />
+      <trace from=".R1 > .pin1" to=".R9 > .pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const error = circuit
+    .getCircuitJson()
+    .find((e: any) => String(e.type).includes("error")) as any
+
+  expect(error).toBeDefined()
+  expect(error.message).toContain('Component ".R9" not found')
+  expect(error.message).not.toContain('".R9 > "')
+})

--- a/tests/repros/repro99-trace-selector-pcbpath-no-throw.test.tsx
+++ b/tests/repros/repro99-trace-selector-pcbpath-no-throw.test.tsx
@@ -20,5 +20,7 @@ test("repro100 trace selector with pcbPath inserts error instead of throwing", a
 
   expect(errors.length).toBeGreaterThan(0)
   expect(errors[0].message).toContain('selector "J1.pin1"')
-  expect(errors[0].message).toContain("It has no ports")
+  // `J1` is an empty <group />, so the message explains that groups have no
+  // pins of their own rather than the bare "It has no ports".
+  expect(errors[0].message).toContain("It is a group")
 })


### PR DESCRIPTION
## Summary

When a trace references a missing pin, the error named the **wrong element** and reported **wrong facts**:

```
Could not find port for selector ".U1 > .NOPE".
Component ".U1 > " found, but does not have pin "NOPE". It has no ports
```

`U1` is a soic8 with ports. The parent selector kept the child combinator (`".U1 > "`), which `selectOne` resolves to an arbitrary descendant (often an unnamed pad with zero ports).

The same split makes a group look like its first child:

```
Could not find port for selector ".G1 > .pin1".
Component "R1" found, but does not have pin "pin1". It has [pin1, ...]
```

`R1` *does* have `pin1` — the user pointed at the group.

This strips trailing `>` / whitespace from the parent selector so the error names the chip and lists its pins. Groups get an explicit "has no pins of its own" message with a working child selector instead of "It has no ports".

## Test plan

- [x] `bun test tests/components/primitive-components/trace-missing-port-error-message.test.tsx`
- [x] `bun test tests/components/primitive-components/trace-group-selector-error.test.tsx`
- [x] existing trace-port-selector / chip-connections / repro99 expectations updated
- [x] `bunx tsc --noEmit`

Fixes #2850
Fixes #2852