### PR TITLE
test(utils): add 360-degree rotation matrix identity loop specs

### DIFF
--- a/tests/day3-w11-rotation-identity.test.ts
+++ b/tests/day3-w11-rotation-identity.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "bun:test"
+import { compose, rotateDEG, identity, applyToPoint } from "transformation-matrix"
+
+test("utils - 360-degree rotation matrix identity loop reconciliation", () => {
+  const fullTurn = rotateDEG(360)
+  const fourQuarterTurns = compose(rotateDEG(90), rotateDEG(90), rotateDEG(90), rotateDEG(90))
+  const p = { x: 42.5, y: -88.1 }
+
+  const ptTurn = applyToPoint(fullTurn, p)
+  const ptQuarters = applyToPoint(fourQuarterTurns, p)
+
+  expect(ptTurn.x).toBeCloseTo(p.x)
+  expect(ptTurn.y).toBeCloseTo(p.y)
+  expect(ptQuarters.x).toBeCloseTo(p.x)
+  expect(ptQuarters.y).toBeCloseTo(p.y)
+})


### PR DESCRIPTION
### Summary\n- Adds test verification for circular rotational closure and identity preservation across full turn matrices.\n\n### Testing\n- Tested with bun test.