### PR TITLE
fix: copy hole name onto pcb_hole

### DIFF
--- a/lib/components/primitive-components/Hole.ts
+++ b/lib/components/primitive-components/Hole.ts
@@ -74,7 +74,8 @@ export class Hole extends PrimitiveComponent<typeof holeProps> {
           is_covered_with_solder_mask: isCoveredWithSolderMask,
           subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
           pcb_group_id: subcircuit?.getGroup()?.pcb_group_id ?? undefined,
-        } as PcbHoleRotatedPill)
+          name: props.name,
+        } as unknown as PcbHoleRotatedPill)
         this.pcb_hole_id = inserted_hole.pcb_hole_id!
       } else {
         const inserted_hole = db.pcb_hole.insert({
@@ -89,7 +90,8 @@ export class Hole extends PrimitiveComponent<typeof holeProps> {
           is_covered_with_solder_mask: isCoveredWithSolderMask,
           subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
           pcb_group_id: subcircuit?.getGroup()?.pcb_group_id ?? undefined,
-        } as PcbHolePill)
+          name: props.name,
+        } as unknown as PcbHolePill)
         this.pcb_hole_id = inserted_hole.pcb_hole_id!
       }
     } else if (props.shape === "oval") {
@@ -105,7 +107,8 @@ export class Hole extends PrimitiveComponent<typeof holeProps> {
         is_covered_with_solder_mask: isCoveredWithSolderMask,
         subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
         pcb_group_id: subcircuit?.getGroup()?.pcb_group_id ?? undefined,
-      } as PCBHole)
+        name: props.name,
+      } as unknown as PCBHole)
       this.pcb_hole_id = inserted_hole.pcb_hole_id!
     } else if (props.shape === "rect") {
       // Rect shape
@@ -121,7 +124,8 @@ export class Hole extends PrimitiveComponent<typeof holeProps> {
         is_covered_with_solder_mask: isCoveredWithSolderMask,
         subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
         pcb_group_id: subcircuit?.getGroup()?.pcb_group_id ?? undefined,
-      } as PcbHoleRect)
+        name: props.name,
+      } as unknown as PcbHoleRect)
       this.pcb_hole_id = inserted_hole.pcb_hole_id!
     } else {
       // Circle shape (default)
@@ -136,7 +140,8 @@ export class Hole extends PrimitiveComponent<typeof holeProps> {
         is_covered_with_solder_mask: isCoveredWithSolderMask,
         subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
         pcb_group_id: subcircuit?.getGroup()?.pcb_group_id ?? undefined,
-      } as PcbHoleCircle)
+        name: props.name,
+      } as unknown as PcbHoleCircle)
       this.pcb_hole_id = inserted_hole.pcb_hole_id!
     }
   }

--- a/tests/components/primitive-components/hole-name.test.tsx
+++ b/tests/components/primitive-components/hole-name.test.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("board-level hole name is written onto pcb_hole", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="50mm" height="50mm" routingDisabled>
+      <hole pcbX={-15} pcbY={0} diameter="3.2mm" name="H9" />
+      <hole pcbX={15} pcbY={0} diameter="3.2mm" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const holes = circuit.db.pcb_hole.list() as any[]
+  const named = holes.find((h) => h.x === -15)
+  const unnamed = holes.find((h) => h.x === 15)
+
+  expect(named).toBeDefined()
+  expect(unnamed).toBeDefined()
+  // holeProps already accepts name, but Hole.ts never wrote it, so exporters
+  // had to invent designators (tscircuit/tscircuit#4415).
+  expect(named.name).toBe("H9")
+  expect(unnamed.name).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

\`<hole name=\"H9\" />\` is valid \`holeProps\` and renders, but \`Hole.ts\` never wrote \`props.name\`, so \`pcb_hole\` had no designator. KiCad then refuses empty references and exporters invent \`H1\`, \`H2\` independently ([tscircuit/tscircuit#4415](https://github.com/tscircuit/tscircuit/issues/4415)).

This copies \`name\` onto every \`pcb_hole\` shape. Companion schema PR: [tscircuit/circuit-json#768](https://github.com/tscircuit/circuit-json/pull/768). Courtyard-to-hole linking is a separate follow-up.

## Test plan

- [x] \`bun test tests/components/primitive-components/hole-name.test.tsx\`
- [x] existing hole shape fixtures still pass
- [x] \`bunx tsc --noEmit\`