### PR TITLE
test(utils): add 45-degree diagonal angle tie-break resolution specs

### DIFF
--- a/tests/utils/get-relative-direction.test.ts
+++ b/tests/utils/get-relative-direction.test.ts
@@ -30,4 +30,11 @@ describe("getRelativeDirection", () => {
     expect(getRelativeDirection({ x: 2, y: -4 }, { x: 3, y: 1 })).toBe("up")
     expect(getRelativeDirection({ x: 8, y: 6 }, { x: 9, y: 1 })).toBe("down")
   })
+
+  test("resolves exactly 45-degree diagonal angles using vertical tie-break rule", () => {
+    expect(getRelativeDirection({ x: 0, y: 0 }, { x: 5, y: 5 })).toBe("up")
+    expect(getRelativeDirection({ x: 0, y: 0 }, { x: -5, y: 5 })).toBe("up")
+    expect(getRelativeDirection({ x: 0, y: 0 }, { x: 5, y: -5 })).toBe("down")
+    expect(getRelativeDirection({ x: 0, y: 0 }, { x: -5, y: -5 })).toBe("down")
+  })
 })


### PR DESCRIPTION
### Summary
- Extends test coverage for `getRelativeDirection` when resolving exactly 45-degree diagonal angles (`|dx| == |dy|`).
- Verifies that implementation prioritizes vertical dominance (`up`/`down`) under equal component deltas.

### Testing
- Validates 45-degree quadrant diagonals across positive and negative coordinate quadrants.