### PR TITLE
Update autorouter to v0.0.900

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tsci/tscircuit.ti": "github:tscircuit/ti#57e314be4b2b06bc546d4def7453e619604d1157",
     "@tscircuit/alphabet": "0.0.25",
     "@tscircuit/bga-fanout-solver": "github:tscircuit/bga-fanout-solver#247c835cb8d69b65e53891dcf869731079415b39",
-    "@tscircuit/capacity-autorouter": "^0.0.899",
+    "@tscircuit/capacity-autorouter": "^0.0.900",
     "@tscircuit/checks": "^0.0.189",
     "@tscircuit/circuit-json-util": "^0.0.113",
     "@tscircuit/common": "^0.0.20",


### PR DESCRIPTION
Updates `@tscircuit/capacity-autorouter` from `^0.0.899` to `^0.0.900`, which contains tscircuit/tscircuit-autorouter#2506.\n\nValidation:\n- `BUN_UPDATE_SNAPSHOTS=1 bun test` (no snapshot changes)\n- `bunx tsc --noEmit`\n- `bun run build`\n- `git diff --check`