### PR TITLE
chore: update capacity-autorouter to 0.0.890

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/bga-fanout-solver": "github:tscircuit/bga-fanout-solver#247c835cb8d69b65e53891dcf869731079415b39",
-    "@tscircuit/capacity-autorouter": "^0.0.887",
+    "@tscircuit/capacity-autorouter": "^0.0.890",
     "@tscircuit/checks": "^0.0.184",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
## Summary

- update `@tscircuit/capacity-autorouter` from 0.0.887 to 0.0.890
- pull in the Pipeline 9 explicit-via-endpoint fix and its follow-up formatting release
- supersede #3770, which targets the older 0.0.888 release

## Verification

- `bunx @tscircuit/dependency-check`
- `bunx @biomejs/biome format .`
- `bunx tsc --noEmit`
- `bun run build`
- Pipeline 9/latest-version, shared-capacitor handoff, and AM62L OSM fanout tests (5 passing)