### PR TITLE
fix: route nets exposed through nested subcircuit levels

### DIFF
--- a/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
+++ b/lib/utils/autorouting/getSimpleRouteJsonFromCircuitJson.ts
@@ -107,7 +107,7 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   minBoardEdgeClearance?: number
   minViaHoleDiameter?: number
   minViaPadDiameter?: number
-  subcircuitComponent?: Pick<ISubcircuit, "selectAll"> & {
+  subcircuitComponent?: Pick<ISubcircuit, "selectAll" | "getDescendants"> & {
     pcb_group_id?: PcbGroupId | null
   }
   /**
@@ -588,12 +588,13 @@ export const getSimpleRouteJsonFromCircuitJson = ({
   // eligible through an explicit current-scope net reference or exposed-net
   // contract.
   const sourceNetIds = new Set(source_nets.map((net) => net.source_net_id))
-  const currentSubcircuitSourceTraces = db.source_trace
-    .list()
-    .filter((trace) => !subcircuit_id || trace.subcircuit_id === subcircuit_id)
+  // Subcircuit creates exposed-net bridge traces with this explicit marker.
+  // A trace display name is user-facing and must not determine routing scope.
+  // selectAll("trace") does not descend into nested subcircuits, so walk
+  // descendants to also find bridge traces created at deeper levels.
   const exposedBridgeSourceTraceIds = new Set(
-    (subcircuitComponent?.selectAll("trace") ?? []).flatMap((trace) => {
-      const candidate = trace as {
+    (subcircuitComponent?.getDescendants() ?? []).flatMap((node) => {
+      const candidate = node as {
         source_trace_id?: string | null
         _exposesSubcircuitConnection?: boolean
       }
@@ -602,16 +603,34 @@ export const getSimpleRouteJsonFromCircuitJson = ({
         : []
     }),
   )
+  const exposedBridgeSourceTraces = db.source_trace
+    .list()
+    .filter((trace) => exposedBridgeSourceTraceIds.has(trace.source_trace_id))
   const exposedDescendantSourceNetIds = new Set<string>()
-  for (const trace of currentSubcircuitSourceTraces) {
-    // Subcircuit creates exposed-net bridge traces with this explicit marker.
-    // A trace display name is user-facing and must not determine routing scope.
-    if (!exposedBridgeSourceTraceIds.has(trace.source_trace_id)) {
-      continue
-    }
+  const exposedNetIdsToVisit: string[] = []
+  for (const trace of exposedBridgeSourceTraces) {
+    if (subcircuit_id && trace.subcircuit_id !== subcircuit_id) continue
     for (const sourceNetId of trace.connected_source_net_ids ?? []) {
       if (!sourceNetIds.has(sourceNetId)) {
         exposedDescendantSourceNetIds.add(sourceNetId)
+        exposedNetIdsToVisit.push(sourceNetId)
+      }
+    }
+  }
+  // A net exposed into the current scope may itself be the parent side of a
+  // deeper bridge. Follow the chain so two nested exposedNets levels stay
+  // reachable from the board (tscircuit/tscircuit#4162).
+  while (exposedNetIdsToVisit.length > 0) {
+    const exposedNetId = exposedNetIdsToVisit.pop()!
+    for (const trace of exposedBridgeSourceTraces) {
+      if (!(trace.connected_source_net_ids ?? []).includes(exposedNetId)) {
+        continue
+      }
+      for (const sourceNetId of trace.connected_source_net_ids ?? []) {
+        if (sourceNetIds.has(sourceNetId)) continue
+        if (exposedDescendantSourceNetIds.has(sourceNetId)) continue
+        exposedDescendantSourceNetIds.add(sourceNetId)
+        exposedNetIdsToVisit.push(sourceNetId)
       }
     }
   }

--- a/tests/subcircuits/subcircuit-nested-exposed-nets-autorouting.test.tsx
+++ b/tests/subcircuits/subcircuit-nested-exposed-nets-autorouting.test.tsx
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test"
+import type { Port } from "lib/components"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+const SourceLeaf = () => (
+  <subcircuit
+    name="SOURCE_LEAF"
+    width="2mm"
+    height="2mm"
+    autorouter="auto_local"
+    exposedNets={["SIGNAL"]}
+  >
+    <resistor name="R1" resistance="1k" footprint="0402" />
+    <trace from="R1.pin1" to="net.SIGNAL" />
+  </subcircuit>
+)
+
+const SourceBlock = () => (
+  <subcircuit
+    name="SOURCE_BLOCK"
+    pcbX={-3}
+    width="2mm"
+    height="2mm"
+    autorouter="auto_local"
+    exposedNets={["SIGNAL"]}
+  >
+    <SourceLeaf />
+  </subcircuit>
+)
+
+const SinkLeaf = () => (
+  <subcircuit
+    name="SINK_LEAF"
+    width="2mm"
+    height="2mm"
+    autorouter="auto_local"
+    exposedNets={["SIGNAL"]}
+  >
+    <resistor name="R2" resistance="1k" footprint="0402" />
+    <trace from="R2.pin1" to="net.SIGNAL" />
+  </subcircuit>
+)
+
+const SinkBlock = () => (
+  <subcircuit
+    name="SINK_BLOCK"
+    pcbX={3}
+    width="2mm"
+    height="2mm"
+    autorouter="auto_local"
+    exposedNets={["SIGNAL"]}
+  >
+    <SinkLeaf />
+  </subcircuit>
+)
+
+test("nets exposed through two nested subcircuit levels are routed with copper", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="12mm" height="6mm">
+      <SourceBlock />
+      <SinkBlock />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const errors = circuitJson.filter((el) => el.type.includes("error"))
+  expect(errors).toEqual([])
+
+  const r1Pin1 = circuit.selectOne(".R1 > .pin1", { type: "port" }) as Port
+  const r2Pin1 = circuit.selectOne(".R2 > .pin1", { type: "port" }) as Port
+  const r1PcbPortId = circuit.db.pcb_port.getWhere({
+    source_port_id: r1Pin1.source_port_id!,
+  })?.pcb_port_id
+  const r2PcbPortId = circuit.db.pcb_port.getWhere({
+    source_port_id: r2Pin1.source_port_id!,
+  })?.pcb_port_id
+  expect(r1PcbPortId).toBeDefined()
+  expect(r2PcbPortId).toBeDefined()
+
+  const pcbTraces = circuit.db.pcb_trace.list()
+  // Two nested exposedNets levels used to produce a valid netlist but zero
+  // parent-scope copper: bridge traces were only collected one hop deep.
+  expect(pcbTraces.length).toBeGreaterThan(0)
+
+  const connectedPcbPortIds = new Set(
+    pcbTraces.flatMap((trace) =>
+      trace.route.flatMap((point) => {
+        const ids: string[] = []
+        if ("start_pcb_port_id" in point && point.start_pcb_port_id) {
+          ids.push(point.start_pcb_port_id)
+        }
+        if ("end_pcb_port_id" in point && point.end_pcb_port_id) {
+          ids.push(point.end_pcb_port_id)
+        }
+        return ids
+      }),
+    ),
+  )
+
+  expect(connectedPcbPortIds.has(r1PcbPortId!)).toBe(true)
+  expect(connectedPcbPortIds.has(r2PcbPortId!)).toBe(true)
+})


### PR DESCRIPTION
## Summary

When a net is exposed through **two nested \`<subcircuit>\` levels**, the netlist is correct but the parent autorouter emits no copper. A single boundary works; wrapping each leaf in another subcircuit drops the connecting \`pcb_trace\` count to zero ([tscircuit/tscircuit#4162](https://github.com/tscircuit/tscircuit/issues/4162)).

Cause: parent-scope SRJ only collected exposed-net bridge traces via \`selectAll(\"trace\")\` (does not enter nested subcircuits) and only followed one hop of the exposed-net contract. The leaf pad traces therefore never became eligible \`pointsToConnect\`.

This walks \`getDescendants()\` for bridge traces marked \`_exposesSubcircuitConnection\`, then follows the bridge chain transitively so two nested \`exposedNets\` levels stay reachable.

## Test plan

- [x] \`bun test tests/subcircuits/subcircuit-nested-exposed-nets-autorouting.test.tsx\`
- [x] single-level \`exposedNets\` fixture still passes
- [x] parent autorouting still excludes private child nets
- [x] \`bunx tsc --noEmit\`