### PR TITLE
fix: export a require condition so CJS registry packages can load core

### DIFF
--- a/.github/workflows/smoke-test-dist.yml
+++ b/.github/workflows/smoke-test-dist.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Run smoke test script
         run: bun run smoke-test:dist
+
+      - name: Run CJS require smoke test
+        run: bun run smoke-test:cjs-require

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "module": "dist/index.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "measure-bundle": "howfat -r table .",
     "pkg-pr-new-release": "bunx pkg-pr-new publish --comment=off --peerDeps",
     "smoke-test:dist": "bun run scripts/smoke-tests/test-dist-simple-circuit.tsx",
+    "smoke-test:cjs-require": "bun run scripts/smoke-tests/test-dist-cjs-require.cjs",
     "build:benchmarking": "bun build --experimental-html ./benchmarking/website/index.html --outdir ./benchmarking-dist",
     "build:benchmarking:watch": "chokidar \"./{benchmarking,lib}/**/*.{ts,tsx}\" -c 'bun build --experimental-html ./benchmarking/website/index.html --outdir ./benchmarking-dist'",
     "start:benchmarking": "concurrently \"bun run build:benchmarking:watch\" \"live-server ./benchmarking-dist\"",

--- a/scripts/smoke-tests/test-dist-cjs-require.cjs
+++ b/scripts/smoke-tests/test-dist-cjs-require.cjs
@@ -1,0 +1,54 @@
+// Registry components published as CJS call require("@tscircuit/core").
+// Reproduce that from a fake package whose node_modules points at this repo.
+const { spawnSync } = require("node:child_process")
+const fs = require("node:fs")
+const os = require("node:os")
+const path = require("node:path")
+
+const coreRoot = path.resolve(__dirname, "../..")
+const distEntry = path.join(coreRoot, "dist", "index.js")
+
+if (!fs.existsSync(distEntry)) {
+  console.error(`Missing ${distEntry}. Run bun run build first.`)
+  process.exit(1)
+}
+
+const fake = fs.mkdtempSync(path.join(os.tmpdir(), "core-cjs-require-"))
+const coreLink = path.join(fake, "node_modules", "@tscircuit", "core")
+fs.mkdirSync(path.dirname(coreLink), { recursive: true })
+fs.symlinkSync(coreRoot, coreLink)
+fs.writeFileSync(
+  path.join(fake, "index.cjs"),
+  `
+    const core = require("@tscircuit/core")
+    const Circuit = core.RootCircuit || core.Circuit
+    if (typeof Circuit !== "function") {
+      console.error("RootCircuit missing after CJS require", Object.keys(core).slice(0, 30))
+      process.exit(1)
+    }
+    console.log("CJS require(@tscircuit/core) loaded RootCircuit")
+  `,
+)
+
+const runtimes = ["bun"]
+if (spawnSync("node", ["-v"], { encoding: "utf8" }).status === 0) {
+  runtimes.push("node")
+}
+
+let failed = false
+for (const runtime of runtimes) {
+  const result = spawnSync(runtime, ["index.cjs"], {
+    cwd: fake,
+    encoding: "utf8",
+  })
+  const output = `${result.stdout || ""}${result.stderr || ""}`.trim()
+  if (result.status !== 0) {
+    failed = true
+    console.error(`${runtime} require("@tscircuit/core") failed:\n${output}`)
+    continue
+  }
+  console.log(`${runtime}: ${output}`)
+}
+
+fs.rmSync(fake, { recursive: true, force: true })
+process.exit(failed ? 1 : 0)

--- a/tests/packaging/cjs-require-export.test.ts
+++ b/tests/packaging/cjs-require-export.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const packageJsonPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../package.json",
+)
+
+test("package exports include a require condition so CJS registry packages can load core", () => {
+  const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8"))
+
+  expect(pkg.exports["."].require).toBe("./dist/index.js")
+})


### PR DESCRIPTION
## Summary

Older tscircuit registry components ship CJS that starts with `require("@tscircuit/core")`. Core is ESM-only and its `exports` map had no `require` condition, so `tsci build` dies with `Cannot find module '@tscircuit/core'`.

Fixes tscircuit/cli#3982 (same as stale tscircuit/cli#1657).

This adds `"require": "./dist/index.js"` next to the existing ESM entry. Bun and Node both resolve and load `RootCircuit` through that path; no separate CJS bundle.

Not a CLI Bun plugin (that approach was tried in tscircuit/cli#3983 and closed). This is the packaging option named on the issue.

## Test plan

- [x] `bun test tests/packaging/cjs-require-export.test.ts`
- [x] `bun run build && bun run smoke-test:cjs-require` (Bun and Node both load `RootCircuit`)
- [x] smoke-test workflow now runs the CJS require check after dist build