### PR TITLE
fix: emit numeric henries for inductor in source_component

### DIFF
--- a/lib/components/normal-components/Inductor.ts
+++ b/lib/components/normal-components/Inductor.ts
@@ -1,13 +1,13 @@
 import { inductorProps } from "@tscircuit/props"
+import type { SourceSimpleInductor } from "circuit-json"
+import { formatSiUnit, parseAndConvertSiUnit } from "format-si-unit"
 import {
-  FTYPE,
   type BaseSymbolName,
+  FTYPE,
   type PassivePorts,
 } from "lib/utils/constants"
 import { NormalComponent } from "../base-components/NormalComponent/NormalComponent"
 import { Port } from "../primitive-components/Port"
-import { formatSiUnit, parseAndConvertSiUnit } from "format-si-unit"
-import type { SourceSimpleInductor } from "circuit-json"
 
 export class Inductor extends NormalComponent<
   typeof inductorProps,
@@ -44,7 +44,7 @@ export class Inductor extends NormalComponent<
     const source_component = db.source_component.insert({
       name: this.name,
       ftype: FTYPE.simple_inductor,
-      inductance: this.props.inductance,
+      inductance: props.inductance,
       max_current_rating:
         props.maxCurrentRating === undefined
           ? undefined

--- a/tests/components/normal-components/inductor-unit-strings.test.tsx
+++ b/tests/components/normal-components/inductor-unit-strings.test.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import type { SourceSimpleInductor } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("inductor parses unit strings into numeric henries in source_component", () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="30mm" height="20mm">
+      <inductor name="L1" inductance="10uH" />
+      <inductor name="L2" inductance="100nH" />
+      <inductor name="L3" inductance="5mH" />
+      <inductor name="L4" inductance={0.001} />
+    </board>,
+  )
+
+  circuit.render()
+
+  const l1 = circuit.db.source_component.getWhere({
+    name: "L1",
+  }) as SourceSimpleInductor
+  expect(typeof l1.inductance).toBe("number")
+  expect(l1.inductance).toBeCloseTo(1e-5, 8)
+  expect(l1.display_inductance).toBe("10µH")
+
+  const l2 = circuit.db.source_component.getWhere({
+    name: "L2",
+  }) as SourceSimpleInductor
+  expect(typeof l2.inductance).toBe("number")
+  expect(l2.inductance).toBeCloseTo(1e-7, 10)
+  expect(l2.display_inductance).toBe("100nH")
+
+  const l3 = circuit.db.source_component.getWhere({
+    name: "L3",
+  }) as SourceSimpleInductor
+  expect(typeof l3.inductance).toBe("number")
+  expect(l3.inductance).toBeCloseTo(0.005, 5)
+  expect(l3.display_inductance).toBe("5mH")
+
+  const l4 = circuit.db.source_component.getWhere({
+    name: "L4",
+  }) as SourceSimpleInductor
+  expect(typeof l4.inductance).toBe("number")
+  expect(l4.inductance).toBe(0.001)
+  expect(l4.display_inductance).toBe("1mH")
+})

--- a/tests/components/normal-components/inductor.test.tsx
+++ b/tests/components/normal-components/inductor.test.tsx
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { getTestFixture } from "tests/fixtures/get-test-fixture"
 
 test("<inductor /> component", async () => {
@@ -21,7 +21,7 @@ test("<inductor /> component", async () => {
 
   expect(circuit.db.source_component.getWhere({ name: "U1" })).toMatchObject({
     ftype: "simple_inductor",
-    inductance: "10",
+    inductance: 10,
     max_current_rating: 2,
   })
 


### PR DESCRIPTION
Fixes #3111

## Problem
In `Inductor.ts`, `doInitialSourceRender()` inserted `inductance: this.props.inductance` into `db.source_component` instead of `props.inductance` from `this._parsedProps`. As a result, when an inductor was declared with a unit string like `inductance="10uH"`, the raw string reached Circuit JSON rather than a numeric henry value, violating the `SourceSimpleInductor` schema.

## Solution
1. In `lib/components/normal-components/Inductor.ts`, updated `inductance: props.inductance` in `db.source_component.insert()` so the parsed numeric value (e.g. `0.00001` for `10uH`) is stored.
2. Updated `tests/components/normal-components/inductor.test.tsx` expectation from string `"10"` to numeric `10`.
3. Added `tests/components/normal-components/inductor-unit-strings.test.tsx` verifying that unit strings (`10uH`, `100nH`, `5mH`) and numeric inputs evaluate to numbers in `source_component` and format properly in `display_inductance`.
