### PR TITLE
test(utils): add scale-translate determinant preservation specs

### DIFF
--- a/tests/day3-w05-scale-translate-determinant.test.ts
+++ b/tests/day3-w05-scale-translate-determinant.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "bun:test"
+import { compose, scale, translate, inverse, applyToPoint } from "transformation-matrix"
+
+test("utils - matrix scale and translate determinant preservation across inversion", () => {
+  const m = compose(scale(0.5, 0.5), translate(-10, 40))
+  const inv = inverse(m)
+  const p = { x: 30, y: 70 }
+  const forward = applyToPoint(m, p)
+  const restored = applyToPoint(inv, forward)
+
+  expect(restored.x).toBeCloseTo(p.x)
+  expect(restored.y).toBeCloseTo(p.y)
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for scale-translate inverse transform stability and point reconciliation.\n\n### Testing\n- Tested with bun test.