### PR TITLE
Record interconnect internal connections on the source component

### DIFF
--- a/lib/components/normal-components/Interconnect.ts
+++ b/lib/components/normal-components/Interconnect.ts
@@ -1,7 +1,6 @@
 import { interconnectProps } from "@tscircuit/props"
 import type { Ftype } from "lib/utils/constants"
 import { NormalComponent } from "../base-components/NormalComponent/NormalComponent"
-import type { Port } from "../primitive-components/Port"
 
 const INTERCONNECT_STANDARD_FOOTPRINTS: Record<string, string> = {
   "0402": "0402",
@@ -53,30 +52,5 @@ export class Interconnect extends NormalComponent<typeof interconnectProps> {
     })
 
     this.source_component_id = source_component.source_component_id
-  }
-
-  /**
-   * After ports have their source_component_id assigned, create the
-   * source_component_internal_connection to indicate which pins are
-   * internally connected (for 0-ohm jumper behavior).
-   */
-  doInitialSourceParentAttachment(): void {
-    const { db } = this.root!
-
-    const internallyConnectedPorts = this._getInternallyConnectedPins()
-
-    for (const ports of internallyConnectedPorts) {
-      const sourcePortIds = ports
-        .map((port: Port) => port.source_port_id)
-        .filter((id): id is string => id !== null)
-
-      if (sourcePortIds.length >= 2) {
-        db.source_component_internal_connection.insert({
-          source_component_id: this.source_component_id!,
-          subcircuit_id: this.getSubcircuit()?.subcircuit_id!,
-          source_port_ids: sourcePortIds,
-        })
-      }
-    }
   }
 }

--- a/tests/components/normal-components/interconnect-internal-connection.test.tsx
+++ b/tests/components/normal-components/interconnect-internal-connection.test.tsx
@@ -22,4 +22,9 @@ test("interconnect with standard footprint should create source_component_intern
     source_component_id: expect.any(String),
     source_port_ids: expect.any(Array),
   })
+
+  const sourceComponent = circuit.db.source_component.getWhere({ name: "IC1" })
+  expect(sourceComponent?.internally_connected_source_port_ids).toEqual([
+    internalConnections[0].source_port_ids,
+  ])
 })


### PR DESCRIPTION
`Interconnect` overrides `doInitialSourceParentAttachment` with a copy of the `NormalComponent` implementation that is missing one block, the `db.source_component.update(..., { internally_connected_source_port_ids })` call. So an `<interconnect standard="0805" />` inserts its `source_component_internal_connection` rows but leaves `internally_connected_source_port_ids` undefined on the source component, while an equivalent `<chip internallyConnectedPins={[["pin1","pin2"]]} />` on the same board gets the field filled in. Anything reading connectivity off the source component rather than joining the internal-connection table sees the interconnect as two unconnected pins.

The override is otherwise identical to the base method, so this deletes it rather than patching it. `Interconnect.defaultInternallyConnectedPinNames` already feeds `_getInternallyConnectedPins`, which is what the base implementation reads. The now-unused `Port` import and the doc comment that described the removed method go with it.

The existing `interconnect-internal-connection` test already built the exact circuit needed, so the assertion is folded in there rather than added as a new file. Restoring the override makes it fail.

Validation: `bunx tsc --noEmit` and biome pass, and all 10 tests across the six interconnect-touching test files pass.
