### PR TITLE
fix: async-loaded footprint pads missing pcb_port_id

### DIFF
--- a/lib/components/primitive-components/Port/Port.ts
+++ b/lib/components/primitive-components/Port/Port.ts
@@ -301,6 +301,16 @@ export class Port extends PrimitiveComponent<typeof portProps> {
    */
   registerMatch(component: PrimitiveComponent) {
     this.matchedComponents.push(component)
+    // If this port already rendered without any matched pcb primitives
+    // (e.g. the primitives were added later by an async footprint load),
+    // mark PcbPortRender dirty so updatePcbPortRender retries now that a
+    // match exists.
+    if (
+      component.isPcbPrimitive &&
+      this.renderPhaseStates.PcbPortRender?.initialized
+    ) {
+      this._markDirty("PcbPortRender")
+    }
   }
   getNameAndAliases() {
     const { _parsedProps: props } = this

--- a/tests/footprint/footprint-kicad-mod-async-pads-port-attachment.test.tsx
+++ b/tests/footprint/footprint-kicad-mod-async-pads-port-attachment.test.tsx
@@ -52,7 +52,7 @@ it("assigns pcb_port_id to pads from an async-loaded .kicad_mod footprint (issue
   const r1 = circuit.selectOne("resistor.R1")
   const r1PcbComponentId = r1?.pcb_component_id
   const r1Pads = circuitJson.filter(
-    (e: any) =>
+    (e): e is Extract<typeof e, { type: "pcb_smtpad" }> =>
       e.type === "pcb_smtpad" && e.pcb_component_id === r1PcbComponentId,
   )
 

--- a/tests/footprint/footprint-kicad-mod-async-pads-port-attachment.test.tsx
+++ b/tests/footprint/footprint-kicad-mod-async-pads-port-attachment.test.tsx
@@ -1,0 +1,64 @@
+import { expect, it } from "bun:test"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+import { KicadFootprintToCircuitJsonConverter } from "kicad-to-circuit-json"
+
+const twoPadKicadMod = `(footprint "TwoPad"
+ (version 20240108)
+ (generator "pcbnew")
+ (layer "F.Cu")
+ (attr smd)
+ (fp_text reference "REF**" (at 0 -2) (layer "F.SilkS") (effects (font (size 1 1) (thickness 0.15))))
+ (pad "1" smd rect (at -0.8 0) (size 0.9 1) (layers "F.Cu" "F.Paste" "F.Mask"))
+ (pad "2" smd rect (at 0.8 0) (size 0.9 1) (layers "F.Cu" "F.Paste" "F.Mask"))
+)`
+
+it("assigns pcb_port_id to pads from an async-loaded .kicad_mod footprint (issue #3887)", async () => {
+  const { circuit } = getTestFixture({
+    platform: {
+      footprintFileParserMap: {
+        kicad_mod: {
+          loadFromUrl: async (_url: string) => {
+            const converter = new KicadFootprintToCircuitJsonConverter()
+            converter.addFile("two-pad.kicad_mod", twoPadKicadMod)
+            converter.runUntilFinished()
+            return {
+              footprintCircuitJson: converter.getOutput(),
+            }
+          },
+        },
+      },
+    },
+  })
+
+  circuit.add(
+    <board width="12mm" height="8mm">
+      <resistor
+        name="R1"
+        resistance="1k"
+        footprint="./two-pad.kicad_mod"
+        pcbX={-3}
+        schX={-2}
+      />
+      <resistor name="R2" resistance="1k" footprint="0603" pcbX={3} schX={2} />
+      <trace from="R1.pin2" to="R2.pin1" />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const circuitJson = circuit.getCircuitJson()
+  const errors = circuitJson.filter((e: any) => e.type.includes("error"))
+
+  const r1 = circuit.selectOne("resistor.R1")
+  const r1PcbComponentId = r1?.pcb_component_id
+  const r1Pads = circuitJson.filter(
+    (e: any) =>
+      e.type === "pcb_smtpad" && e.pcb_component_id === r1PcbComponentId,
+  )
+
+  expect(r1Pads.length).toBe(2)
+  for (const pad of r1Pads) {
+    expect(pad.pcb_port_id).toBeTruthy()
+  }
+  expect(errors).toEqual([])
+})


### PR DESCRIPTION
Fixes #3887.

## Problem
A component using an async-loaded `footprint="./file.kicad_mod"` produced visible SMT pads whose `pcb_port_id` stayed `null`, so autorouting crashed dereferencing `connectedPort.x` and the trace was never emitted.

## Root cause
`Port.doInitialPcbPortRender` early-returns when the port has no matched pcb primitives. With async footprint loading, `PcbPortRender` runs before the `.kicad_mod` finishes loading, so the port renders nothing. When the footprint pads are later added and matched during `PortMatching`, nothing re-triggers the port's pcb render, so `pcb_port_id` remains `null` and the pad's `PcbPortAttachment` writes `null`.

## Fix
`Port.registerMatch` now marks `PcbPortRender` dirty when a pcb primitive matches after that phase already initialized. The existing `updatePcbPortRender` retry path (which is a no-op when `pcb_port_id` is already set) then creates the pcb port, and pad attachment picks up the id in the same render cycle.

## Test
New regression test `footprint-kicad-mod-async-pads-port-attachment.test.tsx` reproduces the issue exactly (two-pad `.kicad_mod` loaded through the platform `footprintFileParserMap`, trace to a builtin 0603) and asserts both imported pads get a `pcb_port_id` with zero circuit errors. Fails before the fix, passes after. `tests/footprint` (27 files) all pass.
