### PR TITLE
Fix plated-hole overlap test after courtyard checks update

### DIFF
--- a/tests/drc/pcb-plated-hole-overlap.test.tsx
+++ b/tests/drc/pcb-plated-hole-overlap.test.tsx
@@ -30,10 +30,10 @@ test("design rule check detects overlapping plated holes", async () => {
   const platedHoles = circuitJson.filter((el) => el.type === "pcb_plated_hole")
   expect(platedHoles.length).toBe(16)
 
-  // Check for footprint overlap errors
-  const overlapErrors = circuitJson.filter(
-    (el) => el.type === "pcb_footprint_overlap_error",
-  )
+  // Count hole-to-hole overlaps only; courtyard overlaps share this error type.
+  const overlapErrors = circuitJson
+    .filter((el) => el.type === "pcb_footprint_overlap_error")
+    .filter((el) => el.pcb_plated_hole_ids?.length === 2)
 
   expect(overlapErrors.length).toBe(14)
   expect(overlapErrors[0]).toHaveProperty("message")
@@ -42,7 +42,13 @@ test("design rule check detects overlapping plated holes", async () => {
   // Verify error contains plated hole IDs
   expect(overlapErrors[0]).toHaveProperty("pcb_plated_hole_ids")
 
-  expect(circuit).toMatchPcbSnapshot(import.meta.path, {
+  // Keep the visual regression focused on the same hole pairs as the assertions.
+  const filteredJson = circuitJson.filter(
+    (el) =>
+      el.type !== "pcb_footprint_overlap_error" ||
+      el.pcb_plated_hole_ids?.length === 2,
+  )
+  expect(filteredJson).toMatchPcbSnapshot(import.meta.path, {
     shouldDrawErrors: true,
   })
 })


### PR DESCRIPTION
Fix the plated-hole overlap regression that failed on core #3804. `@tscircuit/checks@0.0.187` reports 16 additional plated-hole/courtyard overlaps using `pcb_footprint_overlap_error`, so counting every error of that type returns 30 rather than the expected 14 hole pairs.

Scope both the count and the error visualization to overlaps containing two plated-hole IDs. The original expectation of 14 hole-to-hole overlaps and the existing PCB snapshot remain unchanged. No production DRC behavior or dependencies change.

Validation: reproduced the original 30-vs-14 failure with checks 0.0.187; all 18 DRC tests pass, including the unchanged snapshot; formatting and TypeScript checks pass.
