### PR TITLE
chore: update circuit-to-svg to 0.0.416 for schematic text fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "circuit-json-to-connectivity-map": "^0.0.30",
     "circuit-json-to-gltf": "^0.0.124",
     "circuit-json-to-spice": "^0.0.45",
-    "circuit-to-svg": "^0.0.413",
+    "circuit-to-svg": "^0.0.416",
     "concurrently": "^9.1.2",
     "connectivity-map": "^1.0.0",
     "debug": "^4.3.6",


### PR DESCRIPTION
Core uses `circuit-to-svg` for `circuit.getSvg()` and schematic/PCB snapshot rendering. The current `^0.0.413` dependency excludes the newer 0.0.x releases, so core does not pick up fixes for missing component-associated labels and active-low text formatting.

Update the development dependency to `^0.0.416` to include:
- [tscircuit/circuit-to-svg#740](https://github.com/tscircuit/circuit-to-svg/pull/740): render external schematic text associated with custom components. Previously these labels could disappear unless callers removed their component association; the fix preserves their position and styling.
- [tscircuit/circuit-to-svg#708](https://github.com/tscircuit/circuit-to-svg/pull/708): render structured active-low overlines on pin labels and schematic text, preserving partial-label formatting from Circuit JSON.

This is a dependency-only update. No lockfile is committed because this repository disables lockfile saving.

Validation: the schematic-text, repro99 custom-symbol, and repro129 custom-symbol/passives tests passed (3 tests, 8 assertions); `git diff --check` passed. The repro129 test logged an asynchronous autorouting error involving `connectedPort.x` while still passing its schematic assertions. The full test suite was not run.
