### PR TITLE
Update @tscircuit/checks to 0.0.188

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/bga-fanout-solver": "github:tscircuit/bga-fanout-solver#247c835cb8d69b65e53891dcf869731079415b39",
     "@tscircuit/capacity-autorouter": "^0.0.892",
-    "@tscircuit/checks": "^0.0.187",
+    "@tscircuit/checks": "^0.0.188",
     "@tscircuit/circuit-json-util": "^0.0.113",
     "@tscircuit/common": "^0.0.20",
     "@tscircuit/copper-pour-solver": "^0.0.54",


### PR DESCRIPTION
Update `@tscircuit/checks` from `^0.0.187` to `^0.0.188` to pick up the corrected pad/trace, via/trace and via/pad clearance marker locations from tscircuit/checks#276 and tscircuit/checks#277. The automatic release update in #3806 resolved the previous version before npm metadata caught up.

Validation:
- Installed the published `0.0.188` package and verified all 11 corrected Game Boy Advance clearance errors exactly match the fix's output.
- `bun run build` and `bunx tsc --noEmit` pass.
- Focused DRC/platform/subcircuit tests: 23 pass, 1 existing failure. `pcb-plated-hole-overlap.test.tsx` expects 14 overlap errors but receives 30; rerunning with `0.0.187` reproduces the same failure. Its expectation/snapshot update is already covered by #3800.
