### PR TITLE
test(utils): add transformation matrix determinant non-zero inversion specs

### DIFF
--- a/tests/day3-w10-determinant-validation.test.ts
+++ b/tests/day3-w10-determinant-validation.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "bun:test"
+import { compose, scale, rotateDEG, inverse, applyToPoint } from "transformation-matrix"
+
+test("utils - transformation matrix determinant non-zero singular point inversion", () => {
+  const m = compose(scale(3, -2), rotateDEG(90))
+  const inv = inverse(m)
+  const p = { x: -14, y: 28 }
+  const forward = applyToPoint(m, p)
+  const restored = applyToPoint(inv, forward)
+
+  expect(restored.x).toBeCloseTo(p.x)
+  expect(restored.y).toBeCloseTo(p.y)
+})


### PR DESCRIPTION
### Summary\n- Adds test verification for non-singular matrix determinant inversion and coordinate reconciliation.\n\n### Testing\n- Tested with bun test.