### PR TITLE
test(utils): add scaling determinant preservation under translation specs

### DIFF
--- a/tests/day3-w16-scaling-determinant.test.ts
+++ b/tests/day3-w16-scaling-determinant.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "bun:test"
+import { compose, scale, translate, inverse, applyToPoint } from "transformation-matrix"
+
+test("utils - scaling determinant preservation under translational coordinate displacement", () => {
+  const m = compose(scale(4, 4), translate(100, -200))
+  const inv = inverse(m)
+  const p = { x: 50, y: 75 }
+  const forward = applyToPoint(m, p)
+  const restored = applyToPoint(inv, forward)
+
+  expect(restored.x).toBeCloseTo(p.x)
+  expect(restored.y).toBeCloseTo(p.y)
+})


### PR DESCRIPTION
### Summary\n- Adds test verification for composite 4x scaling with large translational coordinate displacement.\n\n### Testing\n- Tested with bun test.