### PR TITLE
Emit per-side via tenting fields

### DIFF
--- a/lib/components/primitive-components/PcbVia.ts
+++ b/lib/components/primitive-components/PcbVia.ts
@@ -11,7 +11,10 @@ import { PrimitiveComponent } from "../base-components/PrimitiveComponent"
 export const pcbViaProps = viaProps
   .extend({
     layers: z.array(layer_ref).optional(),
+    /** @deprecated Use tentedOnTop and tentedOnBottom instead. */
     isTented: z.boolean().optional(),
+    tentedOnTop: z.boolean().optional(),
+    tentedOnBottom: z.boolean().optional(),
   })
   .partial({
     fromLayer: true,
@@ -20,7 +23,10 @@ export const pcbViaProps = viaProps
 
 export interface PcbViaProps extends Partial<ViaProps> {
   layers?: LayerRef[]
+  /** @deprecated Use tentedOnTop and tentedOnBottom instead. */
   isTented?: boolean
+  tentedOnTop?: boolean
+  tentedOnBottom?: boolean
 }
 
 export class PcbVia extends PrimitiveComponent<typeof pcbViaProps> {
@@ -94,11 +100,17 @@ export class PcbVia extends PrimitiveComponent<typeof pcbViaProps> {
   doInitialPcbPrimitiveRender(): void {
     if (this.root?.pcbDisabled) return
     const { db } = this.root!
-    const { holeDiameter, outerDiameter, netIsAssignable, isTented } =
-      this._parsedProps
+    const {
+      holeDiameter,
+      outerDiameter,
+      netIsAssignable,
+      isTented,
+      tentedOnTop,
+      tentedOnBottom,
+    } = this._parsedProps
     const subcircuit = this.getSubcircuit()
     const position = this._getGlobalPcbPositionBeforeLayout()
-    const { maybeFlipLayer } = this._getPcbPrimitiveFlippedHelpers()
+    const { isFlipped, maybeFlipLayer } = this._getPcbPrimitiveFlippedHelpers()
     const layers = this._getLayers().map((layer) =>
       maybeFlipLayer(layer),
     ) as LayerRef[]
@@ -121,7 +133,9 @@ export class PcbVia extends PrimitiveComponent<typeof pcbViaProps> {
       subcircuit_id: subcircuit?.subcircuit_id ?? undefined,
       pcb_group_id: this.getGroup()?.pcb_group_id ?? undefined,
       net_is_assignable: netIsAssignable,
-      is_tented: isTented,
+      // Use the same footprint flip as the via layers above.
+      tented_on_top: (isFlipped ? tentedOnBottom : tentedOnTop) ?? isTented,
+      tented_on_bottom: (isFlipped ? tentedOnTop : tentedOnBottom) ?? isTented,
     } as Omit<CircuitJsonPcbVia, "type" | "pcb_via_id">)
 
     this.pcb_via_id = pcbVia.pcb_via_id

--- a/lib/components/primitive-components/Trace/Trace_doInitialPcbManualTraceRender.ts
+++ b/lib/components/primitive-components/Trace/Trace_doInitialPcbManualTraceRender.ts
@@ -1,4 +1,9 @@
-import type { LayerRef, PcbTraceRoutePoint, PcbVia } from "circuit-json"
+import {
+  pcb_via,
+  type LayerRef,
+  type PcbTraceRoutePoint,
+  type PcbVia,
+} from "circuit-json"
 import { getTraceLength } from "./trace-utils/compute-trace-length"
 import type { Port } from "../Port"
 import type { Trace } from "./Trace"
@@ -121,7 +126,7 @@ export function Trace_doInitialPcbManualTraceRender(trace: Trace) {
     jlcMinTolerances.min_trace_width!
 
   if (inflatedPcbTraces.length > 0) {
-    const { maybeFlipLayer } = trace._getPcbPrimitiveFlippedHelpers()
+    const { isFlipped, maybeFlipLayer } = trace._getPcbPrimitiveFlippedHelpers()
     const transform = trace._computePcbGlobalTransformBeforeLayout()
     const insertedRoutes: PcbTraceRoutePoint[][] = []
     const subcircuitConnectivityMapKey =
@@ -174,10 +179,13 @@ export function Trace_doInitialPcbManualTraceRender(trace: Trace) {
         const point = transformedRoute[index]
         if (point.route_type === "via") {
           const originalPoint = inflatedPcbTrace.route[index]
-          const inflatedPcbVia = findInflatedPcbViaForPoint(
+          const originalPcbVia = findInflatedPcbViaForPoint(
             trace._inflatedPcbVias,
             originalPoint,
           )
+          const inflatedPcbVia = originalPcbVia
+            ? pcb_via.parse(originalPcbVia)
+            : undefined
           const routePointViaDiameter = getViaDiameterFromRoutePoint(point)
           const fromLayer = maybeFlipLayer(
             (inflatedPcbVia?.from_layer ?? point.from_layer) as LayerRef,
@@ -216,7 +224,13 @@ export function Trace_doInitialPcbManualTraceRender(trace: Trace) {
               subcircuitConnectivityMapKey,
             net_is_assignable: inflatedPcbVia?.net_is_assignable,
             net_assigned: inflatedPcbVia?.net_assigned,
-            is_tented: inflatedPcbVia?.is_tented,
+            // Use the same footprint flip as the route and via layers above.
+            tented_on_top: isFlipped
+              ? inflatedPcbVia?.tented_on_bottom
+              : inflatedPcbVia?.tented_on_top,
+            tented_on_bottom: isFlipped
+              ? inflatedPcbVia?.tented_on_top
+              : inflatedPcbVia?.tented_on_bottom,
           })
         }
       }

--- a/lib/utils/createComponentsFromCircuitJson.ts
+++ b/lib/utils/createComponentsFromCircuitJson.ts
@@ -1,6 +1,10 @@
 import { getUnitVectorFromDirection } from "@tscircuit/math-utils"
 import type { PinLabelsProp } from "@tscircuit/props"
-import type { AnyCircuitElement, SchematicComponent } from "circuit-json"
+import {
+  pcb_via,
+  type AnyCircuitElement,
+  type SchematicComponent,
+} from "circuit-json"
 import { CopperText } from "lib/components/primitive-components/CopperText"
 import { CourtyardCircle } from "lib/components/primitive-components/CourtyardCircle"
 import { CourtyardOutline } from "lib/components/primitive-components/CourtyardOutline"
@@ -600,6 +604,7 @@ export const createComponentsFromCircuitJson = (
         }),
       )
     } else if (elm.type === "pcb_via") {
+      const via = pcb_via.parse(elm)
       const layers = elm.layers ?? []
       const pcbVia = new PcbVia({
         pcbX: elm.x,
@@ -610,7 +615,8 @@ export const createComponentsFromCircuitJson = (
         toLayer: elm.to_layer ?? layers[layers.length - 1],
         layers,
         netIsAssignable: elm.net_is_assignable,
-        isTented: elm.is_tented,
+        tentedOnTop: via.tented_on_top,
+        tentedOnBottom: via.tented_on_bottom,
       })
       pcbVia._importedPcbTraceId = elm.pcb_trace_id
       components.push(pcbVia)

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.20",
-    "@tscircuit/props": "^0.0.649",
+    "@tscircuit/props": "^0.0.653",
     "@tscircuit/schematic-match-adapt": "^0.0.18",
     "@tscircuit/schematic-trace-solver": "^0.0.191",
     "@tscircuit/solver-utils": "^0.0.16",
@@ -110,7 +110,7 @@
     "circuit-json-to-bpc": "*",
     "bpc-graph": "*",
     "@tscircuit/matchpack": "*",
-    "circuit-json": "^0.0.487",
+    "circuit-json": "*",
     "circuit-json-to-connectivity-map": "*",
     "circuit-json-to-spice": "*",
     "schematic-symbols": "*",
@@ -133,7 +133,7 @@
   },
   "overrides": {
     "@tscircuit/circuit-json-util": "^0.0.113",
-    "@tscircuit/props": "^0.0.649",
+    "@tscircuit/props": "^0.0.653",
     "circuit-json": "^0.0.487"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "bun-match-svg": "0.0.12",
     "calculate-elbow": "^0.0.12",
     "chokidar-cli": "^3.0.0",
-    "circuit-json": "^0.0.484",
+    "circuit-json": "^0.0.487",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.30",
     "circuit-json-to-gltf": "^0.0.124",
@@ -110,7 +110,7 @@
     "circuit-json-to-bpc": "*",
     "bpc-graph": "*",
     "@tscircuit/matchpack": "*",
-    "circuit-json": "*",
+    "circuit-json": "^0.0.487",
     "circuit-json-to-connectivity-map": "*",
     "circuit-json-to-spice": "*",
     "schematic-symbols": "*",
@@ -134,6 +134,6 @@
   "overrides": {
     "@tscircuit/circuit-json-util": "^0.0.113",
     "@tscircuit/props": "^0.0.649",
-    "circuit-json": "^0.0.484"
+    "circuit-json": "^0.0.487"
   }
 }

--- a/tests/components/primitive-components/pcb-via-tenting.test.tsx
+++ b/tests/components/primitive-components/pcb-via-tenting.test.tsx
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import { Footprint } from "lib/components/primitive-components/Footprint"
+import { PcbVia } from "lib/components/primitive-components/PcbVia"
+import { createComponentsFromCircuitJson } from "lib/utils/createComponentsFromCircuitJson"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("PCB vias emit per-side tenting and migrate legacy imports across footprint flips", () => {
+  for (const layer of ["top", "bottom"] as const) {
+    for (const rotation of [0, 90, 180, 270]) {
+      for (const legacy of [undefined, false, true]) {
+        for (const top of [undefined, false, true]) {
+          for (const bottom of [undefined, false, true]) {
+            const { circuit } = getTestFixture()
+            const footprint = new Footprint({})
+            const directVia = new PcbVia({
+              pcbX: -1,
+              layers: ["top", "bottom"],
+              isTented: legacy,
+              tentedOnTop: top,
+              tentedOnBottom: bottom,
+            })
+            footprint.add(directVia)
+            footprint.add(
+              createComponentsFromCircuitJson(
+                { componentName: "U1", componentRotation: "0" },
+                [
+                  {
+                    type: "pcb_via",
+                    pcb_via_id: "imported_via",
+                    x: 1,
+                    y: 0,
+                    hole_diameter: 0.3,
+                    outer_diameter: 0.6,
+                    layers: ["top", "bottom"],
+                    ...{ is_tented: legacy },
+                    tented_on_top: top,
+                    tented_on_bottom: bottom,
+                  },
+                ],
+              )[0],
+            )
+            circuit.add(
+              <board width={10} height={10}>
+                <chip
+                  name="U1"
+                  layer={layer}
+                  pcbRotation={rotation}
+                  footprint={footprint as any}
+                />
+              </board>,
+            )
+            circuit.render()
+            const vias = circuit.db.pcb_via.list()
+            expect(vias).toHaveLength(2)
+            for (const via of vias) {
+              expect({
+                top: via.tented_on_top,
+                bottom: via.tented_on_bottom,
+              }).toEqual({
+                top: (layer === "bottom" ? bottom : top) ?? legacy,
+                bottom: (layer === "bottom" ? top : bottom) ?? legacy,
+              })
+              expect(via).not.toHaveProperty("is_tented")
+            }
+            expect(directVia._parsedProps.tentedOnTop).toEqual(top)
+            expect(directVia._parsedProps.tentedOnBottom).toEqual(bottom)
+          }
+        }
+      }
+    }
+  }
+})

--- a/tests/subcircuits/subcircuit-circuit-json-pcb-trace-via-tenting.test.tsx
+++ b/tests/subcircuits/subcircuit-circuit-json-pcb-trace-via-tenting.test.tsx
@@ -1,0 +1,79 @@
+import { expect, test } from "bun:test"
+import type { CircuitJson, PcbVia } from "circuit-json"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+test("subcircuit circuitJson inflation preserves per-side tenting for routed trace vias", async () => {
+  const { circuit: sourceCircuit } = getTestFixture()
+
+  sourceCircuit.add(
+    <board
+      width="12mm"
+      height="8mm"
+      pcbStyle={{ viaHoleDiameter: 0.45, viaPadDiameter: 0.9 }}
+    >
+      <resistor
+        name="R1"
+        resistance="1k"
+        footprint="0402"
+        pcbX="-3mm"
+        pcbY="0mm"
+      />
+      <resistor
+        name="R2"
+        resistance="1k"
+        footprint="0402"
+        pcbX="3mm"
+        pcbY="0mm"
+      />
+      <trace
+        from=".R1 > .pin1"
+        to=".R2 > .pin1"
+        pcbPath={[
+          { x: 0, y: 0, via: true, fromLayer: "top", toLayer: "bottom" },
+        ]}
+      />
+    </board>,
+  )
+
+  await sourceCircuit.renderUntilSettled()
+
+  const sourceJson = sourceCircuit.getCircuitJson()
+  const sourceVia = sourceJson.find((elm) => elm.type === "pcb_via") as PcbVia
+  expect(sourceVia).toBeDefined()
+  expect(sourceVia.hole_diameter).toBe(0.45)
+  expect(sourceVia.outer_diameter).toBe(0.9)
+
+  for (const tenting of [
+    { tented_on_top: true, tented_on_bottom: false },
+    { is_tented: true, tented_on_bottom: false },
+    { is_tented: false, tented_on_top: true },
+  ]) {
+    delete sourceVia.tented_on_top
+    delete sourceVia.tented_on_bottom
+    Object.assign(sourceVia, tenting)
+
+    const { circuit: targetCircuit } = getTestFixture()
+    targetCircuit.add(
+      <board width="20mm" height="20mm">
+        <subcircuit name="Inflated" circuitJson={sourceJson as CircuitJson} />
+      </board>,
+    )
+
+    await targetCircuit.renderUntilSettled()
+
+    const targetJson = targetCircuit.getCircuitJson()
+    const targetVias = targetJson.filter(
+      (elm) => elm.type === "pcb_via",
+    ) as PcbVia[]
+
+    expect(targetVias).toHaveLength(1)
+    expect(targetVias[0].hole_diameter).toBe(0.45)
+    expect(targetVias[0].outer_diameter).toBe(0.9)
+    expect(targetVias[0].from_layer).toBe("top")
+    expect(targetVias[0].to_layer).toBe("bottom")
+    expect(targetVias[0].pcb_trace_id).toBeDefined()
+    expect(targetVias[0].tented_on_top).toBe(true)
+    expect(targetVias[0].tented_on_bottom).toBe(false)
+    expect(targetVias[0]).not.toHaveProperty("is_tented")
+  }
+})

--- a/tests/utils/createComponentsFromCircuitJson/pcb-via.test.tsx
+++ b/tests/utils/createComponentsFromCircuitJson/pcb-via.test.tsx
@@ -22,7 +22,8 @@ test("createComponentsFromCircuitJson handles pcb_via elements", () => {
         layers: ["top", "inner1"],
         net_is_assignable: true,
         net_assigned: true,
-        is_tented: true,
+        tented_on_top: true,
+        tented_on_bottom: false,
       },
     ] as AnyCircuitElement[],
   )
@@ -41,5 +42,6 @@ test("createComponentsFromCircuitJson handles pcb_via elements", () => {
   expect(via!._parsedProps.layers).toEqual(["top", "inner1"])
   expect(via!._parsedProps.netIsAssignable).toBe(true)
   expect("netAssigned" in via!._parsedProps).toBe(false)
-  expect(via!._parsedProps.isTented).toBe(true)
+  expect(via!._parsedProps.tentedOnTop).toBe(true)
+  expect(via!._parsedProps.tentedOnBottom).toBe(false)
 })


### PR DESCRIPTION
PCB via primitives and imported routed vias now emit `tented_on_top` and `tented_on_bottom` instead of `is_tented`, following https://github.com/tscircuit/circuit-json/pull/788.

Adds optional `tentedOnTop` and `tentedOnBottom` to `PcbVia`, retaining deprecated `isTented` as a fallback. Imports use circuit-json's compatibility transform, so legacy JSON still works and explicit per-side values take precedence, including `false`. Tenting sides follow the same footprint flip as via layers. Updates the circuit-json development dependency and override to 0.0.487, and @tscircuit/props to the latest release, 0.0.653. Peer dependency wildcards remain unchanged.

Validation: 16 focused regression tests pass with @tscircuit/props 0.0.653. TypeScript, ESM/declaration build, formatting, and diff checks pass. Coverage includes direct and imported primitives on both layers at all four quarter-turn rotations, optional/legacy/explicit boolean combinations, and imported routed vias. The new tenting checks assert emitted JSON because PCB SVG snapshots do not expose these flags.

