### PR TITLE
fix: emit numeric pinheader schematic port_arrangement pins

### DIFF
--- a/lib/components/normal-components/PinHeader.ts
+++ b/lib/components/normal-components/PinHeader.ts
@@ -112,7 +112,7 @@ export class PinHeader extends NormalComponent<typeof pinHeaderProps> {
       "right"
     const schPinArrangement = this._parsedProps.schPinArrangement
 
-    const pins = Array.from({ length: pinCount }, (_, i) => `pin${i + 1}`)
+    const pins = Array.from({ length: pinCount }, (_, i) => i + 1)
 
     if (facingDirection === "left") {
       return {

--- a/tests/components/normal-components/pin-header-schematic-component-parses.test.tsx
+++ b/tests/components/normal-components/pin-header-schematic-component-parses.test.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { any_circuit_element, schematic_component } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("pinheader schematic port_arrangement emits numeric pins that parse", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <pinheader name="J1" pinCount={2} footprint="pinrow2" />
+    </board>,
+  )
+  await circuit.renderUntilSettled()
+
+  const sc = circuit
+    .getCircuitJson()
+    .find((e) => e.type === "schematic_component")
+
+  expect(sc).toBeDefined()
+  expect(
+    (sc as { port_arrangement?: { right_side?: { pins?: unknown } } })
+      .port_arrangement?.right_side?.pins,
+  ).toEqual([1, 2])
+  expect(schematic_component.safeParse(sc).success).toBe(true)
+  expect(any_circuit_element.safeParse(sc).success).toBe(true)
+})


### PR DESCRIPTION
## Summary

Fixes https://github.com/tscircuit/core/issues/3075 (previous PRs https://github.com/tscircuit/core/pull/3076 and https://github.com/tscircuit/core/pull/3257 went stale; no open competitor).

A default `<pinheader>` emits `schematic_component.port_arrangement.<side>.pins` as `["pin1", "pin2", ...]`. circuit-json's `schematic_component_port_arrangement_by_sides` schema requires `z.array(z.number())`, so `schematic_component.safeParse` and `any_circuit_element.safeParse` both fail.

`PinHeader._getSchematicPortArrangement()` now emits pin numbers (`[1, 2, ...]`) instead of label strings. Schematic box layout already resolves both forms through `parsePinNumberFromLabelsOrThrow`, so this only changes the emitted Circuit JSON, not the drawing.

User-supplied `schPinArrangement` is unchanged.

## Test plan

- [x] `bun test tests/components/normal-components/pin-header-schematic-component-parses.test.tsx` (red before: `["pin1","pin2"]`, green after: `[1, 2]` plus both parsers)
- [x] existing pinheader tests (`pin-header.test.tsx`, `pin-header-schPinArragement.test.tsx`, default-footprint)
- [x] `bunx tsc --noEmit`
- [x] `bunx biome format` on the changed TS files