### PR TITLE
test(utils): add 2D skew-scale matrix inverse reconciliation specs

### DIFF
--- a/tests/day3-w07-skew-scale-inverse.test.ts
+++ b/tests/day3-w07-skew-scale-inverse.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "bun:test"
+import { compose, scale, skewDEG, inverse, applyToPoint } from "transformation-matrix"
+
+test("utils - 2D skew-scale matrix inverse reconciliation", () => {
+  const m = compose(scale(1.5, 0.8), skewDEG(15, 0))
+  const inv = inverse(m)
+  const p = { x: 25, y: -40 }
+  const forward = applyToPoint(m, p)
+  const restored = applyToPoint(inv, forward)
+
+  expect(restored.x).toBeCloseTo(p.x)
+  expect(restored.y).toBeCloseTo(p.y)
+})


### PR DESCRIPTION
### Summary\n- Adds test coverage for combined skew and scale affine transformations and point restoration.\n\n### Testing\n- Tested with bun test.